### PR TITLE
Fixes ggm

### DIFF
--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -684,8 +684,9 @@ void GGMModel::update_edge_parameter(size_t i, size_t j, int iteration) {
     ln_alpha += interaction_prior_logp(interaction_prior_type_, precision_proposal_(i, j), pairwise_scale_);
     ln_alpha -= interaction_prior_logp(interaction_prior_type_, precision_matrix_(i, j), pairwise_scale_);
 
-    // Gamma(1,1) prior on K_jj cancels: constrained diagonal is a
-    // deterministic function of phi_{q-1,q} with phi_{q,q} fixed.
+    // Gamma(1,1) prior on changed diagonal K_jj
+    ln_alpha += R::dgamma(precision_proposal_(j, j), 1.0, 1.0, true);
+    ln_alpha -= R::dgamma(precision_matrix_(j, j), 1.0, 1.0, true);
 
     if (MY_LOG(runif(rng_)) < ln_alpha) {
         double omega_ij_old = precision_matrix_(i, j);
@@ -839,7 +840,9 @@ void GGMModel::update_edge_indicator_parameter_pair(size_t i, size_t j) {
         ln_alpha += R::dnorm(precision_matrix_(i, j) / constants_[3], 0.0, proposal_sd, true) - MY_LOG(constants_[3]);
         ln_alpha -= interaction_prior_logp(interaction_prior_type_, precision_matrix_(i, j), pairwise_scale_);
 
-        // Gamma(1,1) prior on K_jj cancels: constrained parameterization.
+        // Gamma(1,1) prior on changed diagonal K_jj
+        ln_alpha += R::dgamma(precision_proposal_(j, j), 1.0, 1.0, true);
+        ln_alpha -= R::dgamma(precision_matrix_(j, j), 1.0, 1.0, true);
 
         if (MY_LOG(runif(rng_)) < ln_alpha) {
 
@@ -893,7 +896,8 @@ void GGMModel::update_edge_indicator_parameter_pair(size_t i, size_t j) {
         ln_alpha += interaction_prior_logp(interaction_prior_type_, omega_prop_ij, pairwise_scale_);
 
         // Gamma(1,1) prior on changed diagonal K_jj
-        // Gamma(1,1) prior on K_jj cancels: constrained parameterization.
+        ln_alpha += R::dgamma(precision_proposal_(j, j), 1.0, 1.0, true);
+        ln_alpha -= R::dgamma(precision_matrix_(j, j), 1.0, 1.0, true);
 
         // Proposal term: proposed edge value given it was generated from truncated normal
         ln_alpha -= R::dnorm(omega_prop_ij / constants_[3], 0.0, proposal_sd, true) - MY_LOG(constants_[3]);

--- a/tests/testthat/test-sbc-ggm.R
+++ b/tests/testthat/test-sbc-ggm.R
@@ -69,12 +69,14 @@ draw_prior_K = function(p, scale = 2.5, max_tries = 10000) {
 
 # Compute SBC rank: number of posterior draws less than the true value.
 # Returns a named vector of ranks (one per parameter).
-compute_sbc_ranks = function(K_true, p, fit) {
+compute_sbc_ranks = function(K_true, p, fit, thin_idx = NULL) {
   # Off-diagonal precision entries (raw precision scale)
   pw_samples = do.call(rbind, fit$raw_samples$pairwise)
+  if(!is.null(thin_idx)) pw_samples = pw_samples[thin_idx, , drop = FALSE]
 
   # Diagonal precision entries
   main_samples = do.call(rbind, fit$raw_samples$main)
+  if(!is.null(thin_idx)) main_samples = main_samples[thin_idx, , drop = FALSE]
 
   ranks = numeric(0)
   names_out = character(0)
@@ -217,16 +219,7 @@ test_that("SBC: GGM MH produces uniform ranks (p=3, no edge selection)", {
 
     # Thin to reduce autocorrelation in MH chains
     thin_idx = seq(1, L_raw, by = thin)
-    fit$raw_samples$pairwise = lapply(
-      fit$raw_samples$pairwise,
-      function(m) m[thin_idx, , drop = FALSE]
-    )
-    fit$raw_samples$main = lapply(
-      fit$raw_samples$main,
-      function(m) m[thin_idx, , drop = FALSE]
-    )
-
-    ranks[r, ] = compute_sbc_ranks(K_true, p, fit)
+    ranks[r, ] = compute_sbc_ranks(K_true, p, fit, thin_idx = thin_idx)
     if(r == 1) colnames(ranks) = names(ranks[1, ])
   }
 
@@ -253,6 +246,133 @@ test_that("SBC: GGM MH produces uniform ranks (p=3, no edge selection)", {
   counts = tabulate(bins, nbins = 20)
   chisq_p = chisq.test(counts)$p.value
   expect_true(chisq_p > 0.001,
-    info = sprintf("SBC global chi-squared p=%.4f", chisq_p)
+    info = sprintf("SBC global chi-squared (MH) p=%.4f", chisq_p)
+  )
+})
+
+
+# ---- Prior sampler with edge selection ---------------------------------------
+
+# Draw a precision matrix from the spike-and-slab GGM prior:
+#   gamma_ij ~ Bernoulli(0.5)
+#   K_ij | gamma_ij=1 ~ Cauchy(0, scale); K_ij | gamma_ij=0 = 0
+#   K_ii ~ Gamma(1, 1)
+# Rejection-samples until K is positive definite.
+draw_prior_K_es = function(p, scale = 2.5, inclusion_prob = 0.5,
+                           max_tries = 50000) {
+  for(attempt in seq_len(max_tries)) {
+    K = matrix(0, p, p)
+    gamma = matrix(0L, p, p)
+
+    for(i in seq_len(p - 1)) {
+      for(j in (i + 1):p) {
+        if(runif(1) < inclusion_prob) {
+          gamma[i, j] = 1L
+          gamma[j, i] = 1L
+          K[i, j] = rcauchy(1, 0, scale)
+          K[j, i] = K[i, j]
+        }
+      }
+    }
+
+    for(i in seq_len(p)) {
+      K[i, i] = rgamma(1, shape = 1, rate = 1)
+    }
+
+    ev = eigen(K, symmetric = TRUE, only.values = TRUE)$values
+    if(all(ev > 1e-8)) {
+      return(list(K = K, gamma = gamma))
+    }
+  }
+  stop("draw_prior_K_es: failed to draw PD matrix in ", max_tries, " attempts")
+}
+
+
+# ---- Diagonal rank computation for edge-selection SBC ------------------------
+
+# Compute SBC ranks for diagonal K_ii only (avoids tied-rank issues
+# from the spike-and-slab on off-diagonals).
+compute_sbc_ranks_diag = function(K_true, p, fit, thin_idx = NULL) {
+  main_samples = do.call(rbind, fit$raw_samples$main)
+  if(!is.null(thin_idx)) main_samples = main_samples[thin_idx, , drop = FALSE]
+
+  ranks = numeric(p)
+  for(i in seq_len(p)) {
+    ranks[i] = sum(main_samples[, i] < K_true[i, i])
+  }
+  names(ranks) = paste0("K_", seq_len(p), seq_len(p))
+  ranks
+}
+
+
+# ---- SBC test: Edge selection (MH, diagonal elements) ------------------------
+
+test_that("SBC: GGM MH produces uniform diagonal ranks (p=3, edge selection)", {
+  skip_unless_slow_sbc()
+
+  p = 3
+  n = 100
+  R = 200
+  L = 999
+  thin = 5
+  L_raw = L * thin
+  scale = 2.5
+
+  set.seed(2028)
+
+  prior_draws = vector("list", R)
+  for(r in seq_len(R)) {
+    prior_draws[[r]] = draw_prior_K_es(p, scale)
+  }
+
+  n_params = p
+  ranks = matrix(NA_real_, nrow = R, ncol = n_params)
+
+  for(r in seq_len(R)) {
+    draw = prior_draws[[r]]
+    K_true = draw$K
+    Sigma = solve(K_true)
+    X = MASS::mvrnorm(n, mu = rep(0, p), Sigma = Sigma)
+    dat = as.data.frame(X)
+    colnames(dat) = paste0("V", seq_len(p))
+
+    fit = bgm(dat,
+      variable_type = "continuous",
+      iter = L_raw, warmup = 5000, chains = 1,
+      edge_selection = TRUE, update_method = "adaptive-metropolis",
+      pairwise_scale = scale,
+      display_progress = "none", seed = 2028L + r
+    )
+
+    # Thin to reduce autocorrelation
+    thin_idx = seq(1, L_raw, by = thin)
+    ranks[r, ] = compute_sbc_ranks_diag(K_true, p, fit, thin_idx = thin_idx)
+    if(r == 1) colnames(ranks) = names(ranks[1, ])
+  }
+
+  n_fail_ks = 0
+  for(j in seq_len(ncol(ranks))) {
+    u = ranks[, j] / (L + 1)
+    p_val = suppressWarnings(ks.test(u, "punif")$p.value)
+    if(p_val <= 0.01) n_fail_ks = n_fail_ks + 1
+  }
+
+  max_fail = max(1, ceiling(n_params * 0.01 * 2))
+  expect_true(n_fail_ks <= max_fail,
+    info = sprintf(
+      "SBC KS (edge selection, diag): %d/%d parameters failed (limit %d)",
+      n_fail_ks, n_params, max_fail
+    )
+  )
+
+  all_ranks = as.vector(ranks)
+  bins = cut(all_ranks / (L + 1),
+    breaks = seq(0, 1, length.out = 21),
+    include.lowest = TRUE
+  )
+  counts = tabulate(bins, nbins = 20)
+  chisq_p = chisq.test(counts)$p.value
+  expect_true(chisq_p > 0.001,
+    info = sprintf("SBC global chi-squared p=%.4f (edge selection, diag)", chisq_p)
   )
 })


### PR DESCRIPTION
This should be checked with the other SBC package.

The fix makes some sense to me. If we propose $(K_{ij}, K_{jj}) \rightarrow (K^\ast_{ij}, K^\ast_{jj})$ then we should evaluate both the prior of $K_{ij}$ and $K_{jj}$, regardless of whether the proposed value was obtained in a deterministic manner.

