### PR TITLE
Remove all unnecessary uses of using namespace Rcpp;

### DIFF
--- a/src/bgmCompare_helper.cpp
+++ b/src/bgmCompare_helper.cpp
@@ -3,8 +3,6 @@
 #include "bgmCompare_helper.h"
 #include "common_helpers.h"
 
-using namespace Rcpp;
-
 
 
 /**

--- a/src/bgmCompare_logp_and_grad.cpp
+++ b/src/bgmCompare_logp_and_grad.cpp
@@ -5,8 +5,6 @@
 #include "explog_switch.h"
 #include "common_helpers.h"
 
-using namespace Rcpp;
-
 
 
 /**

--- a/src/bgmCompare_parallel.cpp
+++ b/src/bgmCompare_parallel.cpp
@@ -11,7 +11,6 @@
 #include "mcmc_adaptation.h"
 #include "common_helpers.h"
 
-using namespace Rcpp;
 using namespace RcppParallel;
 
 

--- a/src/bgmCompare_sampler.cpp
+++ b/src/bgmCompare_sampler.cpp
@@ -15,7 +15,6 @@
 #include <string>
 #include "progress_manager.h"
 
-using namespace Rcpp;
 
 
 

--- a/src/bgm_helper.cpp
+++ b/src/bgm_helper.cpp
@@ -2,8 +2,6 @@
 #include "bgm_helper.h"
 #include "common_helpers.h"
 
-using namespace Rcpp;
-
 
 
 /**

--- a/src/bgm_logp_and_grad.cpp
+++ b/src/bgm_logp_and_grad.cpp
@@ -4,8 +4,6 @@
 #include "common_helpers.h"
 #include "explog_switch.h"
 
-using namespace Rcpp;
-
 
 
 /**

--- a/src/bgm_parallel.cpp
+++ b/src/bgm_parallel.cpp
@@ -11,7 +11,6 @@
 #include "common_helpers.h"
 #include "chainResults.h"
 
-using namespace Rcpp;
 using namespace RcppParallel;
 
 

--- a/src/mcmc_hmc.cpp
+++ b/src/mcmc_hmc.cpp
@@ -4,7 +4,6 @@
 #include "mcmc_leapfrog.h"
 #include "mcmc_utils.h"
 #include "rng_utils.h"
-using namespace Rcpp;
 
 
 

--- a/src/mcmc_leapfrog.cpp
+++ b/src/mcmc_leapfrog.cpp
@@ -2,8 +2,6 @@
 #include <functional>
 #include "mcmc_leapfrog.h"
 #include "mcmc_memoization.h"
-using namespace Rcpp;
-
 
 
  /**

--- a/src/mcmc_nuts.cpp
+++ b/src/mcmc_nuts.cpp
@@ -5,8 +5,6 @@
 #include "mcmc_nuts.h"
 #include "mcmc_utils.h"
 #include "rng_utils.h"
-using namespace Rcpp;
-
 
 
 /**

--- a/src/mcmc_rwm.cpp
+++ b/src/mcmc_rwm.cpp
@@ -4,8 +4,6 @@
 #include "mcmc_utils.h"
 #include "mcmc_rwm.h"
 #include "rng_utils.h"
-using namespace Rcpp;
-
 
 
 /**

--- a/src/mcmc_rwm.h
+++ b/src/mcmc_rwm.h
@@ -6,7 +6,6 @@
 #include "mcmc_utils.h"
 struct SafeRNG;
 
-using namespace Rcpp;
 
 SamplerResult rwm_sampler(
     double current_state,

--- a/src/mcmc_utils.cpp
+++ b/src/mcmc_utils.cpp
@@ -4,8 +4,6 @@
 #include "mcmc_leapfrog.h"
 #include "mcmc_utils.h"
 #include "rng_utils.h"
-using namespace Rcpp;
-
 
 
 /**

--- a/src/sbm_edge_prior.cpp
+++ b/src/sbm_edge_prior.cpp
@@ -2,8 +2,6 @@
 #include "rng_utils.h"
 #include "explog_switch.h"
 
-using namespace Rcpp;
-
 // ----------------------------------------------------------------------------|
 // The c++ code below is based on the R code accompanying the paper:
 //  Geng, J., Bhattacharya, A., & Pati, D. (2019). Probabilistic Community


### PR DESCRIPTION
This is not strictly necessary, but makes it very easy to see where Rcpp is actually used (Ctrl+F "Rcpp::").