### PR TITLE
fix bug when save = FALSE & egde_prior = "Stochastic-Block"

### DIFF
--- a/R/bgm.R
+++ b/R/bgm.R
@@ -544,7 +544,8 @@ bgm = function(x,
           thresholds = thresholds, allocations = out$allocations,
           arguments = arguments)
         class(output) = "bgms"
-        summary_Sbm = summarySBM(output)
+        summary_Sbm = summarySBM(output,
+                                 estimation = TRUE)
 
         output$components = summary_Sbm$components
         output$allocations = summary_Sbm$allocations

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -545,7 +545,7 @@ bgm = function(x,
           arguments = arguments)
         class(output) = "bgms"
         summary_Sbm = summarySBM(output,
-                                 estimation = TRUE)
+                                 internal_call = TRUE)
 
         output$components = summary_Sbm$components
         output$allocations = summary_Sbm$allocations

--- a/R/posterior_utils.R
+++ b/R/posterior_utils.R
@@ -92,9 +92,9 @@ compute_p_k_given_t = function(
 #' number of clusters.
 #'
 #' @param bgm_object A fit object created by the bgm function.
-#' @param estimation A logical value indicating whether the function is used
+#' @param internal_call A logical value indicating whether the function is used
 #' within bgms for calculating the posterior probabilities of the number of
-#' clusters or by the user. This argument should always be set to FALSE.
+#' clusters or by the user. This argument is always set to FALSE.
 #' @return Returns a list of two elements: \code{components} and \code{allocations},
 #' containing the posterior probabilities for the number of components (clusters)
 #' and the estimated cluster allocation of the nodes using Dahl's method.
@@ -111,14 +111,14 @@ compute_p_k_given_t = function(
 #' @export
 summarySBM = function(
     bgm_object,
-    estimation = FALSE) {
+    internal_call = FALSE) {
 
   arguments = extract_arguments(bgm_object)
 
   if(arguments$edge_prior != "Stochastic-Block")
     stop('The bgm function must be run with edge_prior = "Stochastic-Block".')
 
-  if(arguments$save == FALSE && estimation == FALSE)
+  if(arguments$save == FALSE && internal_call == FALSE)
     stop('The bgm function must be run with save = TRUE.')
 
   cluster_allocations = bgm_object$allocations

--- a/R/posterior_utils.R
+++ b/R/posterior_utils.R
@@ -92,6 +92,9 @@ compute_p_k_given_t = function(
 #' number of clusters.
 #'
 #' @param bgm_object A fit object created by the bgm function.
+#' @param estimation A logical value indicating whether the function is used
+#' within bgms for calculating the posterior probabilities of the number of
+#' clusters or by the user. This argument should always be set to FALSE.
 #' @return Returns a list of two elements: \code{components} and \code{allocations},
 #' containing the posterior probabilities for the number of components (clusters)
 #' and the estimated cluster allocation of the nodes using Dahl's method.
@@ -107,14 +110,15 @@ compute_p_k_given_t = function(
 #' }
 #' @export
 summarySBM = function(
-    bgm_object) {
+    bgm_object,
+    estimation = FALSE) {
 
   arguments = extract_arguments(bgm_object)
 
   if(arguments$edge_prior != "Stochastic-Block")
     stop('The bgm function must be run with edge_prior = "Stochastic-Block".')
 
-  if(arguments$save == FALSE)
+  if(arguments$save == FALSE && estimation == FALSE)
     stop('The bgm function must be run with save = TRUE.')
 
   cluster_allocations = bgm_object$allocations

--- a/man/bgms-package.Rd
+++ b/man/bgms-package.Rd
@@ -68,6 +68,7 @@ Useful links:
 
 Other contributors:
 \itemize{
+  \item Giuseppe Arena (\href{https://orcid.org/0000-0001-5204-3326}{ORCID}) [contributor]
   \item Karoline Huth (\href{https://orcid.org/0000-0002-0662-1591}{ORCID}) [contributor]
   \item Nikola Sekulovski (\href{https://orcid.org/0000-0001-7032-1684}{ORCID}) [contributor]
   \item Don van den Bergh (\href{https://orcid.org/0000-0002-9838-7308}{ORCID}) [contributor]

--- a/man/summarySBM.Rd
+++ b/man/summarySBM.Rd
@@ -4,14 +4,14 @@
 \alias{summarySBM}
 \title{Function for summarizing the sampled cluster allocation vectors}
 \usage{
-summarySBM(bgm_object, estimation = FALSE)
+summarySBM(bgm_object, internal_call = FALSE)
 }
 \arguments{
 \item{bgm_object}{A fit object created by the bgm function.}
 
-\item{estimation}{A logical value indicating whether the function is used
+\item{internal_call}{A logical value indicating whether the function is used
 within bgms for calculating the posterior probabilities of the number of
-clusters or by the user. This argument should always be set to FALSE.}
+clusters or by the user. This argument is always set to FALSE.}
 }
 \value{
 Returns a list of two elements: \code{components} and \code{allocations},

--- a/man/summarySBM.Rd
+++ b/man/summarySBM.Rd
@@ -4,10 +4,14 @@
 \alias{summarySBM}
 \title{Function for summarizing the sampled cluster allocation vectors}
 \usage{
-summarySBM(bgm_object)
+summarySBM(bgm_object, estimation = FALSE)
 }
 \arguments{
 \item{bgm_object}{A fit object created by the bgm function.}
+
+\item{estimation}{A logical value indicating whether the function is used
+within bgms for calculating the posterior probabilities of the number of
+clusters or by the user. This argument should always be set to FALSE.}
 }
 \value{
 Returns a list of two elements: \code{components} and \code{allocations},


### PR DESCRIPTION
There was an issue with the` summarySBM` function. Since you added some error checks, the line
 ```
if(arguments$save == FALSE)
    stop('The bgm function must be run with save = TRUE.') 
```
caused bgms to crash when `save = FALSE` and `edge_prior = "Stochastic-Block"`. I adjusted this by including an additional argument. 

