### PR TITLE
update SBM prior functions (rewritten in RcppArmadillo)

### DIFF
--- a/src/gibbs_functions_edge_prior.cpp
+++ b/src/gibbs_functions_edge_prior.cpp
@@ -1,5 +1,5 @@
-#include <Rcpp.h>
-using namespace Rcpp;
+
+#include <RcppArmadillo.h>
 
 // ----------------------------------------------------------------------------|
 // The c++ code below is based on the R code accompanying the paper:
@@ -11,13 +11,13 @@ using namespace Rcpp;
 // ----------------------------------------------------------------------------|
 // A c++ version of table
 // ----------------------------------------------------------------------------|
-IntegerVector table_cpp(IntegerVector x) {
-  int n = x.size();
-  int m = max(x);
-  IntegerVector counts(m + 1);
+arma::uvec table_cpp(arma::uvec x) {
+  arma::uword n = x.n_elem;
+  arma::uword m = arma::max(x);
+  arma::uvec counts(m+1,arma::fill::zeros);
 
-  for (int i = 0; i < n; i++) {
-    counts[x[i]]++;
+  for (arma::uword i = 0; i < n; i++) {
+    counts(x(i))++;
   }
 
   return counts;
@@ -26,30 +26,30 @@ IntegerVector table_cpp(IntegerVector x) {
 // ----------------------------------------------------------------------------|
 // Remove row i and column i from a matrix
 // ----------------------------------------------------------------------------|
-NumericMatrix remove_row_col_matrix(NumericMatrix X, int i) {
-  int n = X.nrow();
+arma::mat remove_row_col_matrix(arma::mat X, arma::uword i) {
+  arma::uword n = X.n_rows;
 
   // Handle special case of matrix with only two rows and columns
   if (n == 2) {
     if(i == 0) {
-      X = X(Range(1, 1), Range(1, 1));
+      X = X(arma::span(1, 1), arma::span(1, 1));
     } else {
-      X = X(Range(0, 0), Range(0, 0));
+      X = X(arma::span(0, 0), arma::span(0, 0));
     }
     return X;
   }
 
   // Remove row i
-  for (int j = i; j < n - 1; j++) {
-    X(j, _) = X(j+1, _);  // Shift all rows below i up by one
+  for (arma::uword j = i; j < n - 1; j++) {
+    X.row(j) = X(j+1);  // Shift all rows below i up by one
   }
-  X = X(Range(0, n - 2), _);  // Remove last row
+  X = X.rows(arma::span(0, n - 2));  // Remove last row
 
   // Remove column i
-  for (int j = i; j < n - 1; j++) {
-    X(_, j) = X(_, j + 1);  // Shift all columns right of i to the left by one
+  for (arma::uword j = i; j < n - 1; j++) {
+    X.col(j) = X.col(j+1);  // Shift all columns right of i to the left by one
   }
-  X = X(_, Range(0, n - 2));  // Remove last column
+  X = X.cols(arma::span(0,n-2));  // Remove last column
 
   return X;
 }
@@ -57,19 +57,19 @@ NumericMatrix remove_row_col_matrix(NumericMatrix X, int i) {
 // ----------------------------------------------------------------------------|
 // Add a row and column to a matrix (and fill with beta variables)
 // ----------------------------------------------------------------------------|
-NumericMatrix add_row_col_block_prob_matrix(NumericMatrix X,
+arma::mat add_row_col_block_prob_matrix(arma::mat X,
                                             double beta_alpha,
                                             double beta_beta) {
-  int dim = X.nrow();
-  NumericMatrix Y(dim + 1, dim + 1);
+  arma::uword dim = X.n_rows;
+  arma::mat Y(dim+1,dim+1,arma::fill::zeros);
 
-  for(int r = 0; r < dim; r++) {
-    for(int c = 0; c < dim; c++) {
+  for(arma::uword r = 0; r < dim; r++) {
+    for(arma::uword c = 0; c < dim; c++) {
       Y(r, c) = X(r, c);
     }
   }
 
-  for(int i = 0; i < dim; i++) {
+  for(arma::uword i = 0; i < dim; i++) {
     Y(dim, i) = R::rbeta(beta_alpha, beta_beta);
     Y(i, dim) = Y(dim, i);
   }
@@ -83,22 +83,22 @@ NumericMatrix add_row_col_block_prob_matrix(NumericMatrix X,
 // Compute partition coefficient for the MFM - SBM
 // ----------------------------------------------------------------------------|
 // [[Rcpp::export]]
-NumericVector compute_Vn_mfm_sbm(int no_variables,
+arma::vec compute_Vn_mfm_sbm(arma::uword no_variables,
                                  double dirichlet_alpha,
-                                 int t_max,
+                                 arma::uword t_max,
                                  double lambda) {
-  NumericVector log_Vn(t_max);
+  arma::vec log_Vn(t_max);
   double r;
   double tmp;
 
-  for(int t = 1; t <= t_max; t++) {
+  for(arma::uword t = 1; t <= t_max; t++) {
     r = -INFINITY;
-    for(int k = t; k < 500; k++) {
+    for(arma::uword k = t; k < 500; k++) {
       tmp = 0.0;
-      for(int tt = 1 - t; tt < 1; tt ++) {
+      for(arma::uword tt = 1 - t; tt < 1; tt ++) {
         tmp += std::log(dirichlet_alpha * k + tt);
       }
-      for(int n = 0; n < no_variables; n++) {
+      for(arma::uword n = 0; n < no_variables; n++) {
         tmp -= std::log(dirichlet_alpha * k + n);
       }
       tmp -= std::lgamma(k + 1);
@@ -122,25 +122,25 @@ NumericVector compute_Vn_mfm_sbm(int no_variables,
 // ----------------------------------------------------------------------------|
 // Compute log-likelihood for the MFM - SBM
 // ----------------------------------------------------------------------------|
-double log_likelihood_mfm_sbm(IntegerVector cluster_assign,
-                              NumericMatrix cluster_probs,
-                              IntegerMatrix indicator,
-                              int node,
-                              int no_variables) {
+double log_likelihood_mfm_sbm(arma::uvec cluster_assign,
+                              arma::mat cluster_probs,
+                              arma::umat indicator,
+                              arma::uword node,
+                              arma::uword no_variables) {
   double output = 0;
 
-  for(int j = 0; j < no_variables; j++) {
+  for(arma::uword j = 0; j < no_variables; j++) {
     if(j != node) {
       if(j < node) {
         output += indicator(j, node) *
-          std::log(cluster_probs(cluster_assign[j], cluster_assign[node]));
+          std::log(cluster_probs(cluster_assign(j), cluster_assign(node)));
         output += (1 - indicator(j, node)) *
-          std::log(1 - cluster_probs(cluster_assign[j], cluster_assign[node]));
+          std::log(1 - cluster_probs(cluster_assign(j), cluster_assign(node)));
       } else {
         output += indicator(node, j) *
-          std::log(cluster_probs(cluster_assign[node], cluster_assign[j]));
+          std::log(cluster_probs(cluster_assign(node), cluster_assign(j)));
         output += (1 - indicator(node, j)) *
-          std::log(1 - cluster_probs(cluster_assign[node], cluster_assign[j]));
+          std::log(1 - cluster_probs(cluster_assign(node), cluster_assign(j)));
       }
     }
   }
@@ -151,28 +151,28 @@ double log_likelihood_mfm_sbm(IntegerVector cluster_assign,
 // ----------------------------------------------------------------------------|
 // Compute log-marginal for the MFM - SBM
 // ----------------------------------------------------------------------------|
-double log_marginal_mfm_sbm(IntegerVector cluster_assign,
-                            IntegerMatrix indicator,
-                            int node,
-                            int no_variables,
+double log_marginal_mfm_sbm(arma::uvec cluster_assign,
+                            arma::umat indicator,
+                            arma::uword node,
+                            arma::uword no_variables,
                             double beta_bernoulli_alpha,
                             double beta_bernoulli_beta) {
 
-  int no_clusters_excl_node = max(cluster_assign);
+  arma::uword no_clusters_excl_node = arma::max(cluster_assign);
   //*std::max_element(cluster_assign.begin(), cluster_assign.end());
   double output = 0;
-  int sumG;
-  int sumN;
+  double sumG;
+  double sumN;
 
   output -= no_clusters_excl_node * R::lbeta(beta_bernoulli_alpha, beta_bernoulli_beta);
 
-  for(int c = 0; c < no_clusters_excl_node; c++) {
+  for(arma::uword c = 0; c < no_clusters_excl_node; c++) {
     sumG = 0;
     sumN = 0;
-    for(int i = 0; i < no_variables; i++) {
-      if(cluster_assign[i] == c) {
-        sumG += indicator(node, i);
-        sumN++;
+    for(arma::uword i = 0; i < no_variables; i++) {
+      if(cluster_assign(i) == c) {
+        sumG += static_cast<double>(indicator(node, i));
+        sumN += 1.0;
       }
     }
     output += R::lbeta(sumG + beta_bernoulli_alpha, sumN - sumG + beta_bernoulli_beta);
@@ -183,17 +183,17 @@ double log_marginal_mfm_sbm(IntegerVector cluster_assign,
 // ----------------------------------------------------------------------------|
 // Helper function to update sumG in sample_block_probs_mfm_sbm()
 // ----------------------------------------------------------------------------|
-inline void update_sumG(int &sumG,
-                        const IntegerVector &cluster_assign,
-                        const IntegerMatrix &indicator,
-                        int r,
-                        int s,
-                        int no_variables) {
-  for(int node1 = 0; node1 < no_variables - 1; node1++) {
-    if(cluster_assign[node1] == r) {
-      for(int node2 = node1 + 1; node2 < no_variables; node2++) {
-        if(cluster_assign[node2] == s) {
-          sumG += indicator(node1, node2);
+inline void update_sumG(double &sumG,
+                        const arma::uvec &cluster_assign,
+                        const arma::umat &indicator,
+                        arma::uword r,
+                        arma::uword s,
+                        arma::uword no_variables) {
+  for(arma::uword node1 = 0; node1 < no_variables - 1; node1++) {
+    if(cluster_assign(node1) == r) {
+      for(arma::uword node2 = node1 + 1; node2 < no_variables; node2++) {
+        if(cluster_assign(node2) == s) {
+          sumG += static_cast<double>(indicator(node1, node2));
         }
       }
     }
@@ -203,58 +203,58 @@ inline void update_sumG(int &sumG,
 // ----------------------------------------------------------------------------|
 // Sample the cluster assignment in sample_block_allocations_mfm_sbm()
 // ----------------------------------------------------------------------------|
-int sample_cluster(NumericVector cluster_prob) {
-  NumericVector cum_prob = cumsum(cluster_prob);
-  double u = R::runif(0, max(cum_prob));
+arma::uword sample_cluster(arma::vec cluster_prob) {
+  arma::vec cum_prob = arma::cumsum(cluster_prob);
+  double u = R::runif(0, arma::max(cum_prob));
 
-  for (int i = 0; i < cum_prob.size(); i++) {
-    if (u <= cum_prob[i]) {
+  for (arma::uword i = 0; i < cum_prob.n_elem; i++) {
+    if (u <= cum_prob(i)) {
       return i;
     }
   }
-  return cum_prob.size();
+  return cum_prob.n_elem;
 }
 
 // ----------------------------------------------------------------------------|
 // Sample the block allocations for the MFM - SBM
 // ----------------------------------------------------------------------------|
-IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
-                                        int no_variables,
-                                        NumericVector log_Vn,
-                                        NumericMatrix block_probs,
-                                        IntegerMatrix indicator,
-                                        int dirichlet_alpha,
+arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
+                                        arma::uword no_variables,
+                                        arma::vec log_Vn,
+                                        arma::mat block_probs,
+                                        arma::umat indicator,
+                                        arma::uword dirichlet_alpha,
                                         double beta_bernoulli_alpha,
                                         double beta_bernoulli_beta) {
-  int old;
-  int cluster;
-  int no_clusters;
+  arma::uword old;
+  arma::uword cluster;
+  arma::uword no_clusters;
   double prob;
   double loglike;
   double logmarg;
 
   // Generate a randomized order using Rcpp's sample function
-  IntegerVector indices = sample(no_variables, no_variables);
+  arma::vec indices = sample(no_variables, no_variables);
 
-  for (int idx = 0; idx < no_variables; ++idx) {
-    int node = indices[idx] - 1; // Convert to zero-based index
-    old = cluster_assign[node];
+  for (arma::uword idx = 0; idx < no_variables; ++idx) {
+    arma::uword node = indices(idx) - 1; // Convert to zero-based index
+    old = cluster_assign(node);
 
-    IntegerVector cluster_size = table_cpp(cluster_assign);
-    no_clusters = cluster_size.size();
+    arma::uvec cluster_size = table_cpp(cluster_assign);
+    no_clusters = cluster_size.n_elem;
 
-    if (cluster_size[old] == 1) {
+    if (cluster_size(old) == 1) {
       // Singleton cluster.
 
       // Cluster sizes without node
-      IntegerVector cluster_size_node = clone(cluster_size);
-      cluster_size_node[old] -= (1 + dirichlet_alpha);
+      arma::uvec cluster_size_node = cluster_size;
+      cluster_size_node(old) -= (1 + dirichlet_alpha);
 
       // Compute probabilities for sampling process
-      NumericVector cluster_prob(no_clusters + 1);
-      for (int c = 0; c <= no_clusters; c++) {
-        IntegerVector cluster_assign_tmp = clone(cluster_assign);
-        cluster_assign_tmp[node] = c;
+      arma::vec cluster_prob(no_clusters + 1);
+      for (arma::uword c = 0; c <= no_clusters; c++) {
+        arma::uvec cluster_assign_tmp = cluster_assign;
+        cluster_assign_tmp(node) = c;
 
         if (c < no_clusters) {
           loglike = log_likelihood_mfm_sbm(cluster_assign_tmp,
@@ -263,7 +263,7 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
                                            node,
                                            no_variables);
 
-          prob = (dirichlet_alpha + cluster_size_node[c]) *
+          prob = (static_cast<double>(dirichlet_alpha) + static_cast<double>(cluster_size_node(c))) *
             std::exp(loglike);
         } else {
           logmarg = log_marginal_mfm_sbm(cluster_assign_tmp,
@@ -273,12 +273,12 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
                                          beta_bernoulli_alpha,
                                          beta_bernoulli_beta);
 
-          prob = dirichlet_alpha *
+          prob = static_cast<double>(dirichlet_alpha) *
             std::exp(logmarg) *
-            std::exp(log_Vn[no_clusters - 1] - log_Vn[no_clusters - 2]);
+            std::exp(log_Vn(no_clusters - 1) - log_Vn(no_clusters - 2));
         }
 
-        cluster_prob[c] = prob;
+        cluster_prob(c) = prob;
       }
 
 
@@ -287,26 +287,26 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
 
       // Remove the empty cluster
       if (cluster == no_clusters) {
-        cluster_assign[node] = old;
+        cluster_assign(node) = old;
       } else {
-        cluster_assign[node] = cluster;
-        for (int i = 0; i < no_variables; i++) {
-          if (cluster_assign[i] > old) {
-            cluster_assign[i] -= 1;
+        cluster_assign(node) = cluster;
+        for (arma::uword i = 0; i < no_variables; i++) {
+          if (cluster_assign(i) > old) {
+            cluster_assign(i) -= 1;
           }
         }
         block_probs = remove_row_col_matrix(block_probs, old);
       }
     } else {
       // Cluster sizes without node
-      IntegerVector cluster_size_node = clone(cluster_size);
-      cluster_size_node[old] -= 1;
+      arma::uvec cluster_size_node = cluster_size;
+      cluster_size_node(old) -= 1;
 
       // Compute probabilities for sampling process
-      NumericVector cluster_prob(no_clusters + 1);
-      for (int c = 0; c <= no_clusters; c++) {
-        IntegerVector cluster_assign_tmp = clone(cluster_assign);
-        cluster_assign_tmp[node] = c;
+      arma::vec cluster_prob(no_clusters + 1);
+      for (arma::uword c = 0; c <= no_clusters; c++) {
+        arma::uvec cluster_assign_tmp = cluster_assign;
+        cluster_assign_tmp(node) = c;
 
         if (c < no_clusters) {
           loglike = log_likelihood_mfm_sbm(cluster_assign_tmp,
@@ -315,7 +315,7 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
                                            node,
                                            no_variables);
 
-          prob = (dirichlet_alpha + cluster_size_node[c]) *
+          prob = (static_cast<double>(dirichlet_alpha) + static_cast<double>(cluster_size_node(c))) *
             std::exp(loglike);
         } else {
           logmarg = log_marginal_mfm_sbm(cluster_assign_tmp,
@@ -325,19 +325,19 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
                                          beta_bernoulli_alpha,
                                          beta_bernoulli_beta);
 
-          prob = dirichlet_alpha *
+          prob = static_cast<double>(dirichlet_alpha) *
             std::exp(logmarg) *
-            std::exp(log_Vn[no_clusters] - log_Vn[no_clusters - 1]);
+            std::exp(log_Vn(no_clusters) - log_Vn(no_clusters - 1));
         }
 
-        cluster_prob[c] = prob;
+        cluster_prob(c) = prob;
       }
 
 
       //Choose the cluster number for node
       cluster = sample_cluster(cluster_prob);
 
-      cluster_assign[node] = cluster;
+      cluster_assign(node) = cluster;
 
       if (cluster == no_clusters) {
         block_probs = add_row_col_block_prob_matrix(block_probs,
@@ -353,34 +353,32 @@ IntegerVector block_allocations_mfm_sbm(IntegerVector cluster_assign,
 // ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM
 // ----------------------------------------------------------------------------|
-NumericMatrix block_probs_mfm_sbm(IntegerVector cluster_assign,
-                                  IntegerMatrix indicator,
-                                  int no_variables,
+arma::mat block_probs_mfm_sbm(arma::uvec cluster_assign,
+                                  arma::umat indicator,
+                                  arma::uword no_variables,
                                   double beta_bernoulli_alpha,
                                   double beta_bernoulli_beta) {
 
-  IntegerVector cluster_size = table_cpp(cluster_assign);
-  int no_clusters = cluster_size.size();
+  arma::uvec cluster_size = table_cpp(cluster_assign);
+  arma::uword no_clusters = cluster_size.n_elem;
 
-  NumericMatrix block_probs(no_clusters, no_clusters);
-  NumericMatrix theta (no_variables, no_variables);
+  arma::mat block_probs(no_clusters, no_clusters);
+  arma::mat theta(no_variables, no_variables);
 
-  int sumG;
-  int size;
+  double sumG;
+  double size;
 
-  for(int r = 0; r < no_clusters; r++) {
-    for(int s = r; s < no_clusters; s++) {
+  for(arma::uword r = 0; r < no_clusters; r++) {
+    for(arma::uword s = r; s < no_clusters; s++) {
       sumG = 0;
-
       if(r == s) {
         update_sumG(sumG, cluster_assign, indicator, r, r, no_variables);
-        size = cluster_size[r] * (cluster_size[r] - 1) / 2;
+        size = static_cast<double>(cluster_size(r)) * (static_cast<double>(cluster_size(r)) - 1) / 2;
       } else {
         update_sumG(sumG, cluster_assign, indicator, r, s, no_variables);
         update_sumG(sumG, cluster_assign, indicator, s, r, no_variables);
-        size = cluster_size[s] * cluster_size[r];
+        size = static_cast<double>(cluster_size(s)) * static_cast<double>(cluster_size(r));
       }
-
       block_probs(r, s) = R::rbeta(sumG + beta_bernoulli_alpha, size - sumG + beta_bernoulli_beta);
       block_probs(s, r) = block_probs(r, s);
     }

--- a/src/gibbs_functions_edge_prior.h
+++ b/src/gibbs_functions_edge_prior.h
@@ -1,31 +1,30 @@
-#include <Rcpp.h>
-using namespace Rcpp;
+#include <RcppArmadillo.h>
 
 // ----------------------------------------------------------------------------|
 // Compute partition coefficient for the MFM - SBM
 // ----------------------------------------------------------------------------|
-Rcpp::NumericVector compute_Vn_mfm_sbm(int no_variables,
-                                       double dirichlet_alpha,
-                                       int t_max,
-                                       double lambda);
+arma::vec compute_Vn_mfm_sbm(arma::uword no_variables,
+                                        double dirichlet_alpha,
+                                        arma::uword t_max,
+                                        double lambda);
 
 // ----------------------------------------------------------------------------|
 // Sample the block allocations for the MFM - SBM
 // ----------------------------------------------------------------------------|
-Rcpp::IntegerVector block_allocations_mfm_sbm(Rcpp::IntegerVector cluster_assign,
-                                              int no_variables,
-                                              Rcpp::NumericVector log_Vn,
-                                              Rcpp::NumericMatrix block_probs,
-                                              Rcpp::IntegerMatrix indicator,
-                                              int dirichlet_alpha,
-                                              double beta_bernoulli_alpha,
-                                              double beta_bernoulli_beta);
+arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
+                                                arma::uword no_variables,
+                                                arma::vec log_Vn,
+                                                arma::mat block_probs,
+                                                arma::umat indicator,
+                                                arma::uword dirichlet_alpha,
+                                                double beta_bernoulli_alpha,
+                                                double beta_bernoulli_beta);
 
 // ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM
 // ----------------------------------------------------------------------------|
-Rcpp::NumericMatrix block_probs_mfm_sbm(Rcpp::IntegerVector cluster_assign,
-                                        Rcpp::IntegerMatrix indicator,
-                                        int no_variables,
+arma::mat block_probs_mfm_sbm(arma::uvec cluster_assign,
+                                        arma::umat indicator,
+                                        arma::uword no_variables,
                                         double beta_bernoulli_alpha,
                                         double beta_bernoulli_beta);


### PR DESCRIPTION
Hi Maarten,

Here is the update to `gibbs_functions_edge_prior.cpp` and `gibbs_functions_edge_prior.h`, where the functions are re-coded using RcppArmadillo.

We get rid of the `clone()` function. While I never had issues copying RcppArmadillo objects the way I do in the code, It would still be safe to check that everything works as intended.

I haven't updated the code in those `bgms` functions that call the functions of the SBM prior. At this stage, this will generate some compilation errors because we need to make sure that the data structures supplied to the SBM prior functions are the same as the required RcppArmadillo structures.


Ciao,

Giuseppe 