### PR TITLE
fix(omrf): restore residual invariant in stage-3b proposal-SD tuning

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -101,6 +101,10 @@ run_mixed_simulation_parallel <- function(mux_samples, disc_samples, muy_samples
     .Call(`_bgms_run_mixed_simulation_parallel`, mux_samples, disc_samples, muy_samples, cont_samples, cross_samples, draw_indices, num_states, p, q, num_categories, variable_type_r, baseline_category, iter, nThreads, seed, progress_type)
 }
 
+test_omrf_residual_invariant <- function(observations, num_categories, pairwise, warmup, seed, target_accept = 0.44, enable_selection = TRUE, learn_sd = TRUE) {
+    .Call(`_bgms_test_omrf_residual_invariant`, observations, num_categories, pairwise, warmup, seed, target_accept, enable_selection, learn_sd)
+}
+
 test_parameter_prior <- function(type, x, scale = 1.0, alpha = 0.5, beta = 0.5, scale_factor = 1.0) {
     .Call(`_bgms_test_parameter_prior`, type, x, scale, alpha, beta, scale_factor)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -505,6 +505,24 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// test_omrf_residual_invariant
+Rcpp::List test_omrf_residual_invariant(const arma::imat& observations, const arma::ivec& num_categories, const arma::mat& pairwise, const int warmup, const int seed, const double target_accept, const bool enable_selection, const bool learn_sd);
+RcppExport SEXP _bgms_test_omrf_residual_invariant(SEXP observationsSEXP, SEXP num_categoriesSEXP, SEXP pairwiseSEXP, SEXP warmupSEXP, SEXP seedSEXP, SEXP target_acceptSEXP, SEXP enable_selectionSEXP, SEXP learn_sdSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::imat& >::type observations(observationsSEXP);
+    Rcpp::traits::input_parameter< const arma::ivec& >::type num_categories(num_categoriesSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type pairwise(pairwiseSEXP);
+    Rcpp::traits::input_parameter< const int >::type warmup(warmupSEXP);
+    Rcpp::traits::input_parameter< const int >::type seed(seedSEXP);
+    Rcpp::traits::input_parameter< const double >::type target_accept(target_acceptSEXP);
+    Rcpp::traits::input_parameter< const bool >::type enable_selection(enable_selectionSEXP);
+    Rcpp::traits::input_parameter< const bool >::type learn_sd(learn_sdSEXP);
+    rcpp_result_gen = Rcpp::wrap(test_omrf_residual_invariant(observations, num_categories, pairwise, warmup, seed, target_accept, enable_selection, learn_sd));
+    return rcpp_result_gen;
+END_RCPP
+}
 // test_parameter_prior
 Rcpp::List test_parameter_prior(const std::string& type, double x, double scale, double alpha, double beta, double scale_factor);
 RcppExport SEXP _bgms_test_parameter_prior(SEXP typeSEXP, SEXP xSEXP, SEXP scaleSEXP, SEXP alphaSEXP, SEXP betaSEXP, SEXP scale_factorSEXP) {
@@ -700,6 +718,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_bgms_run_ggm_simulation_parallel", (DL_FUNC) &_bgms_run_ggm_simulation_parallel, 9},
     {"_bgms_sample_mixed_mrf_gibbs", (DL_FUNC) &_bgms_sample_mixed_mrf_gibbs, 11},
     {"_bgms_run_mixed_simulation_parallel", (DL_FUNC) &_bgms_run_mixed_simulation_parallel, 16},
+    {"_bgms_test_omrf_residual_invariant", (DL_FUNC) &_bgms_test_omrf_residual_invariant, 8},
     {"_bgms_test_parameter_prior", (DL_FUNC) &_bgms_test_parameter_prior, 6},
     {"_bgms_test_scale_prior", (DL_FUNC) &_bgms_test_scale_prior, 4},
     {"_bgms_ggm_test_logp_and_gradient_prior", (DL_FUNC) &_bgms_ggm_test_logp_and_gradient_prior, 11},

--- a/src/models/omrf/omrf_model.cpp
+++ b/src/models/omrf/omrf_model.cpp
@@ -277,8 +277,8 @@ void OMRFModel::tune_proposal_sd(int iteration, const WarmupSchedule& schedule) 
 
             if (current != value) {
                 double delta = value - current;
-                residual_matrix_.col(variable1) += observations_double_.col(variable2) * delta;
-                residual_matrix_.col(variable2) += observations_double_.col(variable1) * delta;
+                residual_matrix_.col(variable1) += 2.0 * observations_double_.col(variable2) * delta;
+                residual_matrix_.col(variable2) += 2.0 * observations_double_.col(variable1) * delta;
             }
 
             proposal_sd = update_proposal_sd_with_robbins_monro(

--- a/src/omrf_residual_test_interface.cpp
+++ b/src/omrf_residual_test_interface.cpp
@@ -1,0 +1,73 @@
+// omrf_residual_test_interface.cpp - test-only interface
+//
+// Exposes a minimal harness to verify the OMRF residual-matrix invariant
+//   residual_matrix_ == 2 * observations_double_ * pairwise_effects_
+// is preserved across a warmup run of tune_proposal_sd(). Used by
+// tests/testthat to characterize the stage-3b proposal-SD tuner.
+#include <RcppArmadillo.h>
+
+#include "models/omrf/omrf_model.h"
+#include "priors/parameter_prior.h"
+#include "mcmc/execution/warmup_schedule.h"
+
+// Build an all-ordinal OMRF model on the given data, set the pairwise
+// effects (which rebuilds residual_matrix_ exactly), then run `warmup`
+// iterations of tune_proposal_sd(). Returns the residual matrix the model
+// holds afterwards alongside the value the invariant requires, so the
+// caller can assert they match.
+//
+// [[Rcpp::export]]
+Rcpp::List test_omrf_residual_invariant(
+    const arma::imat& observations,
+    const arma::ivec& num_categories,
+    const arma::mat& pairwise,
+    const int warmup,
+    const int seed,
+    const double target_accept = 0.44,
+    const bool enable_selection = true,
+    const bool learn_sd = true
+) {
+    const int p = static_cast<int>(observations.n_cols);
+
+    // All-ordinal so observations_double_ == observations (no BC centering),
+    // making the invariant residual == 2 * X * pairwise hold exactly.
+    arma::uvec is_ordinal = arma::ones<arma::uvec>(p);
+    arma::ivec baseline   = arma::zeros<arma::ivec>(p);
+    arma::mat  incl_prob  = 0.5 * arma::ones<arma::mat>(p, p);
+    arma::imat edges      = arma::ones<arma::imat>(p, p);
+    edges.diag().zeros();
+
+    auto interaction_prior = create_parameter_prior("cauchy", 2.5, NA_REAL, NA_REAL);
+    auto threshold_prior   = create_parameter_prior("beta-prime", 1.0, 0.5, 0.5);
+
+    OMRFModel model(
+        observations, num_categories, incl_prob, edges,
+        is_ordinal, baseline,
+        std::move(interaction_prior), std::move(threshold_prior),
+        /*edge_selection=*/false);
+
+    model.set_seed(seed);
+    model.set_metropolis_target_accept(target_accept);
+    model.set_pairwise_effects(pairwise);  // residual now exactly 2*X*pairwise
+
+    WarmupSchedule schedule(warmup, enable_selection, learn_sd);
+    model.init_metropolis_adaptation(schedule);
+
+    for (int iter = 0; iter < warmup; ++iter) {
+        model.tune_proposal_sd(iter, schedule);
+    }
+
+    const arma::mat residual = model.get_residual_matrix();
+    const arma::mat pw       = model.get_pairwise_effects();
+    const arma::mat obs_d    = arma::conv_to<arma::mat>::from(observations);
+    const arma::mat expected = 2.0 * obs_d * pw;
+
+    return Rcpp::List::create(
+        Rcpp::Named("residual")            = residual,
+        Rcpp::Named("expected")            = expected,
+        Rcpp::Named("pairwise_after")      = pw,
+        Rcpp::Named("pairwise_before")     = pairwise,
+        Rcpp::Named("max_abs_discrepancy") = arma::abs(residual - expected).max(),
+        Rcpp::Named("any_move_accepted")   = (arma::abs(pw - pairwise).max() > 0.0)
+    );
+}

--- a/tests/testthat/test-omrf-residual-invariant.R
+++ b/tests/testthat/test-omrf-residual-invariant.R
@@ -1,0 +1,33 @@
+# Regression test for the OMRF residual-matrix invariant during stage-3b
+# proposal-SD tuning (NUTS + edge-selection path).
+#
+# The model maintains residual_matrix_ == 2 * observations_double_ *
+# pairwise_effects_ incrementally. tune_proposal_sd() moves the pairwise
+# effects and must update the residual with the same factor of 2 that every
+# other residual update uses. A missing factor (the historical bug) left the
+# residual inconsistent after any accepted stage-3b move, biasing the
+# between-model edge-proposal SD tuning. See test_omrf_residual_invariant().
+
+test_that("tune_proposal_sd preserves the residual = 2*X*pairwise invariant", {
+  set.seed(1)
+  n = 80L
+  p = 4L
+  x = matrix(rbinom(n * p, 1, 0.5), n, p)
+  storage.mode(x) = "integer"
+  num_categories = rep(1L, p)
+  pairwise = matrix(0.3, p, p)
+  diag(pairwise) = 0
+
+  res = test_omrf_residual_invariant(
+    x, num_categories, pairwise,
+    warmup = 400L, seed = 42L,
+    enable_selection = TRUE, learn_sd = TRUE
+  )
+
+  # The harness must actually exercise stage-3b (otherwise the test is vacuous).
+  expect_true(res$any_move_accepted)
+  expect_gt(max(abs(res$pairwise_after - pairwise)), 0)
+
+  # The invariant must hold to machine precision after tuning.
+  expect_lt(res$max_abs_discrepancy, 1e-10)
+})


### PR DESCRIPTION
## Summary

`OMRFModel::tune_proposal_sd()` moved the pairwise effects after an accepted stage-3b proposal but updated `residual_matrix_` with `obs * delta` instead of `2.0 * obs * delta`, breaking the invariant

```
residual_matrix_ == 2 * observations_double_ * pairwise_effects_
```

that `update_residual_matrix()` establishes and every other incremental update (`update_residual_columns`, `update_pairwise_effect`, `update_edge_indicator`) maintains. `tune_proposal_sd` was the only update site missing the factor of 2.

## Scope / impact

- Reachable **only on the NUTS + edge-selection path** — stage 3b runs only when `enable_selection && learn_sd` (`learn_sd == sampler_type == "nuts"`).
- Does **not** bias the stationary distribution of the continuous effects: NUTS rebuilds the residual from the parameter vector each step via `set_vectorized_parameters()`.
- It **does** corrupt the residual read by the between-model edge-proposal acceptance ratio during stage-3b warmup, mis-tuning the edge-proposal SD (a mixing/efficiency cost, plus a one-iteration transient). This is why SBC and the bitwise compliance suite did not flag it.

## Verification

Added `test_omrf_residual_invariant()` — a test-only Rcpp harness (following the existing `*_test_interface.cpp` pattern) that drives a real model through a stage-3b warmup and reports the residual invariant discrepancy — plus a regression test in `tests/testthat/test-omrf-residual-invariant.R`.

| | residual vs `2*X*pairwise` | moves accepted |
|---|---|---|
| before fix | 3.16 (broken) | yes |
| after fix | 8.9e-16 (machine zero) | yes |

The regression test fails before the fix and passes after.

## Changes

- `src/models/omrf/omrf_model.cpp` — add the missing `2.0` factor (2 lines).
- `src/omrf_residual_test_interface.cpp` — new test-only harness.
- `tests/testthat/test-omrf-residual-invariant.R` — regression test.
- `R/RcppExports.R`, `src/RcppExports.cpp` — regenerated by compileAttributes.