### PR TITLE
Update on the SBM prior: calculating the number of cluster and the allocation of the nodes 

### DIFF
--- a/R/bgm.R
+++ b/R/bgm.R
@@ -509,7 +509,6 @@ bgm = function(x,
                       interactions = interactions,
                       thresholds = thresholds,
                       allocations = out$allocations,
-                      clusters = out$clusters,
                       arguments = arguments)
       } else {
 
@@ -573,7 +572,6 @@ bgm = function(x,
                       interactions = interactions,
                       thresholds = thresholds,
                       allocations = out$allocations,
-                      clusters = out$clusters,
                       arguments = arguments)
       } else {
 

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -504,10 +504,22 @@ bgm = function(x,
     arguments$data_columnnames = data_columnnames
 
     if(edge_selection == TRUE) {
-      output = list(indicator = indicator,
-                    interactions = interactions,
-                    thresholds = thresholds,
-                    arguments = arguments)
+      if(edge_prior == "Stochastic-Block"){
+        output = list(indicator = indicator,
+                      interactions = interactions,
+                      thresholds = thresholds,
+                      allocations = out$allocations,
+                      cluster_edge_prob = out$cluster_edge_prob,
+                      clusters = out$clusters,
+                      arguments = arguments)
+      } else {
+
+        output = list(indicator = indicator,
+                           interactions = interactions,
+                           thresholds = thresholds,
+                           arguments = arguments)
+        }
+
     } else {
       output = list(interactions = interactions,
                     thresholds = thresholds,
@@ -557,10 +569,21 @@ bgm = function(x,
     arguments$data_columnnames = data_columnnames
 
     if(edge_selection == TRUE) {
-      output = list(indicator = indicator,
-                    interactions = interactions,
-                    thresholds = thresholds,
-                    arguments = arguments)
+      if(edge_prior == "Stochastic-Block"){
+        output = list(indicator = indicator,
+                      interactions = interactions,
+                      thresholds = thresholds,
+                      allocations = out$allocations,
+                      cluster_edge_prob = out$cluster_edge_prob,
+                      clusters = out$clusters,
+                      arguments = arguments)
+      } else {
+
+        output = list(indicator = indicator,
+                      interactions = interactions,
+                      thresholds = thresholds,
+                      arguments = arguments)
+      }
     } else {
       output = list(interactions = interactions,
                     thresholds = thresholds,

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -509,7 +509,6 @@ bgm = function(x,
                       interactions = interactions,
                       thresholds = thresholds,
                       allocations = out$allocations,
-                      cluster_edge_prob = out$cluster_edge_prob,
                       clusters = out$clusters,
                       arguments = arguments)
       } else {
@@ -574,7 +573,6 @@ bgm = function(x,
                       interactions = interactions,
                       thresholds = thresholds,
                       allocations = out$allocations,
-                      cluster_edge_prob = out$cluster_edge_prob,
                       clusters = out$clusters,
                       arguments = arguments)
       } else {

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -1007,3 +1007,59 @@ compare_reformat_data = function(x,
               missing_index_gr2 = missing_index_gr2,
               na_impute = na_impute))
 }
+
+# Dahl's method to summarize the samples of the cluster_allocations
+#  This function was adapted from the R code accompanying the paper:
+#  Geng, J., Bhattacharya, A., & Pati, D. (2019). Probabilistic Community
+#  Detection With Unknown Number of Communities, Journal of the American
+#  Statistical Association, 114:526, 893-905, DOI:10.1080/01621459.2018.1458618
+
+getDahl <- function(cluster_allocations) {
+  # Dimensions of the input matrix
+  niters <- nrow(cluster_allocations)  # Number of iterations
+  n <- ncol(cluster_allocations)       # Number of nodes
+
+  # Compute membership matrices for each iteration
+  membershipMatrices <- apply(cluster_allocations, 1, function(clusterAssign) {
+    outer(clusterAssign, clusterAssign, FUN = "==")
+  })
+
+  # Reshape membershipMatrices into a list of matrices
+  membershipMatrices <- lapply(seq_len(niters), function(i) {
+    matrix(membershipMatrices[, i], n, n)
+  })
+
+  # Compute the average membership matrix
+  membershipAverage <- Reduce("+", membershipMatrices) / niters
+
+  # Compute squared error for each iteration
+  SqError <- sapply(membershipMatrices, function(x, av) sum((x - av)^2),
+                    av = membershipAverage)
+
+  # Find the iteration with the minimum squared error
+  DahlIndex <- which.min(SqError)
+
+  # Extract the cluster assignment corresponding to the best iteration
+  DahlAns <- cluster_allocations[DahlIndex, , drop = TRUE]
+
+  return(DahlAns)
+}
+
+
+# A function that computes the cluster posterior probabilities and allocations
+
+summary_SBM <- function(cluster_allocations) {
+  # Compute the number of unique clusters for each iteration
+  clusters <- apply(cluster_allocations, 1, function(row) length(unique(row)))
+
+  # Compute the posterior probabilities of the actual unique clusters
+  no_clusters <- table(clusters) / length(clusters)
+
+  # Compute the allocations of the nodes based on Dahl's method
+  allocations <- getDahl(cluster_allocations)
+
+  # Return the results
+  return(list(no_clusters = no_clusters,
+              allocations = allocations))
+}
+

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -101,12 +101,14 @@ complexity (number of edges) get the same prior weight. The Stochastic Block
 model \code{edge_prior = "Stochastic-Block"} assumes that nodes can be
 organized into blocks or clusters. In principle, the assignment of nodes to
 such clusters is unknown, and the model as implemented here considers all
-possible options \insertCite{@i.e., specifies a Dirichlet process on the node to block
-allocation as described by @GengEtAl_2019}{bgms}. This model is advantageous
+possible options \insertCite{@i.e., specifies a Dirichlet prior on the probability
+of allocations as described by @GengEtAl_2019}{bgms}. This model is advantageous
 when nodes are expected to fall into distinct clusters. The inclusion
 probabilities for the edges are defined at the level of the clusters, with a
 beta prior for the unknown inclusion probability with shape parameters
-\code{beta_bernoulli_alpha} and \code{beta_bernoulli_beta}. The default is
+\code{beta_bernoulli_alpha} and \code{beta_bernoulli_beta}, and a Dirichlet
+prior on the cluster assignment probabilities with a common concentration
+parameter \code{dirichlet_alpha}. The default is
 \code{edge_prior = "Bernoulli"}.}
 
 \item{inclusion_probability}{The prior edge inclusion probability for the
@@ -120,7 +122,7 @@ positive numbers. Defaults to \code{beta_bernoulli_alpha = 1} and
 \code{beta_bernoulli_beta = 1}.}
 
 \item{dirichlet_alpha}{The shape of the Dirichlet prior on the node-to-block
-allocation parameters for the Stochastic Block model.}
+allocation probabilities for the Stochastic Block model.}
 
 \item{na.action}{How do you want the function to handle missing data? If
 \code{na.action = "listwise"}, listwise deletion is used. If
@@ -153,8 +155,14 @@ columns, containing model-averaged category thresholds. In the case of
 ``blume-capel'' variables, the first entry is the parameter for the linear
 effect and the second entry is the parameter for the quadratic effect, which
 models the offset to the reference category.
+\item In the case of
+\code{edge_prior = "Stochastic-Block"} two additional elements are returned:
+a vector \code{allocations} with the estimated cluster assignments of the nodes and an
+table \code{clusters} with the estimated posterior probability of the number
+of clusters in the network. The vector of node allocations is calculated using
+a method proposed by \insertCite{Dahl2009}{bgms} and also used by
+\insertCite{GengEtAl_2019}{bgms}.
 }
-
 If \code{save = TRUE}, the result is a list of class ``bgms'' containing:
 \itemize{
 \item \code{indicator}: A matrix with \code{iter} rows and
@@ -166,8 +174,15 @@ iteration of the Gibbs sampler for the pairwise associations.
 \item \code{thresholds}: A matrix with \code{iter} rows and
 \code{sum(m)} columns, containing parameter states from every iteration of
 the Gibbs sampler for the category thresholds.
+\item In the case of
+\code{edge_prior = "Stochastic-Block"} a matrix \code{allocations} with the
+cluster assignments of the nodes from each iteration is returned. This matrix
+can be used to calculate the posterior probability of the number of clusters
+by utilizing the \code{summary_SBM(bgm_output[["allocations"]])} function.
 }
 Column averages of these matrices provide the model-averaged posterior means.
+Except for the \code{allocations} matrix, for which the \code{summary_SBM}
+needs to be utilized.
 
 In addition to the analysis results, the bgm output lists some of the
 arguments of its call. This is useful for post-processing the results.

--- a/src/gibbs_functions.cpp
+++ b/src/gibbs_functions.cpp
@@ -1034,15 +1034,6 @@ List gibbs_sampler(IntegerMatrix observations,
             theta(j, i) = cluster_prob(cluster_allocations[i], cluster_allocations[j]);
           }
         }
-
-        // Sample the number of clusters (K)
-        int sampled_K = sample_K_mfm_sbm(cluster_allocations,
-                                         dirichlet_alpha,
-                                         log_Vn,
-                                         no_variables + 10);
-
-        // Store the sampled K value
-        K_values.push_back(sampled_K);
       }
     }
   }
@@ -1267,7 +1258,7 @@ List gibbs_sampler(IntegerMatrix observations,
     return List::create(Named("indicator") = out_indicator,
                         Named("interactions") = out_interactions,
                         Named("thresholds") = out_thresholds,
-                        Named("allocations") = out_allocations);  // Include the sampled number of clusters
+                        Named("allocations") = out_allocations);
     } else {
       return List::create(Named("indicator") = out_indicator,
                           Named("interactions") = out_interactions,

--- a/src/gibbs_functions.cpp
+++ b/src/gibbs_functions.cpp
@@ -1040,7 +1040,8 @@ List gibbs_sampler(IntegerMatrix observations,
         // Sample the number of clusters (K)
         int sampled_K = sample_K_mfm_sbm(cluster_allocations,
                                          dirichlet_alpha,
-                                         log_Vn);
+                                         log_Vn,
+                                         no_variables);
 
         // Store the sampled K value
         K_values.push_back(sampled_K);
@@ -1186,7 +1187,8 @@ List gibbs_sampler(IntegerMatrix observations,
         // Sample the number of clusters (K)
         int sampled_K = sample_K_mfm_sbm(cluster_allocations,
                                          dirichlet_alpha,
-                                         log_Vn);
+                                         log_Vn,
+                                         no_variables);
         // Store the sampled K value to out_K
         out_K[iteration] = sampled_K;
       }

--- a/src/gibbs_functions.cpp
+++ b/src/gibbs_functions.cpp
@@ -868,7 +868,6 @@ List gibbs_sampler(IntegerMatrix observations,
 
   // store the allocation indices for each iteration
   NumericMatrix out_allocations(iter, no_variables);
-  IntegerVector out_K(iter); // store the number of clusters for each iteration
 
   if(edge_prior == "Stochastic-Block") { // Initial Configuration of the cluster allocations
     cluster_allocations[0] = 0;
@@ -1057,8 +1056,7 @@ List gibbs_sampler(IntegerMatrix observations,
         return List::create(Named("indicator") = out_indicator,
                             Named("interactions") = out_interactions,
                             Named("thresholds") = out_thresholds,
-                            Named("allocations") = out_allocations,
-                            Named("clusters") = out_K);
+                            Named("allocations") = out_allocations);
       } if(edge_selection == true && edge_prior != "Stochastic-Block") {
         return List::create(Named("indicator") = out_indicator,
                             Named("interactions") = out_interactions,
@@ -1179,14 +1177,6 @@ List gibbs_sampler(IntegerMatrix observations,
             theta(j, i) = cluster_prob(cluster_allocations[i], cluster_allocations[j]);
           }
         }
-
-        // Sample the number of clusters (K)
-        int sampled_K = sample_K_mfm_sbm(cluster_allocations,
-                                         dirichlet_alpha,
-                                         log_Vn,
-                                         no_variables + 10);
-        // Store the sampled K value to out_K
-        out_K[iteration] = sampled_K;
       }
     }
 
@@ -1277,8 +1267,7 @@ List gibbs_sampler(IntegerMatrix observations,
     return List::create(Named("indicator") = out_indicator,
                         Named("interactions") = out_interactions,
                         Named("thresholds") = out_thresholds,
-                        Named("allocations") = out_allocations,  // Include z values
-                        Named("clusters") = out_K);  // Include the sampled number of clusters
+                        Named("allocations") = out_allocations);  // Include the sampled number of clusters
     } else {
       return List::create(Named("indicator") = out_indicator,
                           Named("interactions") = out_interactions,

--- a/src/gibbs_functions.cpp
+++ b/src/gibbs_functions.cpp
@@ -868,7 +868,6 @@ List gibbs_sampler(IntegerMatrix observations,
 
   // store the allocation indices for each iteration
   NumericMatrix out_allocations(iter, no_variables);
-  List out_cluster_prob(iter); // store the cluster probabilities for each iteration
   IntegerVector out_K(iter); // store the number of clusters for each iteration
 
   if(edge_prior == "Stochastic-Block") { // Initial Configuration of the cluster allocations
@@ -1041,7 +1040,7 @@ List gibbs_sampler(IntegerMatrix observations,
         int sampled_K = sample_K_mfm_sbm(cluster_allocations,
                                          dirichlet_alpha,
                                          log_Vn,
-                                         no_variables);
+                                         no_variables + 10);
 
         // Store the sampled K value
         K_values.push_back(sampled_K);
@@ -1059,7 +1058,6 @@ List gibbs_sampler(IntegerMatrix observations,
                             Named("interactions") = out_interactions,
                             Named("thresholds") = out_thresholds,
                             Named("allocations") = out_allocations,
-                            Named("cluster_edge_prob") = out_cluster_prob,
                             Named("clusters") = out_K);
       } if(edge_selection == true && edge_prior != "Stochastic-Block") {
         return List::create(Named("indicator") = out_indicator,
@@ -1174,8 +1172,6 @@ List gibbs_sampler(IntegerMatrix observations,
                                            beta_bernoulli_alpha,
                                            beta_bernoulli_beta);
 
-        // store cluster_prob to out_cluster_prob
-        out_cluster_prob[iteration] = clone(cluster_prob);
 
         for(int i = 0; i < no_variables - 1; i++) {
           for(int j = i + 1; j < no_variables; j++) {
@@ -1188,7 +1184,7 @@ List gibbs_sampler(IntegerMatrix observations,
         int sampled_K = sample_K_mfm_sbm(cluster_allocations,
                                          dirichlet_alpha,
                                          log_Vn,
-                                         no_variables);
+                                         no_variables + 10);
         // Store the sampled K value to out_K
         out_K[iteration] = sampled_K;
       }
@@ -1282,7 +1278,6 @@ List gibbs_sampler(IntegerMatrix observations,
                         Named("interactions") = out_interactions,
                         Named("thresholds") = out_thresholds,
                         Named("allocations") = out_allocations,  // Include z values
-                        Named("cluster_edge_prob") = out_cluster_prob, // Include cluster probabilities (i.e., the block matrix)
                         Named("clusters") = out_K);  // Include the sampled number of clusters
     } else {
       return List::create(Named("indicator") = out_indicator,

--- a/src/gibbs_functions_edge_prior.cpp
+++ b/src/gibbs_functions_edge_prior.cpp
@@ -346,7 +346,7 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
 int sample_K_mfm_sbm(IntegerVector cluster_allocations,
                      double dirichlet_alpha,
                      NumericVector log_Vn,
-                     int max_K = 500) {
+                     int max_K) {
   // compute t = |C| (number of unique clusters i.e., the cardinality of C)
   IntegerVector cluster_size = table_cpp(cluster_allocations); // Cluster sizes
   int t = cluster_size.size(); // Number of non-zero clusters

--- a/src/gibbs_functions_edge_prior.cpp
+++ b/src/gibbs_functions_edge_prior.cpp
@@ -346,7 +346,7 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
 int sample_K_mfm_sbm(IntegerVector cluster_allocations,
                      double dirichlet_alpha,
                      NumericVector log_Vn,
-                     int max_K = 12) {
+                     int max_K = 500) {
   // compute t = |C| (number of unique clusters i.e., the cardinality of C)
   IntegerVector cluster_size = table_cpp(cluster_allocations); // Cluster sizes
   int t = cluster_size.size(); // Number of non-zero clusters

--- a/src/gibbs_functions_edge_prior.cpp
+++ b/src/gibbs_functions_edge_prior.cpp
@@ -337,7 +337,62 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
     }
   }
   return cluster_assign;
+
 }
+
+// ----------------------------------------------------------------------------|
+// Sample the number of clusters (K) based on Equation (3.7) from Miller & Harrison
+// ----------------------------------------------------------------------------|
+int sample_K_mfm_sbm(IntegerVector cluster_allocations,
+                     double dirichlet_alpha,
+                     NumericVector log_Vn,
+                     int max_K = 12) {
+  // compute t = |C| (number of unique clusters i.e., the cardinality of C)
+  IntegerVector cluster_size = table_cpp(cluster_allocations); // Cluster sizes
+  int t = cluster_size.size(); // Number of non-zero clusters
+
+  // Step 2: Compute p(k|t) using Equation 3.7 in Miller and Harrison (2018)
+  NumericVector log_p_K(max_K, R_NegInf); // Log-probabilities of k
+  for (int k = t; k < max_K; ++k) {
+    double log_term1 = std::lgamma(k + 1) - std::lgamma(k - t + 1); // (k choose t)
+    double log_term2 = k * std::log(dirichlet_alpha);              // dirichlet_alpha^k
+    double log_term3 = -log_Vn[t - 1];                             // Normalize by Vn
+    log_p_K[k] = log_term1 + log_term2 + log_term3;                // Combine terms
+  }
+
+  // Normalize probabilities using log-sum-exp
+  double log_sum_exp = -INFINITY;
+  for (int k = t; k < max_K; ++k) {
+    log_sum_exp = std::log1p(std::exp(log_p_K[k] - log_sum_exp)) + log_sum_exp;
+  }
+  NumericVector p_K(max_K, 0.0);
+  for (int k = t; k < max_K; ++k) {
+    p_K[k] = std::exp(log_p_K[k] - log_sum_exp); // Convert log-p to p
+  }
+
+  // Step 3: Exclude zero and adjust probabilities for truncated Poisson
+  double p_zero = std::exp(-1.0); // P(k = 0) for Poisson(lambda = 1)
+  double truncated_normalizer = 1.0 - p_zero;
+  double cumulative_probability = 0.0;
+
+  for (int k = t; k < max_K; ++k) {
+    p_K[k] /= truncated_normalizer; // Adjust probabilities to exclude zero
+    cumulative_probability += p_K[k];
+  }
+
+  // Step 4: Draw a uniform random number within [0, cumulative_probability]
+  double u = R::runif(0, cumulative_probability);
+
+  // Step 5: sample from the truncated Poisson distribution
+  double lambda = 1.0; // Poisson parameter (fixed to 1)
+  int sampled_k = R::qpois(u * truncated_normalizer, lambda, true, false);
+
+  // Ensure k is at least t
+  return std::max(t, std::min(sampled_k, max_K - 1));
+}
+
+
+
 
 // ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM

--- a/src/gibbs_functions_edge_prior.h
+++ b/src/gibbs_functions_edge_prior.h
@@ -26,7 +26,7 @@ Rcpp::IntegerVector block_allocations_mfm_sbm(Rcpp::IntegerVector cluster_assign
 int sample_K_mfm_sbm(IntegerVector cluster_assign,
                      double dirichlet_alpha,
                      NumericVector log_Vn,
-                     int max_K = 500);
+                     int max_K);
 
 // ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM

--- a/src/gibbs_functions_edge_prior.h
+++ b/src/gibbs_functions_edge_prior.h
@@ -26,7 +26,7 @@ Rcpp::IntegerVector block_allocations_mfm_sbm(Rcpp::IntegerVector cluster_assign
 int sample_K_mfm_sbm(IntegerVector cluster_assign,
                      double dirichlet_alpha,
                      NumericVector log_Vn,
-                     int max_K = 12);
+                     int max_K = 500);
 
 // ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM

--- a/src/gibbs_functions_edge_prior.h
+++ b/src/gibbs_functions_edge_prior.h
@@ -21,6 +21,14 @@ Rcpp::IntegerVector block_allocations_mfm_sbm(Rcpp::IntegerVector cluster_assign
                                               double beta_bernoulli_beta);
 
 // ----------------------------------------------------------------------------|
+// Sample the number of clusters (K) based on Equation (3.7) from Miller & Harrison
+// ----------------------------------------------------------------------------|
+int sample_K_mfm_sbm(IntegerVector cluster_assign,
+                     double dirichlet_alpha,
+                     NumericVector log_Vn,
+                     int max_K = 12);
+
+// ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM
 // ----------------------------------------------------------------------------|
 Rcpp::NumericMatrix block_probs_mfm_sbm(Rcpp::IntegerVector cluster_assign,

--- a/src/gibbs_functions_edge_prior.h
+++ b/src/gibbs_functions_edge_prior.h
@@ -21,14 +21,6 @@ Rcpp::IntegerVector block_allocations_mfm_sbm(Rcpp::IntegerVector cluster_assign
                                               double beta_bernoulli_beta);
 
 // ----------------------------------------------------------------------------|
-// Sample the number of clusters (K) based on Equation (3.7) from Miller & Harrison
-// ----------------------------------------------------------------------------|
-int sample_K_mfm_sbm(IntegerVector cluster_assign,
-                     double dirichlet_alpha,
-                     NumericVector log_Vn,
-                     int max_K);
-
-// ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM
 // ----------------------------------------------------------------------------|
 Rcpp::NumericMatrix block_probs_mfm_sbm(Rcpp::IntegerVector cluster_assign,

--- a/vignettes/refs.bib
+++ b/vignettes/refs.bib
@@ -1,10 +1,28 @@
-@article{SekulovskiEtAl_2023,
-  title={Testing conditional independence in psychometric networks: An analysis of three bayesian methods},
-  author={Sekulovski, N. and Keetelaar, S. and Huth, K. and Wagenmakers, {E.-J.} and van Bork, R. and van den Bergh, D. and Marsman, M.},
-  journal={Multivariate Behavioral Research},
-  doi = {10.1080/00273171.2024.2345915},
-  year={in press}
+
+@article{Dahl2009,
+  author       = {David B. Dahl},
+  title        = {Modal clustering in a class of product partition models},
+  journal      = {Bayesian Analysis},
+  volume       = {4},
+  number       = {2},
+  pages        = {243--264},
+  year         = {2009},
+  month        = {June},
+  doi          = {10.1214/09-BA409},
+  url          = {https://doi.org/10.1214/09-BA409}
 }
+
+@article{SekulovskiEtAl_2023,
+	author = {Sekulovski, N. and Keetelaar, S. and Huth, K. B. S. and Wagenmakers, Eric-Jan and {van }Bork, R. and {van den }Bergh, D. and Marsman, M.},
+	date-added = {2023-06-12 16:18:37 +0200},
+	date-modified = {2024-12-07 10:05:32 +0100},
+	doi = {10.1080/00273171.2024.2345915},
+	journal = {Multivariate Behavioral Research},
+	pages = {913--933},
+	title = {Testing conditional independence in psychometric networks: {A}n analysis of three {B}ayesian methods},
+	volume = {59},
+	year = {2024},
+	bdsk-url-1 = {https://doi.org/10.1080/00273171.2024.2345915}}
 
 @article{GengEtAl_2019,
   title={Probabilistic community detection with unknown number of communities},


### PR DESCRIPTION
The following changes have been made:

- We now save the cluster allocation vectors from the Gibbs sampler 
- When save = FALSE we use the cluster allocation vector to calculate the cluster membership (using Dahl's method), as well as the posterior probability of the number of clusters. For the latter, I decided not to use Equation 3.7 from Miller and Harrsion, but instead simply use the sampled allocation vectors (see the `summary_SBM` function in the utility_functions script for more details).
- When save = TRUE, we simply return a matrix of the sampled allocation vectors in each row. Users can then manually make use of the summary_SBM function. 
- I also added some additional clarifications in the roxygen code.