### PR TITLE
fix: ordinal all-unique guard, imputation indexing, difference_scale default

### DIFF
--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -281,7 +281,7 @@ bgm_spec = function(x,
                     difference_prior = c(
                       "Bernoulli", "Beta-Bernoulli", "Stochastic-Block"
                     ),
-                    difference_scale = 2.5,
+                    difference_scale = 1,
                     difference_probability = 0.5,
                     # Compare difference prior hyperparameters
                     beta_bernoulli_alpha = 1,

--- a/R/validate_data.R
+++ b/R/validate_data.R
@@ -182,11 +182,13 @@ handle_impute = function(x, group = NULL) {
   for(node in seq_len(num_variables)) {
     mis = which(is.na(x[, node]))
     if(length(mis) > 0) {
+      observed = x[-mis, node]
       for(i in seq_along(mis)) {
         cntr = cntr + 1
         missing_index[cntr, 1] = mis[i] - 1 # C++ 0-based index
         missing_index[cntr, 2] = node - 1 # C++ 0-based index
-        x[mis[i], node] = sample(x[-mis, node], size = 1)
+        # Index explicitly: sample(v, 1) treats a length-1 numeric v as 1:v.
+        x[mis[i], node] = observed[sample.int(length(observed), 1)]
       }
     }
   }
@@ -232,17 +234,19 @@ reformat_ordinal_data = function(x, is_ordinal, baseline_category) {
     unq_vls = sort(unique(x[, node]))
     mx_vl = max(unq_vls)
 
-    # Check if observed responses are not all unique ---------------------------
-    if(mx_vl == nrow(x)) {
-      stop(paste0(
-        "Only unique responses observed for variable ",
-        node,
-        ". We expect >= 1 observations per category."
-      ))
-    }
-
     # Recode data --------------------------------------------------------------
     if(is_ordinal[node]) { # Regular ordinal variable
+      # A regular ordinal variable needs repeated values: its category
+      # thresholds are unidentified if every response is distinct (the column
+      # then looks continuous). Blume-Capel is parametric in the category score
+      # and is exempt.
+      if(length(unq_vls) == nrow(x)) {
+        stop(paste0(
+          "Only unique responses observed for variable ",
+          node,
+          ". We expect >= 1 observations per category."
+        ))
+      }
       if(length(unq_vls) != mx_vl + 1 || any(unq_vls != 0:mx_vl)) {
         y = x[, node]
         cntr = 0

--- a/tests/testthat/test-bgm-spec.R
+++ b/tests/testthat/test-bgm-spec.R
@@ -681,3 +681,15 @@ test_that("mixed MRF: disc-length baseline_category works", {
   expect_equal(s$model_type, "mixed_mrf")
   expect_equal(s$variables$baseline_category[1:2], c(1L, 1L))
 })
+
+# ==============================================================================
+# bgm_spec() and bgmCompare() must share the same difference_scale default so
+# that a direct bgm_spec(model_type = "compare") call matches the public API.
+# ==============================================================================
+
+test_that("bgm_spec and bgmCompare share the difference_scale default", {
+  expect_equal(
+    eval(formals(bgm_spec)$difference_scale),
+    eval(formals(bgmCompare)$difference_scale)
+  )
+})

--- a/tests/testthat/test-validate-missing-data.R
+++ b/tests/testthat/test-validate-missing-data.R
@@ -176,3 +176,19 @@ test_that("group is absent from result when not provided", {
   result = validate_missing_data(x, na_action = "listwise")
   expect_null(result$group)
 })
+
+# ==============================================================================
+# Imputation draws from the observed values, indexing explicitly so a column
+# with a single observed value is filled with that value (not sample(v, 1),
+# which would treat a length-1 numeric v as the range 1:v).
+# ==============================================================================
+
+test_that("impute fills a single-observed-value column with that value", {
+  x = matrix(c(
+    7, NA, NA, NA, NA, NA,
+    1, 0, 1, 0, 1, 0
+  ), nrow = 6, ncol = 2)
+  set.seed(1)
+  result = validate_missing_data(x, na_action = "impute")
+  expect_true(all(result$x[, 1] == 7))
+})

--- a/tests/testthat/test-validate-ordinal-data.R
+++ b/tests/testthat/test-validate-ordinal-data.R
@@ -9,7 +9,7 @@
 # ==============================================================================
 
 test_that("ordinal: already contiguous 0-based passes through unchanged", {
-  x = matrix(c(0, 1, 2, 0, 1, 2), nrow = 3, ncol = 2)
+  x = matrix(c(0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2), nrow = 6, ncol = 2)
   is_ordinal = c(TRUE, TRUE)
   bc = c(0, 0)
 
@@ -20,13 +20,13 @@ test_that("ordinal: already contiguous 0-based passes through unchanged", {
 })
 
 test_that("ordinal: non-contiguous values are recoded to contiguous 0-based", {
-  x = matrix(c(1, 3, 5, 1, 3, 5), nrow = 3, ncol = 2)
+  x = matrix(c(1, 3, 5, 1, 3, 5, 1, 3, 5, 1, 3, 5), nrow = 6, ncol = 2)
   is_ordinal = c(TRUE, TRUE)
   bc = c(0, 0)
 
   result = reformat_ordinal_data(x, is_ordinal, bc)
-  expect_equal(result$x[, 1], c(0, 1, 2))
-  expect_equal(result$x[, 2], c(0, 1, 2))
+  expect_equal(result$x[, 1], c(0, 1, 2, 0, 1, 2))
+  expect_equal(result$x[, 2], c(0, 1, 2, 0, 1, 2))
   expect_equal(result$num_categories, c(2, 2))
 })
 
@@ -285,4 +285,33 @@ test_that("validate_missing_data + reformat_ordinal_data pipeline works end-to-e
   expect_equal(result$x[, 1], c(0, 1, 2, 0, 1, 2))
   expect_equal(result$num_categories, c(2, 2))
   expect_false(md$na_impute)
+})
+
+# ==============================================================================
+# All-unique guard: a regular ordinal variable needs repeated values (category
+# thresholds are unidentified otherwise). Blume-Capel is parametric in the
+# category score and is exempt.
+# ==============================================================================
+
+test_that("ordinal: errors when every response is distinct", {
+  x = matrix(0:4, ncol = 1) # 5 rows, 5 distinct values
+  expect_error(
+    reformat_ordinal_data(x, is_ordinal = TRUE, baseline_category = 0L),
+    "Only unique responses"
+  )
+})
+
+test_that("Blume-Capel: all-distinct responses are allowed (parametric, exempt)", {
+  x = matrix(0:4, ncol = 1) # 5 rows, 5 distinct values -> fine for BC
+  expect_no_error(
+    reformat_ordinal_data(x, is_ordinal = FALSE, baseline_category = 0L)
+  )
+})
+
+test_that("ordinal: does not error when values repeat even if a code equals nrow", {
+  # nrow = 4, max code = 4 (== nrow), but only 3 distinct values: not all unique.
+  x = matrix(c(0, 4, 4, 1), ncol = 1)
+  expect_no_error(
+    reformat_ordinal_data(x, is_ordinal = TRUE, baseline_category = 0L)
+  )
 })


### PR DESCRIPTION
Three small data-prep / spec fixes verified during the code review. Bundled per maintainer request; full test suite green (single-core), styler clean, lint 0.

## 1. `reformat_ordinal_data()` — all-unique guard (ordinal-only)

The guard tested the wrong quantity (`max(value) == nrow`) and applied to every variable. It now tests the **number of distinct values** (`length(unique) == nrow`) and applies **only to regular ordinal variables**, whose category thresholds are unidentified when every response is distinct (the column then looks continuous). **Blume-Capel is exempt** — it is parametric in the category score (linear + quadratic), so all-distinct data is fine for it.

Old behaviour was both a false positive (rejected valid data where a category code equalled `nrow`) and a false negative (silently accepted all-unique ordinal data). Tiny all-distinct ordinal test fixtures are updated to valid repeated-value data.

## 2. `handle_impute()` — explicit indexing

`sample(v, 1)` treats a length-1 numeric `v` as the range `1:v`, so a column with a single observed value imputed a random value in that range instead of the observed value. Now indexes the observed vector explicitly. Identical RNG behaviour for the normal (length > 1) case.

## 3. `bgm_spec()` — `difference_scale` default `2.5 → 1`

Aligns the dead default with the `bgmCompare()` public default (1). `bgmCompare()` always passes the value explicitly, so production output is unchanged; this only affects direct `bgm_spec(model_type = "compare")` calls.

## Tests

Regression tests added for each, including the Blume-Capel all-distinct exemption and a `formals()`-equality guard against future `difference_scale` drift.