### PR TITLE
fix(predict): recode ordinal newdata via the training category map

### DIFF
--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -653,7 +653,10 @@ build_spec_omrf = function(x, data_columnnames, num_variables,
       data_columnnames = data_columnnames,
       num_variables    = as.integer(num_variables),
       num_cases        = as.integer(nrow(x_recoded)),
-      num_categories   = as.integer(num_categories)
+      num_categories   = as.integer(num_categories),
+      # Recode map (sorted original values per ordinal variable) so predict()
+      # can recode newdata the same way bgm() recoded the training data.
+      category_levels  = ord$category_levels
     ),
     variables = list(
       variable_type     = variable_type,
@@ -1278,6 +1281,7 @@ build_arguments_omrf = function(spec) {
     learn_mass_matrix            = spec$sampler$learn_mass_matrix,
     num_chains                   = spec$sampler$chains,
     num_categories               = spec$data$num_categories,
+    category_levels              = spec$data$category_levels,
     data_columnnames             = spec$data$data_columnnames,
     baseline_category            = spec$variables$baseline_category,
     pairwise_scaling_factors     = spec$prior$pairwise_scaling_factors,

--- a/R/simulate_predict.R
+++ b/R/simulate_predict.R
@@ -1153,9 +1153,11 @@ predict.bgms = function(object,
   #   OMRF (ordinal) path
   # ============================================================================
 
-  # Recode data to 0-based integers (matching what bgm() does)
+  # Recode data to 0-based integers (matching what bgm() did to the training
+  # data) using the stored recode map when available.
   newdata_recoded = recode_data_for_prediction(
-    newdata, num_categories, is_ordinal
+    newdata, num_categories, is_ordinal,
+    category_levels = arguments$category_levels
   )
 
   if(method == "posterior-mean") {
@@ -1528,17 +1530,40 @@ reconstruct_main = function(main_vec, num_variables,
 }
 
 
-# Helper function to recode data for prediction
-recode_data_for_prediction = function(x, num_categories, is_ordinal) {
+# Helper function to recode newdata to the 0-based categories the model was
+# fitted on. When the fit carries a recode map (category_levels: the sorted
+# original training values per ordinal variable), each newdata value is mapped
+# through it exactly as bgm() recoded the training data --- so non-contiguous
+# training categories and newdata with a different range are handled correctly.
+# Fits without a map (older fits) fall back to the legacy subtract-minimum shift.
+recode_data_for_prediction = function(x, num_categories, is_ordinal,
+                                      category_levels = NULL) {
   x = as.matrix(x)
   num_variables = ncol(x)
 
   for(v in seq_len(num_variables)) {
-    if(is_ordinal[v]) {
-      # For ordinal variables, ensure values are in 0:num_categories[v]
+    if(!is_ordinal[v]) next
+
+    levels_v = if(!is.null(category_levels)) category_levels[[v]] else NULL
+
+    if(!is.null(levels_v)) {
+      # Map original value -> 0-based category via its position in the training
+      # levels (match), matching reformat_ordinal_data()'s recoding.
+      recoded = match(x[, v], levels_v) - 1L
+      observed = !is.na(x[, v])
+      if(any(observed & is.na(recoded))) {
+        warning(
+          "newdata for variable ", v, " contains category values not ",
+          "observed in the training data; predictions for those cells are NA.",
+          call. = FALSE
+        )
+      }
+      x[, v] = recoded
+    } else {
+      # Legacy fallback (fit has no recode map): shift to 0-based by the
+      # per-column minimum.
       x[, v] = as.integer(x[, v])
       if(min(x[, v], na.rm = TRUE) > 0) {
-        # Shift to 0-based if necessary
         x[, v] = x[, v] - min(x[, v], na.rm = TRUE)
       }
     }

--- a/R/validate_data.R
+++ b/R/validate_data.R
@@ -229,6 +229,10 @@ reformat_ordinal_data = function(x, is_ordinal, baseline_category) {
   check_fail_zero = FALSE
   num_variables = ncol(x)
   num_categories = vector(length = num_variables)
+  # Per ordinal variable: the sorted unique ORIGINAL values, i.e. the recode
+  # map. The recoded category of an original value v is match(v, levels) - 1.
+  # predict() needs this to recode newdata the same way (NULL for Blume-Capel).
+  category_levels = vector("list", num_variables)
 
   for(node in 1:num_variables) {
     unq_vls = sort(unique(x[, node]))
@@ -236,6 +240,8 @@ reformat_ordinal_data = function(x, is_ordinal, baseline_category) {
 
     # Recode data --------------------------------------------------------------
     if(is_ordinal[node]) { # Regular ordinal variable
+      # Capture the recode map (original sorted values) before recoding x.
+      category_levels[[node]] = unq_vls
       # A regular ordinal variable needs repeated values: its category
       # thresholds are unidentified if every response is distinct (the column
       # then looks continuous). Blume-Capel is parametric in the category score
@@ -344,7 +350,8 @@ reformat_ordinal_data = function(x, is_ordinal, baseline_category) {
   list(
     x                 = x,
     num_categories    = num_categories,
-    baseline_category = baseline_category
+    baseline_category = baseline_category,
+    category_levels   = category_levels
   )
 }
 

--- a/tests/testthat/test-build-arguments.R
+++ b/tests/testthat/test-build-arguments.R
@@ -161,7 +161,7 @@ test_that("OMRF build_arguments: all expected field names present", {
     "dirichlet_alpha", "lambda", "na_action", "version",
     "update_method", "target_accept",
     "nuts_max_depth", "learn_mass_matrix",
-    "num_chains", "num_categories",
+    "num_chains", "num_categories", "category_levels",
     "data_columnnames", "baseline_category",
     "pairwise_scaling_factors", "no_variables",
     "model_type"

--- a/tests/testthat/test-predict-recode-map.R
+++ b/tests/testthat/test-predict-recode-map.R
@@ -1,0 +1,55 @@
+# ==============================================================================
+# recode_data_for_prediction(): newdata must be recoded to the 0-based
+# categories the model was fitted on, using the stored training recode map
+# (category_levels). Subtracting the per-column minimum (the legacy fallback)
+# is wrong when training categories were non-contiguous or newdata spans a
+# different range.
+# ==============================================================================
+
+recode = bgms:::recode_data_for_prediction
+
+test_that("map recodes non-contiguous training categories correctly", {
+  # Training values {1,3,5} -> categories {0,1,2}. Legacy subtract-min gives
+  # {0,2,4} (wrong); the map gives {0,1,2}.
+  levels = list(c(1, 3, 5))
+  out = recode(matrix(c(1, 3, 5), ncol = 1), 2, TRUE, category_levels = levels)
+  expect_equal(out[, 1], c(0, 1, 2))
+})
+
+test_that("map is absolute, not relative to newdata's range", {
+  # Training {1,2,3} -> {0,1,2}; value 2 is category 1 regardless of whether
+  # the lowest category appears in newdata.
+  levels = list(c(1, 2, 3))
+  out = recode(matrix(c(2, 3), ncol = 1), 2, TRUE, category_levels = levels)
+  expect_equal(out[, 1], c(1, 2))
+})
+
+test_that("values not observed in training give NA with a warning", {
+  levels = list(c(1, 2, 3))
+  expect_warning(
+    out <- recode(matrix(c(1, 9), ncol = 1), 2, TRUE, category_levels = levels),
+    "not\\s+observed in the training data"
+  )
+  expect_true(is.na(out[2, 1]))
+  expect_equal(out[1, 1], 0)
+})
+
+test_that("Blume-Capel columns (NULL level entry) fall back to subtract-min", {
+  # category_levels present but NULL for this variable -> legacy behaviour.
+  levels = list(NULL)
+  out = recode(matrix(c(2, 3, 4), ncol = 1), 2, TRUE, category_levels = levels)
+  expect_equal(out[, 1], c(0, 1, 2))
+})
+
+test_that("no map at all (old fit) preserves legacy subtract-min behaviour", {
+  out = recode(matrix(c(2, 3, 4), ncol = 1), 2, TRUE, category_levels = NULL)
+  expect_equal(out[, 1], c(0, 1, 2))
+})
+
+test_that("continuous/non-ordinal columns are left unchanged", {
+  levels = list(NULL, c(0, 1, 2))
+  x = matrix(c(1.5, 2.5, 3.5, 0, 1, 2), ncol = 2)
+  out = recode(x, c(NA, 2), c(FALSE, TRUE), category_levels = levels)
+  expect_equal(out[, 1], c(1.5, 2.5, 3.5))
+  expect_equal(out[, 2], c(0, 1, 2))
+})

--- a/tests/testthat/test-validate-ordinal-data.R
+++ b/tests/testthat/test-validate-ordinal-data.R
@@ -315,3 +315,17 @@ test_that("ordinal: does not error when values repeat even if a code equals nrow
     reformat_ordinal_data(x, is_ordinal = TRUE, baseline_category = 0L)
   )
 })
+
+test_that("ordinal: returns the recode map (sorted original values) per variable", {
+  x = matrix(c(1, 3, 5, 1, 3, 5), nrow = 6, ncol = 1)
+  result = reformat_ordinal_data(x, is_ordinal = TRUE, baseline_category = 0L)
+  # category_levels[[1]] are the original sorted values; recoded = match - 1.
+  expect_equal(result$category_levels[[1]], c(1, 3, 5))
+  expect_equal(result$x[, 1], match(x[, 1], result$category_levels[[1]]) - 1L)
+})
+
+test_that("Blume-Capel variables get no recode map (NULL)", {
+  x = matrix(c(0, 1, 2, 0, 1, 2), nrow = 6, ncol = 1)
+  result = reformat_ordinal_data(x, is_ordinal = FALSE, baseline_category = 0L)
+  expect_null(result$category_levels[[1]])
+})


### PR DESCRIPTION
## The bug

`predict()` for ordinal (OMRF) models recoded `newdata` by subtracting each column's own minimum. That does **not** reproduce how `bgm()` recoded the training data: `reformat_ordinal_data()` collapses gaps to contiguous 0-based categories using the *training* values. Confirmed empirically during review:

- **Non-contiguous training** `{0,2,4}`: training → `{0,1,2}`, but predict → `{0,2,4}` (references categories the model doesn't have).
- **Range-shifted newdata**: training `{1,2,3}`→`{0,1,2}` so value `2`→category `1`, but predict on newdata `{2,3}` → value `2`→category `0`.

So predicted probabilities were computed against mismatched category indices whenever training categories were non-contiguous or newdata spanned a different range than training. It happened to be correct only when training was already 0-based contiguous *and* newdata shared the same minimum.

## The fix

- `reformat_ordinal_data()` now returns `category_levels` — the sorted original training values per ordinal variable (the recode map; `NULL` for Blume-Capel, which is parametric in the category score).
- Stored in the spec and exposed via `build_arguments_omrf()`, so it lives in the fit object.
- `predict.bgms()` passes it to `recode_data_for_prediction()`, which maps each newdata value through it (`match - 1`) exactly as training was recoded.
- Newdata values **not** observed in training → `NA` with a warning (genuinely out-of-range categories the model has no parameters for).
- **Backward compatible:** fits without a stored map (older fits) fall back to the previous subtract-minimum behaviour.

## Scope

OMRF path only. `predict.bgmCompare()` uses the same helper but recodes via cross-group collapsing (`collapse_categories_across_groups`), a distinct map; it keeps the legacy fallback and is left for a **follow-up PR**.

## Notes

- The fit object's `arguments` gains a `category_levels` field (structure test updated). This changes the fit shape vs. older versions — relevant to the deferred compliance-fixture redesign.
- Full test suite green (single-core); new regression tests cover the map (reformat output) and `recode_data_for_prediction` (non-contiguous, range-shifted, out-of-range warning, Blume-Capel/legacy fallbacks).