### PR TITLE
feat: expose adaptive-Metropolis acceptance probability via fit$am_diag

### DIFF
--- a/R/bgms_s7.R
+++ b/R/bgms_s7.R
@@ -79,6 +79,7 @@ bgms_class = new_class("bgms",
 
     # --- Optional ---
     nuts_diag = new_property(class_any, default = NULL),
+    am_diag = new_property(class_any, default = NULL),
 
     # --- easybgm compatibility (deprecated) ---
     indicator = new_property(class_any, default = NULL),
@@ -117,6 +118,7 @@ s3_list_to_bgms = function(results) {
     posterior_num_blocks = .subset2(results, "posterior_num_blocks"),
     posterior_summary_pairwise_allocations = .subset2(results, "posterior_summary_pairwise_allocations"),
     nuts_diag = .subset2(results, "nuts_diag"),
+    am_diag = .subset2(results, "am_diag"),
     indicator = .subset2(results, "indicator"),
     interactions = .subset2(results, "interactions"),
     thresholds = .subset2(results, "thresholds"),
@@ -190,6 +192,7 @@ bgmCompare_class = new_class("bgmCompare",
 
     # --- Optional ---
     nuts_diag = new_property(class_any, default = NULL),
+    am_diag = new_property(class_any, default = NULL),
 
     # --- Internal ---
     .bgm_spec = new_property(class_any, default = NULL),
@@ -223,6 +226,7 @@ s3_list_to_bgmCompare = function(results) {
     posterior_num_blocks = .subset2(results, "posterior_num_blocks"),
     posterior_summary_pairwise_allocations = .subset2(results, "posterior_summary_pairwise_allocations"),
     nuts_diag = .subset2(results, "nuts_diag"),
+    am_diag = .subset2(results, "am_diag"),
     .bgm_spec = .subset2(results, ".bgm_spec"),
     .field_names = names(results)
   )

--- a/R/build_output.R
+++ b/R/build_output.R
@@ -308,6 +308,7 @@ build_output_bgm = function(spec, raw) {
       if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
       if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
       if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
+      if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
       res
     })
   } else {
@@ -335,6 +336,7 @@ build_output_bgm = function(spec, raw) {
       if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
       if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
       if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
+      if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
       res
     })
   }
@@ -522,6 +524,8 @@ build_output_bgm = function(spec, raw) {
       raw,
       nuts_max_depth = s$nuts_max_depth
     )
+  } else if(s$update_method == "adaptive-metropolis") {
+    results$am_diag = summarize_am_diagnostics(raw, target_accept = s$target_accept)
   }
 
   results$.bgm_spec = spec
@@ -600,6 +604,7 @@ build_output_mixed_mrf = function(spec, raw) {
     if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
     if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
     if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
+    if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
     res
   })
 
@@ -804,6 +809,8 @@ build_output_mixed_mrf = function(spec, raw) {
       raw,
       nuts_max_depth = s$nuts_max_depth
     )
+  } else if(s$update_method == "adaptive-metropolis") {
+    results$am_diag = summarize_am_diagnostics(raw, target_accept = s$target_accept)
   }
 
   results$.bgm_spec = spec
@@ -1038,6 +1045,8 @@ build_output_compare = function(spec, raw) {
       raw,
       nuts_max_depth = s$nuts_max_depth
     )
+  } else if(s$update_method == "adaptive-metropolis") {
+    results$am_diag = summarize_am_diagnostics(raw, target_accept = s$target_accept)
   }
 
   results$.bgm_spec = spec

--- a/R/nuts_diagnostics.R
+++ b/R/nuts_diagnostics.R
@@ -245,3 +245,48 @@ summarize_nuts_diagnostics = function(out, nuts_max_depth = 10, verbose = TRUE) 
     )
   ))
 }
+
+
+# ------------------------------------------------------------------------------
+# summarize_am_diagnostics
+# ------------------------------------------------------------------------------
+# Combine and summarize adaptive-Metropolis diagnostics across chains.
+#
+# Mirrors summarize_nuts_diagnostics but only reports the per-iteration
+# mean acceptance probability, since adaptive-Metropolis has no
+# tree-depth, divergence, or energy concepts.
+#
+# @param out  List of chain outputs. Each element is a named list that
+#   must contain "am_accept_prob__". Chains without this field are
+#   silently dropped.
+# @param target_accept  Numeric scalar. The target acceptance rate the
+#   sampler was tuned toward (default: 0.44 for adaptive Metropolis).
+#   Stored alongside the diagnostic for convenience.
+#
+# Returns: An invisible named list with:
+#   - accept_prob: Numeric matrix (chains x iterations) of per-iteration
+#       mean Metropolis acceptance across all updated components.
+#   - target_accept: Numeric scalar; the target acceptance rate.
+#   - summary: List with mean_accept_prob (across all chains and iters).
+# ------------------------------------------------------------------------------
+summarize_am_diagnostics = function(out, target_accept = 0.44) {
+  am_chains = Filter(function(chain) {
+    "am_accept_prob__" %in% names(chain)
+  }, out)
+
+  if(length(am_chains) == 0) {
+    return(NULL)
+  }
+
+  accept_prob_mat = do.call(rbind, lapply(am_chains, function(chain) {
+    as.numeric(chain[["am_accept_prob__"]])
+  }))
+
+  invisible(list(
+    accept_prob = accept_prob_mat,
+    target_accept = target_accept,
+    summary = list(
+      mean_accept_prob = mean(accept_prob_mat, na.rm = TRUE)
+    )
+  ))
+}

--- a/src/mcmc/execution/chain_result.h
+++ b/src/mcmc/execution/chain_result.h
@@ -50,6 +50,12 @@ public:
     /// Whether NUTS diagnostics are stored.
     bool        has_nuts_diagnostics = false;
 
+    /// Adaptive-Metropolis mean per-iteration acceptance probability across
+    /// all updated components (n_iter).
+    arma::vec   am_accept_prob_samples;
+    /// Whether AM diagnostics are stored.
+    bool        has_am_diagnostics = false;
+
     /**
      * Reserve storage for samples
      * @param param_dim  Number of parameters per sample
@@ -90,6 +96,15 @@ public:
         energy_samples.set_size(n_iter);
         accept_prob_samples.set_size(n_iter);
         has_nuts_diagnostics = true;
+    }
+
+    /**
+     * Reserve storage for adaptive-Metropolis diagnostics
+     * @param n_iter  Number of sampling iterations
+     */
+    void reserve_am_diagnostics(const size_t n_iter) {
+        am_accept_prob_samples.set_size(n_iter);
+        has_am_diagnostics = true;
     }
 
     /**
@@ -134,5 +149,14 @@ public:
         non_reversible_samples(iter) = non_reversible ? 1 : 0;
         energy_samples(iter) = energy;
         accept_prob_samples(iter) = accept_prob;
+    }
+
+    /**
+     * Store adaptive-Metropolis diagnostics for one iteration
+     * @param iter         Iteration index (0-based)
+     * @param accept_prob  Mean acceptance probability across the sweep
+     */
+    void store_am_diagnostics(const size_t iter, double accept_prob) {
+        am_accept_prob_samples(iter) = accept_prob;
     }
 };

--- a/src/mcmc/execution/chain_runner.cpp
+++ b/src/mcmc/execution/chain_runner.cpp
@@ -85,6 +85,10 @@ void run_mcmc_chain(
                 }
             }
 
+            if (chain_result.has_am_diagnostics) {
+                chain_result.store_am_diagnostics(sample_index, result.accept_prob);
+            }
+
             chain_result.store_sample(sample_index, model.get_storage_vectorized_parameters());
 
             if (chain_result.has_indicators) {
@@ -135,6 +139,8 @@ std::vector<ChainResult> run_mcmc_sampler(
     ProgressManager& pm
 ) {
     const bool has_nuts_diag = (config.sampler_type == "nuts");
+    const bool has_am_diag = (config.sampler_type == "adaptive-metropolis" ||
+                              config.sampler_type == "mh");
     const bool has_sbm_alloc = edge_prior.has_allocations() ||
         (config.edge_selection && dynamic_cast<StochasticBlockEdgePrior*>(&edge_prior) != nullptr);
 
@@ -153,6 +159,10 @@ std::vector<ChainResult> run_mcmc_sampler(
 
         if (has_nuts_diag) {
             results[c].reserve_nuts_diagnostics(config.no_iter);
+        }
+
+        if (has_am_diag) {
+            results[c].reserve_am_diagnostics(config.no_iter);
         }
     }
 
@@ -216,6 +226,10 @@ Rcpp::List convert_results_to_list(const std::vector<ChainResult>& results) {
                 chain_list["non_reversible"] = chain.non_reversible_samples;
                 chain_list["energy"] = chain.energy_samples;
                 chain_list["accept_prob"] = chain.accept_prob_samples;
+            }
+
+            if (chain.has_am_diagnostics) {
+                chain_list["am_accept_prob"] = chain.am_accept_prob_samples;
             }
         }
 

--- a/src/mcmc/samplers/metropolis_sampler.h
+++ b/src/mcmc/samplers/metropolis_sampler.h
@@ -39,7 +39,11 @@ public:
     }
 
     /**
-     * Perform one Metropolis step with adaptation
+     * Perform one Metropolis step with adaptation.
+     *
+     * Returns the mean acceptance probability over all components updated
+     * in the sweep (read from the model). This drives the per-iteration
+     * AM diagnostics surfaced as fit$am_diag$accept_prob.
      */
     StepResult step(BaseModel& model, int iteration) override {
         if (!initialized_) {
@@ -49,7 +53,7 @@ public:
         model.do_one_metropolis_step(iteration);
 
         StepResult result;
-        result.accept_prob = 1.0;
+        result.accept_prob = model.last_metropolis_mean_accept_prob();
         return result;
     }
 

--- a/src/models/base_model.h
+++ b/src/models/base_model.h
@@ -3,6 +3,7 @@
 #include <RcppArmadillo.h>
 #include <stdexcept>
 #include <memory>
+#include <limits>
 
 // Forward declarations
 struct StepResult;
@@ -90,6 +91,20 @@ public:
      * @param iteration  Current iteration index (for Robbins-Monro adaptation)
      */
     virtual void do_one_metropolis_step(int iteration = -1) = 0;
+
+    /**
+     * Mean Metropolis acceptance probability across all components updated
+     * in the most recent do_one_metropolis_step() call.
+     *
+     * Used to populate the per-iteration `am_diag$accept_prob` diagnostic
+     * for the adaptive-Metropolis sampler. Defaults to NaN for models that
+     * do not implement Metropolis updates or have not yet taken a step.
+     *
+     * @return Mean acceptance probability over the last sweep, or NaN.
+     */
+    virtual double last_metropolis_mean_accept_prob() const {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
     /**
      * Initialize Metropolis adaptation controllers.

--- a/src/models/omrf/omrf_model.cpp
+++ b/src/models/omrf/omrf_model.cpp
@@ -1214,6 +1214,11 @@ void OMRFModel::update_edge_indicator(int var1, int var2) {
 // =============================================================================
 
 void OMRFModel::do_one_metropolis_step(int iteration) {
+    // Track running mean acceptance probability across all components
+    // updated this iteration; exposed via last_metropolis_mean_accept_prob().
+    double sum_accept = 0.0;
+    int    n_accept   = 0;
+
     // --- Pairwise effects sweep ---
     arma::mat accept_prob_pairwise = arma::zeros<arma::mat>(p_, p_);
     arma::umat index_mask_pairwise = arma::zeros<arma::umat>(p_, p_);
@@ -1224,6 +1229,8 @@ void OMRFModel::do_one_metropolis_step(int iteration) {
             if (edge_indicators_(v1, v2) == 1) {
                 accept_prob_pairwise(v1, v2) = ap;
                 index_mask_pairwise(v1, v2) = 1;
+                sum_accept += ap;
+                ++n_accept;
             }
         }
     }
@@ -1242,11 +1249,17 @@ void OMRFModel::do_one_metropolis_step(int iteration) {
         if (is_ordinal_variable_(v)) {
             int num_cats = num_categories_(v);
             for (int c = 0; c < num_cats; ++c) {
-                accept_prob_main(v, c) = update_main_effect_parameter(v, c, -1);
+                double ap = update_main_effect_parameter(v, c, -1);
+                accept_prob_main(v, c) = ap;
+                sum_accept += ap;
+                ++n_accept;
             }
         } else {
             for (int p = 0; p < 2; ++p) {
-                accept_prob_main(v, p) = update_main_effect_parameter(v, -1, p);
+                double ap = update_main_effect_parameter(v, -1, p);
+                accept_prob_main(v, p) = ap;
+                sum_accept += ap;
+                ++n_accept;
             }
         }
     }
@@ -1254,6 +1267,10 @@ void OMRFModel::do_one_metropolis_step(int iteration) {
     if (metropolis_main_adapter_) {
         metropolis_main_adapter_->update(index_mask_main, accept_prob_main, iteration);
     }
+
+    last_mh_mean_accept_ = (n_accept > 0)
+        ? sum_accept / static_cast<double>(n_accept)
+        : std::numeric_limits<double>::quiet_NaN();
 
     invalidate_gradient_cache();
 }

--- a/src/models/omrf/omrf_model.h
+++ b/src/models/omrf/omrf_model.h
@@ -87,6 +87,14 @@ public:
     void do_one_metropolis_step(int iteration = -1) override;
 
     /**
+     * @return Mean Metropolis acceptance probability over the most recent
+     *         do_one_metropolis_step() sweep. NaN before the first step.
+     */
+    double last_metropolis_mean_accept_prob() const override {
+        return last_mh_mean_accept_;
+    }
+
+    /**
      * Initialize Metropolis adaptation controllers for proposal-SD tuning
      * Must be called before warmup begins (e.g., by MetropolisSampler on first step)
      */
@@ -259,6 +267,10 @@ private:
     // =========================================================================
     // Data members
     // =========================================================================
+
+    // Most recent mean Metropolis acceptance probability over all updated
+    // pairwise + main-effect components. Reset every do_one_metropolis_step().
+    double last_mh_mean_accept_ = std::numeric_limits<double>::quiet_NaN();
 
     // Data
     size_t n_;                          ///< Number of observations


### PR DESCRIPTION
For the adaptive-Metropolis sampler, the fitted object now carries an am_diag slot that mirrors the existing nuts_diag for NUTS:

  fit$am_diag$accept_prob          # chains x iterations matrix
  fit$am_diag$target_accept        # scalar (default 0.44)
  fit$am_diag$summary$mean_accept_prob

Per-iteration mean acceptance is computed in OMRFModel::do_one_metropolis_step across all updated pairwise and main-effect components, exposed by a new virtual BaseModel::last_metropolis_mean_accept_prob(), read by MetropolisSampler::step into StepResult.accept_prob, accumulated in ChainResult::am_accept_prob_samples, and surfaced to R via build_output.R and a new summarize_am_diagnostics() helper. The AM property is wired through bgms_class and bgmCompare_class.

NUTS is unaffected: fit$am_diag is NULL for NUTS fits and fit$nuts_diag is NULL for AM fits.

Verified on a 6-variable ADHD subset (chains=2, iter=500): observed am_diag$summary$mean_accept_prob = 0.444, hitting the 0.44 Robbins-Monro target. All 6696 existing tests pass.