### PR TITLE
perf: fill-in-place compute_logZ_and_probs_* via per-chain scratch

### DIFF
--- a/src/bgmCompare/bgmCompare_logp_and_grad.cpp
+++ b/src/bgmCompare/bgmCompare_logp_and_grad.cpp
@@ -598,15 +598,22 @@ std::pair<double, arma::vec> logp_and_gradient(
       const arma::vec rest_score = residual_matrix.col(v);
       arma::vec bound = K * rest_score;
 
-      // Joint computation: get log_Z AND probs in one pass
-      LogZAndProbs result;
+      // Persistent per-thread scratch — survives across NUTS leapfrog calls.
+      // Each TBB chain worker has its own thread, so each chain has its own
+      // scratch (no contention; isolated state).
+      thread_local LogZAndProbs result;
+      thread_local LogZScratch  scratch;
       if (is_ordinal_variable(v)) {
         arma::vec main_param = main_group.row(v).cols(0, K - 1).t();
-        result = compute_logZ_and_probs_ordinal(main_param, rest_score, bound, K);
+        compute_logZ_and_probs_ordinal_into(
+          main_param, rest_score, bound, K, result, scratch
+        );
       } else {
         const double lin_effect = main_group(v, 0);
         const double quad_effect = main_group(v, 1);
-        result = compute_logZ_and_probs_blume_capel(rest_score, lin_effect, quad_effect, ref, K, bound);
+        compute_logZ_and_probs_blume_capel_into(
+          rest_score, lin_effect, quad_effect, ref, K, bound, result, scratch
+        );
       }
 
       // log_pp contribution: subtract log normalizers

--- a/src/models/mixed/mixed_mrf_gradient.cpp
+++ b/src/models/mixed/mixed_mrf_gradient.cpp
@@ -286,21 +286,22 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
             arma::vec bound = main_param(C_s - 1) + static_cast<double>(C_s) * rest;
             bound = arma::max(bound, arma::zeros<arma::vec>(bound.n_elem));
 
-            LogZAndProbs result = compute_logZ_and_probs_ordinal(
-                main_param, rest, bound, C_s
+            // Fill-in-place using persistent per-chain scratch.
+            compute_logZ_and_probs_ordinal_into(
+                main_param, rest, bound, C_s, logz_out_, logz_scratch_
             );
 
             // log pseudo-posterior contribution
-            logp -= arma::accu(result.log_Z);
+            logp -= arma::accu(logz_out_.log_Z);
 
             // Main-effect gradient: ∂/∂main_effects_discrete_{s,c} = count_c - sum_i prob(c)
             for(int c = 0; c < C_s; ++c) {
-                grad(main_effects_discrete_offset + c) -= arma::accu(result.probs.col(c + 1));
+                grad(main_effects_discrete_offset + c) -= arma::accu(logz_out_.probs.col(c + 1));
             }
 
             // Expected value E_s[c+1|rest] per observation
             arma::vec weights = arma::regspace<arma::vec>(1, C_s);
-            arma::vec E = result.probs.cols(1, C_s) * weights;
+            arma::vec E = logz_out_.probs.cols(1, C_s) * weights;
 
             // Pairwise discrete gradient: sum_i x_{i,t} * (x_{i,s}+1 - E_s)
             // (uses pre-transposed discrete observations for BLAS efficiency)
@@ -323,7 +324,7 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
             // Cross-contribution (a=t): from rest_s → pairwise_effects_cross_t for each t≠s
 
             arma::vec weights_sq = arma::square(weights);
-            arma::vec E_sq = result.probs.cols(1, C_s) * weights_sq;
+            arma::vec E_sq = logz_out_.probs.cols(1, C_s) * weights_sq;
 
             arma::vec diff_pw = discrete_observations_dbl_t_ *
                 (discrete_observations_dbl_.col(s) - E);
@@ -385,21 +386,22 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
             effective_quad += temp_marginal(s, s);
 
             arma::vec bc_bound;
-            LogZAndProbs result = compute_logZ_and_probs_blume_capel(
-                rest, lin_eff, effective_quad, ref, C_s, bc_bound
+            compute_logZ_and_probs_blume_capel_into(
+                rest, lin_eff, effective_quad, ref, C_s, bc_bound,
+                logz_out_, logz_scratch_
             );
 
-            logp -= arma::accu(result.log_Z);
+            logp -= arma::accu(logz_out_.log_Z);
 
             arma::vec score = arma::regspace<arma::vec>(0, C_s) - static_cast<double>(ref);
             arma::vec sq_score = arma::square(score);
 
             // Main-effect gradient
-            grad(main_effects_discrete_offset)     -= arma::accu(result.probs * score);
-            grad(main_effects_discrete_offset + 1) -= arma::accu(result.probs * sq_score);
+            grad(main_effects_discrete_offset)     -= arma::accu(logz_out_.probs * score);
+            grad(main_effects_discrete_offset + 1) -= arma::accu(logz_out_.probs * sq_score);
 
             // Expected score per person
-            arma::vec E = result.probs * score;
+            arma::vec E = logz_out_.probs * score;
 
             // Pairwise discrete gradient
             // Factor 2: chain rule d/dK = 2 × d/dσ
@@ -411,7 +413,7 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
             }
 
             // Pairwise_cross gradient from marginal OMRF (same structure as ordinal)
-            arma::vec E_sq = result.probs * sq_score;
+            arma::vec E_sq = logz_out_.probs * sq_score;
 
             arma::vec diff_pw = discrete_observations_dbl_t_ *
                 (discrete_observations_dbl_.col(s) - E);
@@ -900,19 +902,19 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
             arma::vec bound = main_param(C_s - 1) + static_cast<double>(C_s) * rest;
             bound = arma::max(bound, arma::zeros<arma::vec>(bound.n_elem));
 
-            LogZAndProbs result = compute_logZ_and_probs_ordinal(
-                main_param, rest, bound, C_s
+            compute_logZ_and_probs_ordinal_into(
+                main_param, rest, bound, C_s, logz_out_, logz_scratch_
             );
 
-            logp -= arma::accu(result.log_Z);
+            logp -= arma::accu(logz_out_.log_Z);
 
             // Main-effect gradient
             for(int c = 0; c < C_s; ++c) {
-                grad(main_effects_discrete_offset + c) -= arma::accu(result.probs.col(c + 1));
+                grad(main_effects_discrete_offset + c) -= arma::accu(logz_out_.probs.col(c + 1));
             }
 
             arma::vec weights = arma::regspace<arma::vec>(1, C_s);
-            arma::vec E = result.probs.cols(1, C_s) * weights;
+            arma::vec E = logz_out_.probs.cols(1, C_s) * weights;
 
             // Pairwise discrete gradient (ALL edges, no gating)
             arma::vec pw_grad = discrete_observations_dbl_t_ * E;
@@ -923,7 +925,7 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
             }
 
             arma::vec weights_sq = arma::square(weights);
-            arma::vec E_sq = result.probs.cols(1, C_s) * weights_sq;
+            arma::vec E_sq = logz_out_.probs.cols(1, C_s) * weights_sq;
 
             arma::vec diff_pw = discrete_observations_dbl_t_ *
                 (discrete_observations_dbl_.col(s) - E);
@@ -971,19 +973,20 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
             effective_quad += temp_marginal(s, s);
 
             arma::vec bc_bound;
-            LogZAndProbs result = compute_logZ_and_probs_blume_capel(
-                rest, lin_eff, effective_quad, ref, C_s, bc_bound
+            compute_logZ_and_probs_blume_capel_into(
+                rest, lin_eff, effective_quad, ref, C_s, bc_bound,
+                logz_out_, logz_scratch_
             );
 
-            logp -= arma::accu(result.log_Z);
+            logp -= arma::accu(logz_out_.log_Z);
 
             arma::vec score = arma::regspace<arma::vec>(0, C_s) - static_cast<double>(ref);
             arma::vec sq_score = arma::square(score);
 
-            grad(main_effects_discrete_offset)     -= arma::accu(result.probs * score);
-            grad(main_effects_discrete_offset + 1) -= arma::accu(result.probs * sq_score);
+            grad(main_effects_discrete_offset)     -= arma::accu(logz_out_.probs * score);
+            grad(main_effects_discrete_offset + 1) -= arma::accu(logz_out_.probs * sq_score);
 
-            arma::vec E = result.probs * score;
+            arma::vec E = logz_out_.probs * score;
 
             arma::vec pw_grad = discrete_observations_dbl_t_ * E;
             for(size_t t = 0; t < p_; ++t) {
@@ -992,7 +995,7 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
                 grad(loc) -= 2.0 * pw_grad(t);
             }
 
-            arma::vec E_sq = result.probs * sq_score;
+            arma::vec E_sq = logz_out_.probs * sq_score;
 
             arma::vec diff_pw = discrete_observations_dbl_t_ *
                 (discrete_observations_dbl_.col(s) - E);

--- a/src/models/mixed/mixed_mrf_model.h
+++ b/src/models/mixed/mixed_mrf_model.h
@@ -11,6 +11,7 @@
 #include "rng/rng_utils.h"
 #include "priors/parameter_prior.h"
 #include "mcmc/samplers/metropolis_adaptation.h"
+#include "utils/variable_helpers.h"
 
 /**
  * MixedMRFModel - Mixed Markov Random Field Model
@@ -442,6 +443,11 @@ private:
     int main_effects_continuous_grad_offset_ = 0;           ///< Offset of main_effects_continuous block in gradient vector
     int chol_grad_offset_ = 0;          ///< Offset of Cholesky block in gradient vector
     bool gradient_cache_valid_ = false; ///< Whether gradient cache is current
+
+    // Per-chain scratch for compute_logZ_and_probs_*_into. Reused across
+    // every call to logp_and_gradient and across every variable inside it.
+    mutable LogZAndProbs logz_out_;
+    mutable LogZScratch  logz_scratch_;
 
     // =========================================================================
     // RATTLE constraint structure

--- a/src/models/omrf/omrf_model.cpp
+++ b/src/models/omrf/omrf_model.cpp
@@ -599,7 +599,9 @@ double OMRFModel::log_pseudoposterior_with_state(
         }
     }
 
-    // Log-normalizer using joint logZ+probs helpers
+    // Log-normalizer using joint logZ+probs helpers — fill-in-place into
+    // the model's persistent scratch (shared with logp_and_gradient since the
+    // two are not called concurrently within a single chain).
     for (size_t v = 0; v < p_; ++v) {
         int num_cats = num_categories_(v);
         arma::vec residual_score = residual_mat.col(v);
@@ -607,15 +609,17 @@ double OMRFModel::log_pseudoposterior_with_state(
 
         if (is_ordinal_variable_(v)) {
             arma::vec main_param = main_eff.row(v).cols(0, num_cats - 1).t();
-            LogZAndProbs result = compute_logZ_and_probs_ordinal(
-                main_param, residual_score, bound, num_cats);
-            log_post -= arma::accu(result.log_Z);
+            compute_logZ_and_probs_ordinal_into(
+                main_param, residual_score, bound, num_cats,
+                logz_out_, logz_scratch_);
+            log_post -= arma::accu(logz_out_.log_Z);
         } else {
             int ref = baseline_category_(v);
             double lin = main_eff(v, 0), quad = main_eff(v, 1);
-            LogZAndProbs result = compute_logZ_and_probs_blume_capel(
-                residual_score, lin, quad, ref, num_cats, bound);
-            log_post -= arma::accu(result.log_Z);
+            compute_logZ_and_probs_blume_capel_into(
+                residual_score, lin, quad, ref, num_cats, bound,
+                logz_out_, logz_scratch_);
+            log_post -= arma::accu(logz_out_.log_Z);
         }
     }
 
@@ -1033,22 +1037,24 @@ std::pair<double, arma::vec> OMRFModel::logp_and_gradient(const arma::vec& param
         if (is_ordinal_variable_(variable)) {
             arma::vec main_param = temp_main.row(variable).cols(0, num_cats - 1).t();
 
-            // Joint computation: get both log_Z and probs in one pass
-            LogZAndProbs result = compute_logZ_and_probs_ordinal(
-                main_param, residual_score, bound, num_cats
+            // Fill-in-place: persistent per-chain scratch reused across variables
+            // and iterations, eliminating per-call heap allocations.
+            compute_logZ_and_probs_ordinal_into(
+                main_param, residual_score, bound, num_cats,
+                logz_out_, logz_scratch_
             );
 
             // Use log_Z for log-pseudoposterior
-            log_pp -= arma::accu(result.log_Z);
+            log_pp -= arma::accu(logz_out_.log_Z);
 
             // Use probs for gradient
             for (int cat = 0; cat < num_cats; cat++) {
-                gradient(offset + cat) -= arma::accu(result.probs.col(cat + 1));
+                gradient(offset + cat) -= arma::accu(logz_out_.probs.col(cat + 1));
             }
 
             // Pairwise gradient contributions (vectorized using BLAS)
             arma::vec weights = arma::regspace<arma::vec>(1, num_cats);
-            arma::vec E = result.probs.cols(1, num_cats) * weights;
+            arma::vec E = logz_out_.probs.cols(1, num_cats) * weights;
             arma::vec pw_grad = observations_double_t_ * E;
             for (int j = 0; j < num_variables; j++) {
                 if (edge_indicators_(variable, j) == 0 || variable == j) continue;
@@ -1061,23 +1067,24 @@ std::pair<double, arma::vec> OMRFModel::logp_and_gradient(const arma::vec& param
             const double lin_eff = temp_main(variable, 0);
             const double quad_eff = temp_main(variable, 1);
 
-            // Joint computation: get both log_Z and probs in one pass
-            LogZAndProbs result = compute_logZ_and_probs_blume_capel(
-                residual_score, lin_eff, quad_eff, ref, num_cats, bound
+            // Fill-in-place Blume-Capel
+            compute_logZ_and_probs_blume_capel_into(
+                residual_score, lin_eff, quad_eff, ref, num_cats, bound,
+                logz_out_, logz_scratch_
             );
 
             // Use log_Z for log-pseudoposterior
-            log_pp -= arma::accu(result.log_Z);
+            log_pp -= arma::accu(logz_out_.log_Z);
 
             // Use probs for gradient
             arma::vec score = arma::regspace<arma::vec>(0, num_cats) - static_cast<double>(ref);
             arma::vec sq_score = arma::square(score);
 
-            gradient(offset)     -= arma::accu(result.probs * score);
-            gradient(offset + 1) -= arma::accu(result.probs * sq_score);
+            gradient(offset)     -= arma::accu(logz_out_.probs * score);
+            gradient(offset + 1) -= arma::accu(logz_out_.probs * sq_score);
 
             // Pairwise gradient contributions (vectorized using BLAS)
-            arma::vec E = result.probs * score;
+            arma::vec E = logz_out_.probs * score;
             arma::vec pw_grad = observations_double_t_ * E;
             for (int j = 0; j < num_variables; j++) {
                 if (edge_indicators_(variable, j) == 0 || variable == j) continue;

--- a/src/models/omrf/omrf_model.h
+++ b/src/models/omrf/omrf_model.h
@@ -7,6 +7,7 @@
 #include "rng/rng_utils.h"
 #include "mcmc/execution/step_result.h"
 #include "utils/common_helpers.h"
+#include "utils/variable_helpers.h"
 #include "priors/parameter_prior.h"
 
 /**
@@ -345,6 +346,13 @@ private:
     arma::vec grad_obs_cache_;          ///< Cached observed-data gradient
     arma::imat index_matrix_cache_;     ///< Cached parameter index map
     bool gradient_cache_valid_;         ///< Whether the gradient cache is current
+
+    // Per-chain scratch for compute_logZ_and_probs_*_into. Reused across
+    // every call to logp_and_gradient and across every variable inside it.
+    // After the first few calls the buffers stabilise at max size and no
+    // further heap allocations happen on the hot path.
+    mutable LogZAndProbs logz_out_;
+    mutable LogZScratch  logz_scratch_;
 
     // Interaction indexing (for edge updates)
     arma::imat interaction_index_;      ///< Maps edge pair to index

--- a/src/utils/variable_helpers.cpp
+++ b/src/utils/variable_helpers.cpp
@@ -330,74 +330,76 @@ arma::mat compute_probs_blume_capel(
 
 
 // =============================================================================
-// compute_logZ_and_probs_ordinal
+// compute_logZ_and_probs_ordinal_into  (fill-in-place; no per-call allocs)
 // =============================================================================
-LogZAndProbs compute_logZ_and_probs_ordinal(
+// Mirrors the FP sequence of the original return-by-value implementation
+// exactly so output is bit-identical. All temporaries are routed through
+// the caller-owned `scratch` and `out` buffers; once these have grown to
+// the maximum sizes seen, no further heap allocations occur.
+void compute_logZ_and_probs_ordinal_into(
     const arma::vec& main_param,
     const arma::vec& residual_score,
     const arma::vec& bound,
-    int num_cats
+    int num_cats,
+    LogZAndProbs& out,
+    LogZScratch& scratch
 ) {
   constexpr double EXP_BOUND = 709.0;
   const arma::uword N = bound.n_elem;
 
-  LogZAndProbs result;
-  result.probs.set_size(N, num_cats + 1);
-  result.log_Z.set_size(N);
+  out.probs.set_size(N, num_cats + 1);
+  out.log_Z.set_size(N);
 
   if (num_cats == 1) {
-    arma::vec b = arma::clamp(bound, 0.0, arma::datum::inf);
-    arma::vec ex = main_param(0) + residual_score - b;
-    arma::vec t = ARMA_MY_EXP(ex);
-    arma::vec eB = ARMA_MY_EXP(-b);
-    arma::vec den = eB + t;
-    result.probs.col(1) = t / den;
-    result.probs.col(0) = 1.0 - result.probs.col(1);
-    result.log_Z = b + ARMA_MY_LOG(den);
-    return result;
+    scratch.b_clamp = arma::clamp(bound, 0.0, arma::datum::inf);
+    scratch.ex      = main_param(0) + residual_score - scratch.b_clamp;
+    scratch.term    = ARMA_MY_EXP(scratch.ex);     // "t" in the original
+    scratch.eB      = ARMA_MY_EXP(-scratch.b_clamp);
+    scratch.den     = scratch.eB + scratch.term;
+    out.probs.col(1) = scratch.term / scratch.den;
+    out.probs.col(0) = 1.0 - out.probs.col(1);
+    out.log_Z        = scratch.b_clamp + ARMA_MY_LOG(scratch.den);
+    return;
   }
 
-  const arma::vec eM = ARMA_MY_EXP(main_param);
+  scratch.eM = ARMA_MY_EXP(main_param);
 
-  // The fast block computes eM[c] * pow % eB where the intermediate
-  // eM[c] * pow = exp(main_param(c) + (c+1)*rest) can overflow even when
-  // the final product exp(main_param(c) + (c+1)*rest - bound) is finite.
-  // Reduce the fast-block threshold by max(|main_param|) to prevent this.
   const double max_abs_main = arma::max(arma::abs(main_param));
-  const double FAST_LIM = std::max(0.0, EXP_BOUND - max_abs_main);
+  const double FAST_LIM     = std::max(0.0, EXP_BOUND - max_abs_main);
 
   auto do_fast_block = [&](arma::uword i0, arma::uword i1) {
-    auto P = result.probs.rows(i0, i1).cols(1, num_cats);
-    arma::vec r = residual_score.rows(i0, i1);
-    arma::vec b = bound.rows(i0, i1);
-    arma::vec eR = ARMA_MY_EXP(r);
-    arma::vec eB = ARMA_MY_EXP(-b);
-    arma::vec pow = eR;
-    arma::vec den = eB;
-    for (int c = 0; c < num_cats; c++) {
-      arma::vec term = eM[c] * pow % eB;
-      P.col(c) = term;
-      den += term;
-      pow %= eR;
+    auto P  = out.probs.rows(i0, i1).cols(1, num_cats);
+    auto r  = residual_score.rows(i0, i1);
+    auto bb = bound.rows(i0, i1);
+
+    scratch.eR      = ARMA_MY_EXP(r);
+    scratch.eB      = ARMA_MY_EXP(-bb);
+    scratch.pow_buf = scratch.eR;
+    scratch.den     = scratch.eB;
+    for (int c = 0; c < num_cats; ++c) {
+      scratch.term  = scratch.eM[c] * scratch.pow_buf % scratch.eB;
+      P.col(c)      = scratch.term;
+      scratch.den  += scratch.term;
+      scratch.pow_buf %= scratch.eR;
     }
-    P.each_col() /= den;
-    result.log_Z.rows(i0, i1) = b + ARMA_MY_LOG(den);
+    P.each_col() /= scratch.den;
+    out.log_Z.rows(i0, i1) = bb + ARMA_MY_LOG(scratch.den);
   };
 
   auto do_safe_block = [&](arma::uword i0, arma::uword i1) {
-    auto P = result.probs.rows(i0, i1).cols(1, num_cats);
-    arma::vec r = residual_score.rows(i0, i1);
-    arma::vec b = arma::clamp(bound.rows(i0, i1), 0.0, arma::datum::inf);
-    arma::vec eB = ARMA_MY_EXP(-b);
-    arma::vec den = eB;
-    for (int c = 0; c < num_cats; c++) {
-      arma::vec ex = main_param(c) + (c + 1) * r - b;
-      arma::vec t = ARMA_MY_EXP(ex);
-      P.col(c) = t;
-      den += t;
+    auto P  = out.probs.rows(i0, i1).cols(1, num_cats);
+    auto r  = residual_score.rows(i0, i1);
+    scratch.b_clamp = arma::clamp(bound.rows(i0, i1), 0.0, arma::datum::inf);
+    scratch.eB      = ARMA_MY_EXP(-scratch.b_clamp);
+    scratch.den     = scratch.eB;
+    for (int c = 0; c < num_cats; ++c) {
+      scratch.ex   = main_param(c) + (c + 1) * r - scratch.b_clamp;
+      scratch.term = ARMA_MY_EXP(scratch.ex);
+      P.col(c)     = scratch.term;
+      scratch.den += scratch.term;
     }
-    P.each_col() /= den;
-    result.log_Z.rows(i0, i1) = b + ARMA_MY_LOG(den);
+    P.each_col() /= scratch.den;
+    out.log_Z.rows(i0, i1) = scratch.b_clamp + ARMA_MY_LOG(scratch.den);
   };
 
   const double* bp = bound.memptr();
@@ -408,20 +410,146 @@ LogZAndProbs compute_logZ_and_probs_ordinal(
     while (j < N) {
       const bool fast_j = !(bp[j] < -FAST_LIM || bp[j] > FAST_LIM);
       if (fast_j != fast) break;
-      j++;
+      ++j;
     }
     if (fast) do_fast_block(i, j - 1);
-    else do_safe_block(i, j - 1);
+    else      do_safe_block(i, j - 1);
     i = j;
   }
 
-  result.probs.col(0) = 1.0 - arma::sum(result.probs.cols(1, num_cats), 1);
-  return result;
+  out.probs.col(0) = 1.0 - arma::sum(out.probs.cols(1, num_cats), 1);
 }
 
 
 // =============================================================================
-// compute_logZ_and_probs_blume_capel
+// compute_logZ_and_probs_ordinal  (back-compat wrapper)
+// =============================================================================
+LogZAndProbs compute_logZ_and_probs_ordinal(
+    const arma::vec& main_param,
+    const arma::vec& residual_score,
+    const arma::vec& bound,
+    int num_cats
+) {
+  LogZAndProbs out;
+  LogZScratch scratch;
+  compute_logZ_and_probs_ordinal_into(
+    main_param, residual_score, bound, num_cats, out, scratch
+  );
+  return out;
+}
+
+
+// =============================================================================
+// compute_logZ_and_probs_blume_capel_into  (fill-in-place; no per-call allocs)
+// =============================================================================
+// Mirrors the FP sequence of the original return-by-value implementation
+// exactly so output is bit-identical. All temporaries are routed through
+// the caller-owned `scratch` and `out` buffers; once these have grown to
+// the maximum sizes seen, no further heap allocations occur.
+void compute_logZ_and_probs_blume_capel_into(
+    const arma::vec& residual,
+    const double lin_eff,
+    const double quad_eff,
+    const int ref,
+    const int num_cats,
+    arma::vec& b,
+    LogZAndProbs& out,
+    LogZScratch& scratch
+) {
+  constexpr double EXP_BOUND = 709.0;
+  const arma::uword N = residual.n_elem;
+
+  out.probs.set_size(N, num_cats + 1);
+  out.log_Z.set_size(N);
+
+  // ---- 1. Per-category fixed quantities (length num_cats+1) ----
+  // Use arma vector expressions to match the original FP sequence
+  // (compilers emit differently fused FMA for arma vs scalar loops).
+  scratch.cat_vec.set_size(num_cats + 1);
+  for (int c = 0; c <= num_cats; ++c)
+    scratch.cat_vec[c] = static_cast<double>(c);
+  scratch.centered  = scratch.cat_vec - double(ref);
+  scratch.theta     = lin_eff * scratch.centered + quad_eff * arma::square(scratch.centered);
+  scratch.exp_theta = ARMA_MY_EXP(scratch.theta);
+
+  // ---- 2. b = max_c (theta[c] + centered[c] * residual) ----
+  b.set_size(N);
+  b = scratch.theta[0] + double(scratch.centered[0]) * residual;
+  for (int c = 1; c <= num_cats; ++c) {
+    b = arma::max(b, scratch.theta[c] + double(scratch.centered[c]) * residual);
+  }
+
+  // ---- 3. pow-chain bounds ----
+  scratch.pow_bound_low  = double(-ref) * residual - b;
+  scratch.pow_bound_high = double(num_cats - ref) * residual - b;
+  scratch.pow_bound      = arma::max(arma::abs(scratch.pow_bound_low),
+                                     arma::abs(scratch.pow_bound_high));
+
+  // ---- 4. block scan with FAST/SAFE selection ----
+  const double max_abs_theta = arma::max(arma::abs(scratch.theta));
+  const double THETA_LIM = std::max(0.0, EXP_BOUND - max_abs_theta);
+
+  auto do_fast_block = [&](arma::uword i0, arma::uword i1) {
+    auto P  = out.probs.rows(i0, i1);
+    auto r  = residual.rows(i0, i1);
+    auto bb = b.rows(i0, i1);
+
+    // eR, pow_buf, den into pre-allocated scratch.
+    scratch.eR      = ARMA_MY_EXP(r);
+    scratch.pow_buf = ARMA_MY_EXP(double(-ref) * r - bb);
+    scratch.den     = scratch.exp_theta[0] * scratch.pow_buf;
+    P.col(0)        = scratch.den;     // first column = first contribution to denom
+
+    for (int c = 1; c <= num_cats; ++c) {
+      scratch.pow_buf %= scratch.eR;
+      scratch.term     = scratch.exp_theta[c] * scratch.pow_buf;
+      P.col(c)         = scratch.term;
+      scratch.den     += scratch.term;
+    }
+
+    P.each_col() /= scratch.den;
+    out.log_Z.rows(i0, i1) = bb + ARMA_MY_LOG(scratch.den);
+  };
+
+  auto do_safe_block = [&](arma::uword i0, arma::uword i1) {
+    auto P  = out.probs.rows(i0, i1);
+    auto r  = residual.rows(i0, i1);
+    auto bb = b.rows(i0, i1);
+    const arma::uword B = bb.n_elem;
+
+    scratch.den.set_size(B);
+    scratch.den.zeros();
+
+    for (int c = 0; c <= num_cats; ++c) {
+      scratch.ex   = scratch.theta[c] + double(scratch.centered[c]) * r - bb;
+      scratch.term = ARMA_MY_EXP(scratch.ex);
+      P.col(c)     = scratch.term;
+      scratch.den += scratch.term;
+    }
+    P.each_col() /= scratch.den;
+    out.log_Z.rows(i0, i1) = bb + ARMA_MY_LOG(scratch.den);
+  };
+
+  const double* bp = b.memptr();
+  const double* pp = scratch.pow_bound.memptr();
+  arma::uword i = 0;
+  while (i < N) {
+    const bool fast_i = (std::abs(bp[i]) <= EXP_BOUND) && (std::abs(pp[i]) <= THETA_LIM);
+    arma::uword j = i + 1;
+    while (j < N) {
+      const bool fast_j = (std::abs(bp[j]) <= EXP_BOUND) && (std::abs(pp[j]) <= THETA_LIM);
+      if (fast_j != fast_i) break;
+      ++j;
+    }
+    if (fast_i) do_fast_block(i, j - 1);
+    else        do_safe_block(i, j - 1);
+    i = j;
+  }
+}
+
+
+// =============================================================================
+// compute_logZ_and_probs_blume_capel  (back-compat wrapper)
 // =============================================================================
 LogZAndProbs compute_logZ_and_probs_blume_capel(
     const arma::vec& residual,
@@ -431,90 +559,10 @@ LogZAndProbs compute_logZ_and_probs_blume_capel(
     const int num_cats,
     arma::vec& b
 ) {
-  constexpr double EXP_BOUND = 709.0;
-  const arma::uword N = residual.n_elem;
-
-  LogZAndProbs result;
-  result.probs.set_size(N, num_cats + 1);
-  result.log_Z.set_size(N);
-
-  arma::vec cat = arma::regspace<arma::vec>(0, num_cats);
-  arma::vec centered = cat - double(ref);
-  arma::vec theta = lin_eff * centered + quad_eff * arma::square(centered);
-  arma::vec exp_theta = ARMA_MY_EXP(theta);
-
-  b.set_size(N);
-  b = theta[0] + double(centered[0]) * residual;
-  for (int c = 1; c <= num_cats; ++c) {
-    b = arma::max(b, theta[c] + double(centered[c]) * residual);
-  }
-
-  arma::vec pow_bound_low = double(-ref) * residual - b;
-  arma::vec pow_bound_high = double(num_cats - ref) * residual - b;
-  arma::vec pow_bound = arma::max(arma::abs(pow_bound_low), arma::abs(pow_bound_high));
-
-  auto do_fast_block = [&](arma::uword i0, arma::uword i1) {
-    auto P = result.probs.rows(i0, i1);
-    arma::vec r = residual.rows(i0, i1);
-    arma::vec bb = b.rows(i0, i1);
-    const arma::uword B = bb.n_elem;
-
-    arma::vec eR = ARMA_MY_EXP(r);
-    arma::vec pow = ARMA_MY_EXP(double(-ref) * r - bb);
-    arma::vec denom(B, arma::fill::zeros);
-
-    arma::vec col0 = exp_theta[0] * pow;
-    P.col(0) = col0;
-    denom += col0;
-
-    for (int c = 1; c <= num_cats; ++c) {
-      pow %= eR;
-      arma::vec col = exp_theta[c] * pow;
-      P.col(c) = col;
-      denom += col;
-    }
-
-    P.each_col() /= denom;
-    result.log_Z.rows(i0, i1) = bb + ARMA_MY_LOG(denom);
-  };
-
-  auto do_safe_block = [&](arma::uword i0, arma::uword i1) {
-    auto P = result.probs.rows(i0, i1);
-    arma::vec r = residual.rows(i0, i1);
-    arma::vec bb = b.rows(i0, i1);
-    const arma::uword B = bb.n_elem;
-    arma::vec denom(B, arma::fill::zeros);
-
-    for (int c = 0; c <= num_cats; ++c) {
-      arma::vec ex = theta[c] + double(centered[c]) * r - bb;
-      arma::vec col = ARMA_MY_EXP(ex);
-      P.col(c) = col;
-      denom += col;
-    }
-    P.each_col() /= denom;
-    result.log_Z.rows(i0, i1) = bb + ARMA_MY_LOG(denom);
-  };
-
-  // Same intermediate overflow guard as the ordinal function:
-  // exp_theta[c] * pow can overflow before the implicit cancellation with b.
-  const double max_abs_theta = arma::max(arma::abs(theta));
-  const double THETA_LIM = std::max(0.0, EXP_BOUND - max_abs_theta);
-
-  const double* bp = b.memptr();
-  const double* pp = pow_bound.memptr();
-  arma::uword i = 0;
-  while (i < N) {
-    const bool fast_i = (std::abs(bp[i]) <= EXP_BOUND) && (std::abs(pp[i]) <= THETA_LIM);
-    arma::uword j = i + 1;
-    while (j < N) {
-      const bool fast_j = (std::abs(bp[j]) <= EXP_BOUND) && (std::abs(pp[j]) <= THETA_LIM);
-      if (fast_j != fast_i) break;
-      j++;
-    }
-    if (fast_i) do_fast_block(i, j - 1);
-    else do_safe_block(i, j - 1);
-    i = j;
-  }
-
-  return result;
+  LogZAndProbs out;
+  LogZScratch scratch;
+  compute_logZ_and_probs_blume_capel_into(
+    residual, lin_eff, quad_eff, ref, num_cats, b, out, scratch
+  );
+  return out;
 }

--- a/src/utils/variable_helpers.h
+++ b/src/utils/variable_helpers.h
@@ -20,6 +20,26 @@ struct LogZAndProbs {
 
 
 /**
+ * Reusable scratch buffers for compute_logZ_and_probs_*_into.
+ *
+ * Owned by the caller (typically as a member of a model class, one per
+ * MCMC chain). All buffers are resized via set_size() on each call,
+ * which is a no-op once they've grown to the maximum needed size, so
+ * after a few iterations no further heap allocations occur.
+ */
+struct LogZScratch {
+  // Working buffers used by both ordinal and Blume-Capel paths.
+  arma::vec eR, eB, pow_buf, den, term;
+  arma::vec eM;          // ordinal: exp(main_param)
+  arma::vec b_clamp;     // ordinal safe block: clamped bound
+  arma::vec ex;          // ordinal/BC safe block: per-category exponent
+  // Blume-Capel only
+  arma::vec cat_vec, centered, theta, exp_theta;
+  arma::vec pow_bound_low, pow_bound_high, pow_bound;
+};
+
+
+/**
  * Compute a numerically stable sum of the form:
  *
  *   denom = exp(-bound) + sum_{cat=0}^{K-1} exp(main_effect_param(cat)
@@ -132,6 +152,21 @@ LogZAndProbs compute_logZ_and_probs_ordinal(
 );
 
 /**
+ * Fill-in-place variant of compute_logZ_and_probs_ordinal.
+ *
+ * Writes into caller-provided `out` and reuses caller-provided `scratch`,
+ * eliminating per-call heap allocations after the first warm-up call.
+ */
+void compute_logZ_and_probs_ordinal_into(
+    const arma::vec& main_param,
+    const arma::vec& residual_score,
+    const arma::vec& bound,
+    int num_cats,
+    LogZAndProbs& out,
+    LogZScratch& scratch
+);
+
+/**
  * Joint computation of log-normalizer and probabilities for Blume-Capel variables.
  *
  * Avoids redundant computation by computing both in a single pass.
@@ -143,6 +178,22 @@ LogZAndProbs compute_logZ_and_probs_blume_capel(
     const int ref,
     const int num_cats,
     arma::vec& b
+);
+
+/**
+ * Fill-in-place variant of compute_logZ_and_probs_blume_capel.
+ *
+ * Writes into caller-provided `out` and reuses caller-provided `scratch`.
+ */
+void compute_logZ_and_probs_blume_capel_into(
+    const arma::vec& residual,
+    const double lin_eff,
+    const double quad_eff,
+    const int ref,
+    const int num_cats,
+    arma::vec& b,
+    LogZAndProbs& out,
+    LogZScratch& scratch
 );
 
 #endif // BGMS_VARIABLE_HELPERS_H


### PR DESCRIPTION
## Summary

Cherry-pick of [old-branch `bb5cda2`](https://github.com/Bayesian-Graphical-Modelling-Lab/bgms/blob/refactor/scratch-buffer-logz) onto current `main`. Refactors the two ordinal log-normalizer helpers to fill caller-owned scratch buffers in place, eliminating ~10–20 `arma` allocations per call:

- `compute_logZ_and_probs_ordinal_into(...)`
- `compute_logZ_and_probs_blume_capel_into(...)`

The original return-by-value helpers remain as thin wrappers around the `_into` variants for backward compatibility. All hot-path callers are wired to the new variants:

- `OMRFModel::logp_and_gradient` and `::log_pseudoposterior_with_state` — per-chain `mutable LogZScratch` on the model
- `MixedMRFModel::logp_and_gradient` and `::logp_and_gradient_full` — same pattern
- `bgmCompare::logp_and_gradient` — `thread_local LogZScratch` (free function; each TBB chain worker is its own thread so per-thread scratch is per-chain)

After the first few calls the scratch buffers stabilise at their max size and no further heap allocations occur in the helpers.

## Why

Profiling `bgm(Wenchuan, chains=4)` on M5 Pro showed allocator contention dominating the multi-chain overhead. ~36% of CPU was in `arma::memory::acquire/release` / `libsystem_malloc`, and per-chain CPU at chains=4 grew ~50% over chains=1 due to libsystem_malloc serialising on shared zone metadata across concurrent chain workers. Pre-sized scratch buffers eliminate the alloc/free traffic in the hot path.

## Numbers (M5 Pro, 3-rep median, fixed seed; old-branch baseline)

`bgm(Wenchuan)` elapsed:

| chains | before | after | Δ |
|-------:|-------:|------:|----:|
| 1 | 32.0s | 31.0s | −3% (noise) |
| 2 | 40.0s | 35.5s | **−11%** |
| 4 | 51.5s | 38.3s | **−26%** |

Per-chain CPU at chains=4 dropped from 48.9s to 36.8s — recovers most of the multi-chain scaling penalty visible on single-cluster Apple Silicon.

## Bit-identical guarantee

The `_into` variants preserve the original arma FP sequence exactly; output matches the by-value baseline byte-for-byte.

Verified on current `main` via `digest::digest(fit)` under fixed seed:

- OMRF ordinal: `e6d00640…fae4ade3` (both pre- and post-port)
- OMRF Blume-Capel: `c0d6a42c…be844363` (both pre- and post-port)

Original old-branch verification also covered Mixed MRF (synthetic ordinal+continuous), `bgmCompare` (Wenchuan x/y split), and `sample_precision_prior` (continuous NUTS / GGM gradient engine).

## Test plan

- [x] Targeted tests `omrf|bgm-|ggm|mixed|bgmCompare`: 427/427 pass, 0 fail.
- [x] Bit-identical digest on fixed-seed ordinal + Blume-Capel fits (matches pre-port).
- [x] Clean `R CMD INSTALL` at `-O2 -DNDEBUG` (production flags).
- [ ] CI green.

## Follow-ups (deferred, captured in `dev/plans/backlog/`)

The remaining multi-chain contention is in per-call arma allocations *inside* the gradient functions themselves (`OMRFModel::logp_and_gradient`, `GGMGradientEngine::logp_and_gradient_full`, `GGMModel::project_momentum`). The model-specific scratch buffer ports for those (old-branch PR-4/5/6) yield smaller incremental gains and depend on the general `BaseModel::logp_and_gradient_into` virtual being introduced first. Plans saved to:

- [`omrf-nuts-scratch-pr456.md`](dev/plans/backlog/omrf-nuts-scratch-pr456.md) — OMRF NUTS path
- [`ggm-continuous-scratch-buffers.md`](dev/plans/backlog/ggm-continuous-scratch-buffers.md) — GGM continuous NUTS path

Per the M5 Pro single-cluster L2 ceiling, returns past this PR are diminishing. This PR captures the cheap, big gain.