### PR TITLE
feat(sample_ggm_prior): add spec = "joint" and joint-spec SBC test

### DIFF
--- a/R/sample_ggm_prior.R
+++ b/R/sample_ggm_prior.R
@@ -1,9 +1,25 @@
 #' Sample from the GGM (Partial-Association) Prior
 #'
-#' Draws from the prior of a Gaussian graphical model using the same
-#' constrained NUTS sampler that drives \code{\link{bgm}} for continuous
-#' data. The likelihood is omitted (\eqn{n = 0}, \eqn{S = 0}), so the chain
-#' targets the prior alone.
+#' Draws from the prior of a Gaussian graphical model. The likelihood is
+#' omitted (\eqn{n = 0}, \eqn{S = 0}), so the chain targets the prior alone.
+#' Two specifications are supported via the \code{spec} argument:
+#' \itemize{
+#'   \item \code{"conditional"} (default): fix a graph \eqn{\Gamma} and
+#'     sample \eqn{K \mid \Gamma} via the same constrained NUTS sampler
+#'     that drives \code{\link{bgm}} for continuous data. The chain
+#'     targets \eqn{p(K \mid \Gamma) \propto \mathrm{slab}(K) \cdot
+#'     \mathrm{diag}(K) \cdot |K|^{\delta} \cdot \mathbf{1}\{K \in
+#'     \mathcal{M}^{+}(\Gamma)\} / Z(\Gamma)}.
+#'   \item \code{"joint"}: sample \eqn{(K, \Gamma)} jointly from the
+#'     un-normalised joint prior \eqn{p(K, \Gamma) \propto
+#'     \mathrm{slab}(K) \cdot \mathrm{diag}(K) \cdot |K|^{\delta} \cdot
+#'     \mathbf{1}\{K \in \mathcal{M}^{+}(\Gamma)\} \cdot \pi(\Gamma)}.
+#'     Uses the adaptive-Metropolis MH chain from \code{\link{bgm}} with
+#'     edge selection on and the likelihood off, so the marginal on
+#'     \eqn{\Gamma} is \eqn{\pi(\Gamma) \cdot Z(\Gamma)} (joint
+#'     specification, not hierarchical). Useful for simulation-based
+#'     calibration of \code{\link{bgm}}'s default sampler.
+#' }
 #'
 #' The priors are specified on the partial-association scale
 #' \eqn{K_{yy} = -K/2}: \code{interaction_prior} acts on
@@ -14,8 +30,10 @@
 #' there. Output samples are reported as entries of \eqn{K}; convert with
 #' \eqn{K_{yy} = -K/2} if you want them on the partial-association scale.
 #'
-#' When \code{edge_indicators} is supplied, off-diagonals at excluded
-#' positions are constrained to zero throughout the chain.
+#' When \code{spec = "conditional"} and \code{edge_indicators} is supplied,
+#' off-diagonals at excluded positions are constrained to zero throughout
+#' the chain. \code{edge_indicators} is ignored when \code{spec = "joint"}
+#' (the chain samples \eqn{\Gamma}).
 #'
 #' @param p Integer. Dimension of the precision matrix (\eqn{p \ge 2}).
 #' @param n_samples Integer. Number of post-warmup draws to keep.
@@ -32,13 +50,24 @@
 #'   which implies \eqn{K_{ii}/2 \sim \textrm{Exp}(1)} and therefore
 #'   \eqn{K_{ii} \sim \textrm{Exp}(1/2)} (mean \eqn{2}).
 #' @param step_size Positive numeric. Initial NUTS step size used to seed
-#'   dual-averaging adaptation. Default \code{0.1}.
+#'   dual-averaging adaptation. Default \code{0.1}. Used only for
+#'   \code{spec = "conditional"} (NUTS path); ignored for the
+#'   \code{"joint"} MH path.
 #' @param max_depth Integer. Maximum NUTS tree depth. Default \code{10}.
+#'   Used only for \code{spec = "conditional"}.
 #' @param seed Integer. RNG seed for the chain. Default \code{1L}.
 #' @param verbose Logical. If \code{TRUE} (default), print a progress bar.
 #' @param edge_indicators Optional integer \eqn{p \times p} matrix with
 #'   \code{1} = edge included, \code{0} = excluded. Must be symmetric with
 #'   \code{1}s on the diagonal. Default: full graph (all edges included).
+#'   Used only for \code{spec = "conditional"} (the chain samples
+#'   \eqn{K \mid \Gamma}); ignored for \code{spec = "joint"}.
+#' @param spec One of \code{"conditional"} (default, sample
+#'   \eqn{K \mid \Gamma} at fixed \eqn{\Gamma}) or \code{"joint"} (sample
+#'   \eqn{(K, \Gamma)} jointly from the un-normalised joint prior).
+#' @param edge_inclusion_prob Probability in \eqn{(0, 1)} for the
+#'   Bernoulli edge prior used when \code{spec = "joint"}. Default
+#'   \code{0.5}. Ignored when \code{spec = "conditional"}.
 #' @param delta Non-negative numeric, or \code{NULL} for the dimension-
 #'   adaptive default. Determinant-tilt exponent: multiplies the prior
 #'   by \eqn{|K|^{\delta}}, softly repelling the chain from the
@@ -55,8 +84,10 @@
 #'     \item{\code{K_offdiag}}{Numeric matrix of size
 #'       \code{n_samples} x \code{p * (p - 1) / 2} containing the upper-triangle
 #'       off-diagonal entries of \eqn{K} for each draw, in column-major order
-#'       \eqn{(K_{12}, K_{13}, K_{23}, K_{14}, \ldots)}. Excluded edges are
-#'       returned as \code{0}.}
+#'       \eqn{(K_{12}, K_{13}, K_{23}, K_{14}, \ldots)}. Under
+#'       \code{spec = "conditional"}, excluded edges are returned as
+#'       \code{0}; under \code{spec = "joint"}, off-diagonals at excluded
+#'       edges are sampled at \code{0} per the inclusion indicator.}
 #'     \item{\code{K_diag}}{Numeric matrix of size
 #'       \code{n_samples} x \code{p} containing the diagonal entries
 #'       \eqn{K_{11}, \ldots, K_{pp}}.}
@@ -65,9 +96,12 @@
 #'       (e.g. \code{"K_1_2"}).}
 #'     \item{\code{diag_names}}{Character vector of length \code{p} naming
 #'       the columns of \code{K_diag}.}
-#'     \item{\code{step_size}}{The (initial) NUTS step size used.}
-#'     \item{\code{edge_indicators}}{The integer edge-indicator matrix used
-#'       (full graph if not supplied).}
+#'     \item{\code{edge_indicators}}{Under \code{spec = "conditional"}, the
+#'       \code{p x p} integer matrix of fixed inclusion indicators used
+#'       (full graph if not supplied). Under \code{spec = "joint"}, an
+#'       \code{n_samples x p(p-1)/2} integer matrix of sampled
+#'       \eqn{\Gamma_{ij}} indicators (column order matches
+#'       \code{K_offdiag}).}
 #'   }
 #'
 #' @seealso \code{\link{cauchy_prior}}, \code{\link{normal_prior}},
@@ -107,8 +141,11 @@ sample_ggm_prior = function(
   seed = 1L,
   verbose = TRUE,
   edge_indicators = NULL,
-  delta = NULL
+  delta = NULL,
+  spec = c("conditional", "joint"),
+  edge_inclusion_prob = 0.5
 ) {
+  spec = match.arg(spec)
   validate_positive_integer(p, "p", min_value = 2L)
   validate_positive_integer(n_samples, "n_samples", min_value = 1L)
   validate_positive_integer(n_warmup, "n_warmup", min_value = 0L)
@@ -125,6 +162,11 @@ sample_ggm_prior = function(
   if(!is.logical(verbose) || length(verbose) != 1L || is.na(verbose)) {
     stop("'verbose' must be TRUE or FALSE.")
   }
+  if(!is.numeric(edge_inclusion_prob) || length(edge_inclusion_prob) != 1L ||
+     is.na(edge_inclusion_prob) || edge_inclusion_prob <= 0 ||
+     edge_inclusion_prob >= 1) {
+    stop("'edge_inclusion_prob' must be a single numeric in (0, 1).")
+  }
 
   ip = unpack_interaction_prior(interaction_prior)
   if(identical(ip$interaction_prior_type, "beta-prime")) {
@@ -137,21 +179,100 @@ sample_ggm_prior = function(
 
   edge_indicators = validate_ggm_prior_edge_indicators(edge_indicators, p)
 
-  sample_ggm_prior_cpp(
-    p                        = as.integer(p),
-    n_samples                = as.integer(n_samples),
-    n_warmup                 = as.integer(n_warmup),
-    pairwise_scale           = ip$pairwise_scale,
-    interaction_prior_type   = ip$interaction_prior_type,
-    scale_prior_type         = sp$scale_prior_type,
-    gamma_shape              = sp$scale_shape,
-    gamma_rate               = sp$scale_rate,
-    step_size                = step_size,
-    max_depth                = as.integer(max_depth),
-    seed                     = as.integer(seed),
-    verbose                  = verbose,
-    edge_indicators_nullable = edge_indicators,
-    delta                    = as.numeric(delta)
+  if(spec == "conditional") {
+    return(sample_ggm_prior_cpp(
+      p                        = as.integer(p),
+      n_samples                = as.integer(n_samples),
+      n_warmup                 = as.integer(n_warmup),
+      pairwise_scale           = ip$pairwise_scale,
+      interaction_prior_type   = ip$interaction_prior_type,
+      scale_prior_type         = sp$scale_prior_type,
+      gamma_shape              = sp$scale_shape,
+      gamma_rate               = sp$scale_rate,
+      step_size                = step_size,
+      max_depth                = as.integer(max_depth),
+      seed                     = as.integer(seed),
+      verbose                  = verbose,
+      edge_indicators_nullable = edge_indicators,
+      delta                    = as.numeric(delta)
+    ))
+  }
+
+  # spec == "joint": drive the bgm() MH chain with edge selection on and
+  # zero data (n = 0, S = 0). The chain targets the un-normalised joint
+  # prior p(K, Gamma) and produces (K, Gamma) draws.
+  inputFromR = list(
+    n                      = 0L,
+    suf_stat               = matrix(0, p, p),
+    pairwise_scale         = ip$pairwise_scale,
+    interaction_prior_type = ip$interaction_prior_type,
+    scale_prior_type       = sp$scale_prior_type,
+    scale_shape            = sp$scale_shape,
+    scale_rate             = sp$scale_rate
+  )
+
+  results = sample_ggm(
+    inputFromR              = inputFromR,
+    prior_inclusion_prob    = matrix(edge_inclusion_prob, p, p),
+    initial_edge_indicators = matrix(1L, p, p),
+    no_iter                 = as.integer(n_samples),
+    no_warmup               = as.integer(n_warmup),
+    no_chains               = 1L,
+    edge_selection          = TRUE,
+    sampler_type            = "adaptive-metropolis",
+    seed                    = as.integer(seed),
+    no_threads              = 1L,
+    progress_type           = if(verbose) 2L else 0L,
+    edge_prior              = "Bernoulli",
+    delta                   = as.numeric(delta)
+  )
+  if(length(results) == 0L || isTRUE(results[[1L]]$error)) {
+    msg = if(length(results) > 0L) results[[1L]]$error_msg else "empty result"
+    stop("sample_ggm_prior (joint): chain failed (", msg, ")")
+  }
+
+  # Reformat the bgm() output to match the conditional spec's return shape.
+  # Both `samples` and `indicator_samples` are emitted as the full upper
+  # triangle in (i <= j) order, p(p+1)/2 rows per iteration. Diagonals on
+  # the indicator side are always 1 and discarded here.
+  upper = results[[1L]]$samples            # ((p*(p+1))/2) x n_samples
+  inds  = results[[1L]]$indicator_samples  # ((p*(p+1))/2) x n_samples
+  n_edges = as.integer(p * (p - 1) / 2)
+
+  K_offdiag    = matrix(0,  n_samples, n_edges)
+  K_diag       = matrix(0,  n_samples, p)
+  gamma_offdiag = matrix(0L, n_samples, n_edges)
+  e = 1L
+  off_idx = 1L
+  for(i in seq_len(p)) {
+    for(j in i:p) {
+      if(i == j) {
+        K_diag[, i] = upper[e, ]
+      } else {
+        K_offdiag[,    off_idx] = upper[e, ]
+        gamma_offdiag[, off_idx] = inds[e, ]
+        off_idx = off_idx + 1L
+      }
+      e = e + 1L
+    }
+  }
+
+  offdiag_names = character(n_edges)
+  idx = 1L
+  for(i in seq_len(p - 1L)) {
+    for(j in (i + 1L):p) {
+      offdiag_names[idx] = paste0("K_", i, "_", j)
+      idx = idx + 1L
+    }
+  }
+  diag_names = paste0("K_", seq_len(p), "_", seq_len(p))
+
+  list(
+    K_offdiag       = K_offdiag,
+    K_diag          = K_diag,
+    offdiag_names   = offdiag_names,
+    diag_names      = diag_names,
+    edge_indicators = gamma_offdiag
   )
 }
 

--- a/man/sample_ggm_prior.Rd
+++ b/man/sample_ggm_prior.Rd
@@ -15,7 +15,9 @@ sample_ggm_prior(
   seed = 1L,
   verbose = TRUE,
   edge_indicators = NULL,
-  delta = NULL
+  delta = NULL,
+  spec = c("conditional", "joint"),
+  edge_inclusion_prob = 0.5
 )
 }
 \arguments{
@@ -39,9 +41,12 @@ which implies \eqn{K_{ii}/2 \sim \textrm{Exp}(1)} and therefore
 \eqn{K_{ii} \sim \textrm{Exp}(1/2)} (mean \eqn{2}).}
 
 \item{step_size}{Positive numeric. Initial NUTS step size used to seed
-dual-averaging adaptation. Default \code{0.1}.}
+dual-averaging adaptation. Default \code{0.1}. Used only for
+\code{spec = "conditional"} (NUTS path); ignored for the
+\code{"joint"} MH path.}
 
-\item{max_depth}{Integer. Maximum NUTS tree depth. Default \code{10}.}
+\item{max_depth}{Integer. Maximum NUTS tree depth. Default \code{10}.
+Used only for \code{spec = "conditional"}.}
 
 \item{seed}{Integer. RNG seed for the chain. Default \code{1L}.}
 
@@ -49,7 +54,9 @@ dual-averaging adaptation. Default \code{0.1}.}
 
 \item{edge_indicators}{Optional integer \eqn{p \times p} matrix with
 \code{1} = edge included, \code{0} = excluded. Must be symmetric with
-\code{1}s on the diagonal. Default: full graph (all edges included).}
+\code{1}s on the diagonal. Default: full graph (all edges included).
+Used only for \code{spec = "conditional"} (the chain samples
+\eqn{K \mid \Gamma}); ignored for \code{spec = "joint"}.}
 
 \item{delta}{Non-negative numeric, or \code{NULL} for the dimension-
 adaptive default. Determinant-tilt exponent: multiplies the prior
@@ -61,6 +68,14 @@ dimension-adaptive rule \eqn{\delta(p) = c \log p} with
 determinant-tilted spike-and-slab priors (Marsman et al., in
 preparation). Pass \code{delta = 0} for the untilted prior (the
 companion-paper baseline) or a non-negative numeric to override.}
+
+\item{spec}{One of \code{"conditional"} (default, sample
+\eqn{K \mid \Gamma} at fixed \eqn{\Gamma}) or \code{"joint"} (sample
+\eqn{(K, \Gamma)} jointly from the un-normalised joint prior).}
+
+\item{edge_inclusion_prob}{Probability in \eqn{(0, 1)} for the
+Bernoulli edge prior used when \code{spec = "joint"}. Default
+\code{0.5}. Ignored when \code{spec = "conditional"}.}
 }
 \value{
 A list with components
@@ -68,8 +83,10 @@ A list with components
 \item{\code{K_offdiag}}{Numeric matrix of size
 \code{n_samples} x \code{p * (p - 1) / 2} containing the upper-triangle
 off-diagonal entries of \eqn{K} for each draw, in column-major order
-\eqn{(K_{12}, K_{13}, K_{23}, K_{14}, \ldots)}. Excluded edges are
-returned as \code{0}.}
+\eqn{(K_{12}, K_{13}, K_{23}, K_{14}, \ldots)}. Under
+\code{spec = "conditional"}, excluded edges are returned as
+\code{0}; under \code{spec = "joint"}, off-diagonals at excluded
+edges are sampled at \code{0} per the inclusion indicator.}
 \item{\code{K_diag}}{Numeric matrix of size
 \code{n_samples} x \code{p} containing the diagonal entries
 \eqn{K_{11}, \ldots, K_{pp}}.}
@@ -78,16 +95,35 @@ returned as \code{0}.}
 (e.g. \code{"K_1_2"}).}
 \item{\code{diag_names}}{Character vector of length \code{p} naming
 the columns of \code{K_diag}.}
-\item{\code{step_size}}{The (initial) NUTS step size used.}
-\item{\code{edge_indicators}}{The integer edge-indicator matrix used
-(full graph if not supplied).}
+\item{\code{edge_indicators}}{Under \code{spec = "conditional"}, the
+\code{p x p} integer matrix of fixed inclusion indicators used
+(full graph if not supplied). Under \code{spec = "joint"}, an
+\code{n_samples x p(p-1)/2} integer matrix of sampled
+\eqn{\Gamma_{ij}} indicators (column order matches
+\code{K_offdiag}).}
 }
 }
 \description{
-Draws from the prior of a Gaussian graphical model using the same
-constrained NUTS sampler that drives \code{\link{bgm}} for continuous
-data. The likelihood is omitted (\eqn{n = 0}, \eqn{S = 0}), so the chain
-targets the prior alone.
+Draws from the prior of a Gaussian graphical model. The likelihood is
+omitted (\eqn{n = 0}, \eqn{S = 0}), so the chain targets the prior alone.
+Two specifications are supported via the \code{spec} argument:
+\itemize{
+\item \code{"conditional"} (default): fix a graph \eqn{\Gamma} and
+sample \eqn{K \mid \Gamma} via the same constrained NUTS sampler
+that drives \code{\link{bgm}} for continuous data. The chain
+targets \eqn{p(K \mid \Gamma) \propto \mathrm{slab}(K) \cdot
+    \mathrm{diag}(K) \cdot |K|^{\delta} \cdot \mathbf{1}\{K \in
+    \mathcal{M}^{+}(\Gamma)\} / Z(\Gamma)}.
+\item \code{"joint"}: sample \eqn{(K, \Gamma)} jointly from the
+un-normalised joint prior \eqn{p(K, \Gamma) \propto
+    \mathrm{slab}(K) \cdot \mathrm{diag}(K) \cdot |K|^{\delta} \cdot
+    \mathbf{1}\{K \in \mathcal{M}^{+}(\Gamma)\} \cdot \pi(\Gamma)}.
+Uses the adaptive-Metropolis MH chain from \code{\link{bgm}} with
+edge selection on and the likelihood off, so the marginal on
+\eqn{\Gamma} is \eqn{\pi(\Gamma) \cdot Z(\Gamma)} (joint
+specification, not hierarchical). Useful for simulation-based
+calibration of \code{\link{bgm}}'s default sampler.
+}
 }
 \details{
 The priors are specified on the partial-association scale
@@ -99,8 +135,10 @@ a prior argument passed here means the same distribution it would mean
 there. Output samples are reported as entries of \eqn{K}; convert with
 \eqn{K_{yy} = -K/2} if you want them on the partial-association scale.
 
-When \code{edge_indicators} is supplied, off-diagonals at excluded
-positions are constrained to zero throughout the chain.
+When \code{spec = "conditional"} and \code{edge_indicators} is supplied,
+off-diagonals at excluded positions are constrained to zero throughout
+the chain. \code{edge_indicators} is ignored when \code{spec = "joint"}
+(the chain samples \eqn{\Gamma}).
 }
 \examples{
 \donttest{

--- a/tests/testthat/test-sbc-ggm.R
+++ b/tests/testthat/test-sbc-ggm.R
@@ -500,3 +500,120 @@ test_that("SBC: GGM NUTS produces uniform ranks under tilt (p=3, delta=1)", {
     info = sprintf("SBC global chi-squared (delta=1) p=%.4f", chisq_p)
   )
 })
+
+
+# ---- SBC test: Joint specification (edge selection on) ----------------------
+
+# Reconstruct a p x p symmetric K matrix from the (off-diag, diag) row pair
+# returned by sample_ggm_prior(spec = "joint"). Column order in off matches
+# the (i < j) upper-triangle visit order.
+reconstruct_K = function(off_row, diag_row, p) {
+  K = matrix(0, p, p)
+  idx = 1L
+  for(i in seq_len(p - 1)) {
+    for(j in (i + 1):p) {
+      K[i, j] = off_row[idx]
+      K[j, i] = off_row[idx]
+      idx = idx + 1L
+    }
+  }
+  diag(K) = diag_row
+  K
+}
+
+test_that("SBC: GGM joint-spec produces uniform ranks (p=5, edge selection)", {
+  skip_unless_slow_sbc()
+
+  # Joint-specification SBC: draw (K_true, Gamma_true) from the un-normalised
+  # joint prior via sample_ggm_prior(spec = "joint"), simulate Y | K_true, and
+  # check that bgm()'s default-MH posterior reproduces the prior in rank
+  # histograms. Generator and fit both use the auto-default tilt (delta =
+  # 0.5 * log(p)), and both target the joint specification, so the SBC ranks
+  # should be uniform.
+  #
+  # Test functions are the continuous K diagonals and log|K|. Off-diagonal
+  # K_ij entries are skipped here because the spike-and-slab point mass at
+  # zero induces tied ranks that break standard uniformity tests (the same
+  # rationale as the existing edge-selection SBC test, which only checks the
+  # diagonal).
+  p = 5
+  n = 100
+  R = 300
+  L = 999
+  thin = 10
+
+  set.seed(2030)
+
+  # Step 1: a single thinned joint-prior chain produces R quasi-independent
+  # (K_true, Gamma_true) draws. Auto-default delta on the prior generator.
+  joint = sample_ggm_prior(
+    p = p, n_samples = as.integer(R * thin), n_warmup = 2000L,
+    spec = "joint", delta = NULL, seed = 2030L, verbose = FALSE
+  )
+  thin_idx = seq(thin, R * thin, by = thin)
+  K_off_true  = joint$K_offdiag[thin_idx, , drop = FALSE]
+  K_diag_true = joint$K_diag[thin_idx, , drop = FALSE]
+
+  n_params = p + 1L                          # K_11, ..., K_pp, log|K|
+  ranks = matrix(NA_real_, nrow = R, ncol = n_params)
+
+  for(r in seq_len(R)) {
+    K_true = reconstruct_K(K_off_true[r, ], K_diag_true[r, ], p)
+    Sigma = solve(K_true)
+    X = MASS::mvrnorm(n, mu = rep(0, p), Sigma = Sigma)
+    dat = as.data.frame(X)
+    colnames(dat) = paste0("V", seq_len(p))
+
+    fit = bgm(dat,
+      variable_type = "continuous",
+      iter = L, warmup = 1000, chains = 1,
+      edge_selection = TRUE, update_method = "adaptive-metropolis",
+      delta = NULL,                          # auto-default, matches generator
+      display_progress = "none", seed = 2030L + r
+    )
+
+    main_samples = do.call(rbind, fit$raw_samples$main)
+    pw_samples   = do.call(rbind, fit$raw_samples$pairwise)
+
+    # K diagonal ranks
+    for(i in seq_len(p)) {
+      ranks[r, i] = sum(main_samples[, i] < K_true[i, i])
+    }
+
+    # log|K| rank: rebuild K_post per iteration, compute log|K|.
+    log_det_K_true = determinant(K_true, logarithm = TRUE)$modulus
+    log_det_K_post = vapply(seq_len(nrow(main_samples)), function(it) {
+      K_it = reconstruct_K(pw_samples[it, ], main_samples[it, ], p)
+      determinant(K_it, logarithm = TRUE)$modulus
+    }, numeric(1))
+    ranks[r, p + 1L] = sum(log_det_K_post < log_det_K_true)
+  }
+
+  # Per-parameter KS test, allowing 1 false positive across (p + 1)
+  # parameters at alpha = 0.01.
+  n_fail_ks = 0
+  for(j in seq_len(ncol(ranks))) {
+    u = ranks[, j] / (L + 1)
+    p_val = suppressWarnings(ks.test(u, "punif")$p.value)
+    if(p_val <= 0.01) n_fail_ks = n_fail_ks + 1
+  }
+  max_fail = max(1, ceiling(n_params * 0.01 * 2))
+  expect_true(n_fail_ks <= max_fail,
+    info = sprintf(
+      "SBC KS (joint): %d/%d parameters failed (limit %d)",
+      n_fail_ks, n_params, max_fail
+    )
+  )
+
+  # Global chi-squared on aggregated ranks.
+  all_ranks = as.vector(ranks)
+  bins = cut(all_ranks / (L + 1),
+    breaks = seq(0, 1, length.out = 21),
+    include.lowest = TRUE
+  )
+  counts = tabulate(bins, nbins = 20)
+  chisq_p = chisq.test(counts)$p.value
+  expect_true(chisq_p > 0.001,
+    info = sprintf("SBC global chi-squared (joint) p=%.4f", chisq_p)
+  )
+})


### PR DESCRIPTION
## Summary

Implements Stage 2 of [dev/plans/backlog/hierarchical-ggm-degord-rr.md](dev/plans/backlog/hierarchical-ggm-degord-rr.md): a joint-specification mode for `sample_ggm_prior()`, plus a calibration test that uses it.

`sample_ggm_prior()` gains a `spec` argument:

- **`spec = "conditional"`** (default, unchanged): sample $K \mid \Gamma$ at fixed $\Gamma$ via the existing NUTS path. Backward compatible.
- **`spec = "joint"`** (new): sample $(K, \Gamma)$ jointly from the un-normalised joint prior

  $$p(K, \Gamma) \propto \mathrm{slab}(K) \cdot \mathrm{diag}(K) \cdot |K|^{\delta} \cdot \mathbf{1}\{K \in \mathcal{M}^{+}(\Gamma)\} \cdot \pi(\Gamma).$$

  The chain marginal on $\Gamma$ is $\pi(\Gamma) \cdot Z(\Gamma)$ — the joint specification of the manuscript framing, not the hierarchical one. Useful for simulation-based calibration of `bgm()`'s default sampler.

## Implementation

The joint dispatch reuses the existing `sample_ggm()` C++ entry point with `n = 0`, `S = 0`, `edge_selection = TRUE`, `sampler_type = "adaptive-metropolis"`. **No C++ changes required** — the `n = 0` path was already wired in:

- [`initialize_precision_from_mle()`](src/models/ggm/ggm_model.cpp#L1115-L1117) short-circuits when `n_ == 0`, keeping the identity initialization.
- [`log_density_impl_edge` / `_diag`](src/models/ggm/ggm_model.cpp#L642-L656) have $(n_- \cdot \log|K| - \mathrm{tr}(K \cdot S)) / 2$ shape, both terms vanish at $(n, S) = (0, 0)$.

`sample_ggm_prior()` formats the output to match the `"conditional"` shape (K_offdiag, K_diag), plus a new $n_\textnormal{samples} \times p(p-1)/2$ integer matrix of sampled $\Gamma_{ij}$ in `edge_indicators` (column order matches `K_offdiag`).

## SBC test

New slow test in [test-sbc-ggm.R](tests/testthat/test-sbc-ggm.R) (gated behind `BGMS_RUN_SLOW_TESTS`):

```
SBC: GGM joint-spec produces uniform ranks (p=5, edge selection)
```

Generator and fit both target the joint specification under the auto-default tilt $\delta = 0.5 \log(p) \approx 0.80$ at $p = 5$. Test functions:
- $K_{11}, \ldots, K_{55}$ (5 continuous diagonals)
- $\log|K|$ (scalar summary of $K$)

Off-diagonal $K_{ij}$ ranks are skipped — the spike-and-slab point mass at zero induces tied ranks that break standard uniformity tests (same rationale as the existing edge-selection SBC test).

$R = 300$ reps; per-parameter KS at $\alpha = 0.01$ + global $\chi^2$ on aggregated ranks. Local wall: 11 s.

## Test plan

- [x] Joint-mode smoke: `sample_ggm_prior(p = 4, spec = "joint", delta = 1)` returns matching-dimension K and γ matrices; `γ = 0 ⇔ K_off = 0` holds across all draws.
- [x] Conditional path: unchanged, verified by smoke and the existing slow SBC tests.
- [x] New slow SBC test: 2/2 assertions pass in 11 s (R = 300, p = 5).
- [ ] CI green.

## Stacking

This PR is **stacked on #107** (Stage 1, auto-default `delta`). Base set to `feat/auto-tilt-default`; once #107 merges, GitHub will auto-retarget the base to `main` and show only the Stage 2 diff.

## Companion / next stage

Stage 3 (DEGORD + Russian Roulette for hierarchical GGM inference) is the next major piece. Stage 2's joint SBC test will be mirrored by a hierarchical-spec SBC test once DEGORD+RR lands. See the plan document for the full multi-stage sketch.