### PR TITLE
feat(bgm): dimension-adaptive auto-default for the determinant tilt

### DIFF
--- a/R/bgm.R
+++ b/R/bgm.R
@@ -94,13 +94,22 @@
 #'   Ignored for pure ordinal models.
 #'   Default: \code{gamma_prior(shape = 1, rate = 1)}.
 #'
-#' @param delta Non-negative numeric. Determinant-tilt exponent on the
-#'   continuous-block precision matrix \eqn{K} (GGM) or \eqn{K_{yy}}
-#'   (mixed MRF): multiplies the prior by \eqn{|K|^{\delta}}, pushing the
-#'   chain away from the positive-definite cone boundary. Both NUTS and
-#'   adaptive-Metropolis update paths apply the tilt. \code{delta = 0}
-#'   (default) recovers the untilted prior. Not allowed for pure ordinal
-#'   models (no precision matrix to tilt).
+#' @param delta Non-negative numeric, or \code{NULL} for the dimension-
+#'   adaptive default. Determinant-tilt exponent on the continuous-block
+#'   precision matrix \eqn{K} (GGM) or \eqn{K_{yy}} (mixed MRF):
+#'   multiplies the prior by \eqn{|K|^{\delta}}, softly repelling the
+#'   chain from the positive-definite cone boundary. \code{delta = NULL}
+#'   (default) auto-resolves to \eqn{0.5 \log(p)} where \eqn{p} is the
+#'   dimension of the continuous precision matrix (the number of
+#'   variables for GGM, the number of continuous variables for mixed
+#'   MRF). The rule is the simple form of the dimension-adaptive scaling
+#'   \eqn{\delta(p) = c \log p} with \eqn{c \in (0.3, 0.6)} discussed in
+#'   the companion paper on determinant-tilted spike-and-slab priors
+#'   (Marsman et al., in preparation). Pass \code{delta = 0} for the
+#'   untilted prior (the companion-paper baseline) or a non-negative
+#'   numeric to override. Both NUTS and adaptive-Metropolis update paths
+#'   apply the tilt. Not allowed for pure ordinal models (no precision
+#'   matrix to tilt).
 #'
 #' @param pairwise_scale `r lifecycle::badge("deprecated")` Double.
 #'   Scale of the Cauchy prior for pairwise
@@ -333,7 +342,7 @@ bgm = function(
   threshold_prior = beta_prime_prior(alpha = 0.5, beta = 0.5),
   means_prior = normal_prior(scale = 1),
   precision_scale_prior = gamma_prior(shape = 1, rate = 1),
-  delta = 0,
+  delta = NULL,
   edge_selection = TRUE,
   edge_prior = bernoulli_prior(0.5),
   na_action = c("listwise", "impute"),

--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -265,7 +265,7 @@ bgm_spec = function(x,
                     scale_prior_type = "gamma",
                     scale_shape = 1,
                     scale_rate = 1,
-                    delta = 0,
+                    delta = NULL,
                     standardize = FALSE,
                     edge_selection = TRUE,
                     edge_prior = bernoulli_prior(0.5),
@@ -345,16 +345,30 @@ bgm_spec = function(x,
     model_type = "mixed_mrf"
   }
 
+  # Auto-resolve delta = NULL to the dimension-adaptive default 0.5 * log(p),
+  # where p is the dimension of the continuous precision matrix. For models
+  # without a continuous block (omrf, compare) the tilt has no target, so
+  # NULL resolves to 0.
+  if(is.null(delta)) {
+    delta = if(model_type == "ggm") {
+      0.5 * log(max(num_variables, 1))
+    } else if(model_type == "mixed_mrf") {
+      0.5 * log(max(sum(!is_ordinal), 1))
+    } else {
+      0
+    }
+  }
+
   # Validate determinant-tilt exponent and reject for pure-ordinal models
   if(!is.numeric(delta) || length(delta) != 1L || is.na(delta) ||
      !is.finite(delta) || delta < 0) {
-    stop("'delta' must be a single finite non-negative numeric.")
+    stop("'delta' must be a single finite non-negative numeric, or NULL.")
   }
   if(delta > 0 && model_type %in% c("omrf", "compare")) {
     stop(
       "'delta' (determinant tilt) requires continuous variables; the ",
       "current model_type is '", model_type, "', which has no precision ",
-      "matrix to tilt. Pass delta = 0 (default) or use continuous data."
+      "matrix to tilt. Pass delta = 0 or use continuous data."
     )
   }
 

--- a/R/sample_ggm_prior.R
+++ b/R/sample_ggm_prior.R
@@ -39,10 +39,16 @@
 #' @param edge_indicators Optional integer \eqn{p \times p} matrix with
 #'   \code{1} = edge included, \code{0} = excluded. Must be symmetric with
 #'   \code{1}s on the diagonal. Default: full graph (all edges included).
-#' @param delta Non-negative numeric. Determinant-tilt exponent: multiplies
-#'   the prior by \eqn{|K|^{\delta}}, pushing the chain away from the
-#'   positive-definite cone boundary. \code{delta = 0} (default) recovers
-#'   the untilted prior.
+#' @param delta Non-negative numeric, or \code{NULL} for the dimension-
+#'   adaptive default. Determinant-tilt exponent: multiplies the prior
+#'   by \eqn{|K|^{\delta}}, softly repelling the chain from the
+#'   positive-definite cone boundary. \code{delta = NULL} (default)
+#'   auto-resolves to \eqn{0.5 \log(p)}, the simple form of the
+#'   dimension-adaptive rule \eqn{\delta(p) = c \log p} with
+#'   \eqn{c \in (0.3, 0.6)} discussed in the companion paper on
+#'   determinant-tilted spike-and-slab priors (Marsman et al., in
+#'   preparation). Pass \code{delta = 0} for the untilted prior (the
+#'   companion-paper baseline) or a non-negative numeric to override.
 #'
 #' @return A list with components
 #'   \describe{
@@ -101,7 +107,7 @@ sample_ggm_prior = function(
   seed = 1L,
   verbose = TRUE,
   edge_indicators = NULL,
-  delta = 0
+  delta = NULL
 ) {
   validate_positive_integer(p, "p", min_value = 2L)
   validate_positive_integer(n_samples, "n_samples", min_value = 1L)
@@ -109,9 +115,12 @@ sample_ggm_prior = function(
   validate_positive_integer(max_depth, "max_depth", min_value = 1L)
   validate_finite_scalar(step_size, "step_size", positive = TRUE)
   validate_positive_integer(seed, "seed", min_value = 0L)
+  if(is.null(delta)) {
+    delta = 0.5 * log(p)
+  }
   if(!is.numeric(delta) || length(delta) != 1L || is.na(delta) ||
      !is.finite(delta) || delta < 0) {
-    stop("'delta' must be a single finite non-negative numeric.")
+    stop("'delta' must be a single finite non-negative numeric, or NULL.")
   }
   if(!is.logical(verbose) || length(verbose) != 1L || is.na(verbose)) {
     stop("'verbose' must be TRUE or FALSE.")

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -14,7 +14,7 @@ bgm(
   threshold_prior = beta_prime_prior(alpha = 0.5, beta = 0.5),
   means_prior = normal_prior(scale = 1),
   precision_scale_prior = gamma_prior(shape = 1, rate = 1),
-  delta = 0,
+  delta = NULL,
   edge_selection = TRUE,
   edge_prior = bernoulli_prior(0.5),
   na_action = c("listwise", "impute"),
@@ -116,13 +116,22 @@ Only used for models with continuous variables (GGM and mixed MRF).
 Ignored for pure ordinal models.
 Default: \code{gamma_prior(shape = 1, rate = 1)}.}
 
-\item{delta}{Non-negative numeric. Determinant-tilt exponent on the
-continuous-block precision matrix \eqn{K} (GGM) or \eqn{K_{yy}}
-(mixed MRF): multiplies the prior by \eqn{|K|^{\delta}}, pushing the
-chain away from the positive-definite cone boundary. Both NUTS and
-adaptive-Metropolis update paths apply the tilt. \code{delta = 0}
-(default) recovers the untilted prior. Not allowed for pure ordinal
-models (no precision matrix to tilt).}
+\item{delta}{Non-negative numeric, or \code{NULL} for the dimension-
+adaptive default. Determinant-tilt exponent on the continuous-block
+precision matrix \eqn{K} (GGM) or \eqn{K_{yy}} (mixed MRF):
+multiplies the prior by \eqn{|K|^{\delta}}, softly repelling the
+chain from the positive-definite cone boundary. \code{delta = NULL}
+(default) auto-resolves to \eqn{0.5 \log(p)} where \eqn{p} is the
+dimension of the continuous precision matrix (the number of
+variables for GGM, the number of continuous variables for mixed
+MRF). The rule is the simple form of the dimension-adaptive scaling
+\eqn{\delta(p) = c \log p} with \eqn{c \in (0.3, 0.6)} discussed in
+the companion paper on determinant-tilted spike-and-slab priors
+(Marsman et al., in preparation). Pass \code{delta = 0} for the
+untilted prior (the companion-paper baseline) or a non-negative
+numeric to override. Both NUTS and adaptive-Metropolis update paths
+apply the tilt. Not allowed for pure ordinal models (no precision
+matrix to tilt).}
 
 \item{edge_selection}{Logical. Whether to perform Bayesian edge selection.
 If \code{FALSE}, the model estimates all edges. Default: \code{TRUE}.}

--- a/man/sample_ggm_prior.Rd
+++ b/man/sample_ggm_prior.Rd
@@ -15,7 +15,7 @@ sample_ggm_prior(
   seed = 1L,
   verbose = TRUE,
   edge_indicators = NULL,
-  delta = 0
+  delta = NULL
 )
 }
 \arguments{
@@ -51,10 +51,16 @@ dual-averaging adaptation. Default \code{0.1}.}
 \code{1} = edge included, \code{0} = excluded. Must be symmetric with
 \code{1}s on the diagonal. Default: full graph (all edges included).}
 
-\item{delta}{Non-negative numeric. Determinant-tilt exponent: multiplies
-the prior by \eqn{|K|^{\delta}}, pushing the chain away from the
-positive-definite cone boundary. \code{delta = 0} (default) recovers
-the untilted prior.}
+\item{delta}{Non-negative numeric, or \code{NULL} for the dimension-
+adaptive default. Determinant-tilt exponent: multiplies the prior
+by \eqn{|K|^{\delta}}, softly repelling the chain from the
+positive-definite cone boundary. \code{delta = NULL} (default)
+auto-resolves to \eqn{0.5 \log(p)}, the simple form of the
+dimension-adaptive rule \eqn{\delta(p) = c \log p} with
+\eqn{c \in (0.3, 0.6)} discussed in the companion paper on
+determinant-tilted spike-and-slab priors (Marsman et al., in
+preparation). Pass \code{delta = 0} for the untilted prior (the
+companion-paper baseline) or a non-negative numeric to override.}
 }
 \value{
 A list with components

--- a/tests/testthat/test-mixed-nuts.R
+++ b/tests/testthat/test-mixed-nuts.R
@@ -576,6 +576,7 @@ test_that("M.2J: NUTS diagnostics are clean for mixed MRF", {
     iter = 2000, warmup = 1000, chains = 2,
     edge_selection = FALSE, update_method = "nuts",
     pairwise_scale = pw_scale, main_alpha = main_a, main_beta = main_b,
+    delta = 0,
     display_progress = "none", seed = 303
   )
 

--- a/tests/testthat/test-sbc-ggm.R
+++ b/tests/testthat/test-sbc-ggm.R
@@ -144,7 +144,7 @@ test_that("SBC: GGM NUTS produces uniform ranks (p=3, no edge selection)", {
       variable_type = "continuous",
       iter = L, warmup = 1000, chains = 1,
       edge_selection = FALSE, update_method = "nuts",
-      pairwise_scale = scale,
+      pairwise_scale = scale, delta = 0,
       display_progress = "none", seed = 2026L + r
     )
 
@@ -218,7 +218,7 @@ test_that("SBC: GGM MH produces uniform ranks (p=3, no edge selection)", {
       variable_type = "continuous",
       iter = L_raw, warmup = 5000, chains = 1,
       edge_selection = FALSE, update_method = "adaptive-metropolis",
-      pairwise_scale = scale,
+      pairwise_scale = scale, delta = 0,
       display_progress = "none", seed = 2027L + r
     )
 
@@ -350,7 +350,7 @@ test_that("SBC: GGM MH produces uniform diagonal ranks (p=3, edge selection)", {
       variable_type = "continuous",
       iter = L_raw, warmup = 5000, chains = 1,
       edge_selection = TRUE, update_method = "adaptive-metropolis",
-      pairwise_scale = scale,
+      pairwise_scale = scale, delta = 0,
       display_progress = "none", seed = 2028L + r
     )
 


### PR DESCRIPTION
## Summary

Implements Stage 1 of [dev/plans/backlog/hierarchical-ggm-degord-rr.md](dev/plans/backlog/hierarchical-ggm-degord-rr.md): a dimension-adaptive auto-default for the `delta` argument.

`bgm()` and `sample_ggm_prior()` now accept `delta = NULL` (the new default), which resolves to

$$\delta(p) = 0.5 \cdot \log(p)$$

where $p$ is the dimension of the continuous precision matrix. This is the simple form of the dimension-adaptive scaling $\delta(p) = c \cdot \log p$ with $c \in (0.3, 0.6)$ established in the companion paper on determinant-tilted spike-and-slab priors (Marsman et al., in preparation). The rule keeps the prior bulk in the positive-definite cone interior uniformly in $p$, whereas constant $\delta$ drifts off-target and the G-Wishart-style linear rule $(q-2)/2$ overshoots.

At common dimensions the auto-default produces sensible values:

| p    | 5    | 10   | 20   | 50   | 100  |
|------|------|------|------|------|------|
| auto | 0.80 | 1.15 | 1.50 | 1.96 | 2.30 |

## Changes

- **`R/bgm.R`**: signature `delta = 0` → `delta = NULL`; roxygen documents the auto-default, the companion-paper motivation, and the explicit override path.
- **`R/bgm_spec.R`**: signature `delta = 0` → `delta = NULL`; resolver added after `model_type` is finalized. Routing:
  - GGM: $\delta = 0.5 \log(\textnormal{num_variables})$
  - Mixed MRF: $\delta = 0.5 \log(\textnormal{num_continuous})$
  - OMRF / compare: $\delta = 0$ (no continuous block to tilt; the existing validation already forbids $\delta > 0$ here)
- **`R/sample_ggm_prior.R`**: same treatment; GGM-only so the resolver is simply $0.5 \log(p)$.
- **Roxygen**: regenerated `man/bgm.Rd` and `man/sample_ggm_prior.Rd` via `devtools::document()`.
- **Tests**: four tests that relied on the implicit `delta = 0` for their original calibration (3 GGM SBC tests + M.2J mixed-MRF NUTS diagnostics) now pass `delta = 0` explicitly. Their prior generators sample from the untilted prior; explicit `delta = 0` preserves the test's calibration.

## Behavior change

Users who previously called `bgm()` or `sample_ggm_prior()` without specifying `delta` get the tilted prior by default. Reproducibility note: chains with the same `seed` will differ from previous versions; pass `delta = 0` to recover identical behavior.

## Test plan

- [x] Smoke test: `sample_ggm_prior(p = 4, delta = NULL)` resolves to $\delta \approx 0.693$ and produces finite draws.
- [x] Smoke test: `sample_ggm_prior(p = 4, delta = 0)` continues to work (explicit untilted).
- [x] Smoke test: `sample_ggm_prior(p = 4, delta = -1)` errors with a clear message.
- [x] Fast test suite: 6786/6786 assertions pass.
- [x] Slow tests (filter `sbc-ggm|parameter-recovery-ggm|ggm-nuts|mixed-nuts|scaling-diagnostics`): all pass after the four targeted patches.
- [ ] CI green.

## Companion / next stage

Stage 2 follows: `sample_ggm_prior(spec = "joint")` for joint-specification SBC. The auto-default exposed here applies in either spec.