### PR TITLE
feat(output): label ordinal thresholds in the original category scale

### DIFF
--- a/R/build_output.R
+++ b/R/build_output.R
@@ -245,6 +245,23 @@ build_output = function(spec, raw) {
 
 
 # ==============================================================================
+# ordinal_threshold_labels()
+# ------------------------------------------------------------------------------
+# Labels for an ordinal variable's category thresholds (recoded categories
+# 1..K). When the fit carries a recode map (category_levels_v: the sorted
+# original training values, length K+1 with position 1 the reference category),
+# the original category values for categories 1..K are returned so output is in
+# the user's scale. Otherwise the rescored indices 1..K are used (older fits).
+ordinal_threshold_labels = function(num_categories_v, category_levels_v = NULL) {
+  if(!is.null(category_levels_v) &&
+    length(category_levels_v) == num_categories_v + 1L) {
+    category_levels_v[-1L] # drop the reference category (recoded 0)
+  } else {
+    seq_len(num_categories_v)
+  }
+}
+
+
 # build_output_bgm()  --- unified GGM + OMRF
 # ==============================================================================
 #
@@ -354,7 +371,10 @@ build_output_bgm = function(spec, raw) {
     names_main = character()
     for(vi in seq_len(num_variables)) {
       if(is_ordinal_variable[vi]) {
-        cats = seq_len(num_categories[vi])
+        cats = ordinal_threshold_labels(
+          num_categories[vi],
+          if(!is.null(d$category_levels)) d$category_levels[[vi]] else NULL
+        )
         names_main = c(
           names_main,
           paste0(data_columnnames[vi], " (", cats, ")")

--- a/tests/testthat/test-original-scale-labels.R
+++ b/tests/testthat/test-original-scale-labels.R
@@ -1,0 +1,37 @@
+# ==============================================================================
+# Ordinal category thresholds are reported using the original category values
+# (the recode map, category_levels) rather than the internal rescored indices
+# 1, 2, ... See ordinal_threshold_labels() and build_output naming.
+# ==============================================================================
+
+test_that("ordinal_threshold_labels uses original category values when available", {
+  f = bgms:::ordinal_threshold_labels
+  # Training {1,3,5} -> recoded {0,1,2}; thresholds for cats 1,2 are original 3,5.
+  expect_equal(f(2, c(1, 3, 5)), c(3, 5))
+  # 0-based contiguous: original == rescored.
+  expect_equal(f(2, c(0, 1, 2)), c(1, 2))
+  expect_equal(f(3, c(1, 2, 4, 8)), c(2, 4, 8))
+})
+
+test_that("ordinal_threshold_labels falls back to rescored indices without a map", {
+  f = bgms:::ordinal_threshold_labels
+  expect_equal(f(2, NULL), seq_len(2))
+  # Defensive: a map whose length does not match K+1 falls back, too.
+  expect_equal(f(2, c(1, 3)), seq_len(2))
+})
+
+test_that("summary labels ordinal thresholds in the original category scale", {
+  set.seed(1)
+  n = 60L
+  x = cbind(sample(c(1, 3, 5), n, TRUE), sample(0:2, n, TRUE))
+  colnames(x) = c("A", "B")
+  fit = bgm(x,
+    iter = 80, warmup = 80, chains = 1,
+    display_progress = "none", update_method = "adaptive-metropolis"
+  )
+  rn = rownames(summary(fit)$main)
+  # Variable A's thresholds carry the original values 3 and 5.
+  expect_true(all(c("A (3)", "A (5)") %in% rn))
+  # Variable B is 0-based, so labels are unchanged.
+  expect_true(all(c("B (1)", "B (2)") %in% rn))
+})


### PR DESCRIPTION
Builds on #114 (the `category_levels` recode map).

## What

OMRF category thresholds were reported with the internal **rescored** indices — `Var (1)`, `Var (2)`, … — which don't match the user's categories when the training data wasn't already 0-based contiguous. Using the recode map now stored on the fit, thresholds are labelled with the **original category values**:

```
# variable observed at {1, 3, 5}
before:  A (1)   A (2)
after:   A (3)   A (5)
```

0-based data is unaffected (`B (1)`, `B (2)` stays as-is), and so are older fits without a stored map.

## How

- New `ordinal_threshold_labels()` — single source of truth: original values when the map is present (length `K+1`, position 1 is the reference category), rescored indices otherwise.
- Used in the OMRF main-effect naming (`names_main`) that feeds `summary()` and `print()`.

## Scope

- **OMRF (single-group) only.**
- The `posterior_mean_main` matrix returned by `extract_main_effects()` keeps **positional** column names (`cat (c)`) — a shared-column matrix can't carry per-variable original values; the human-readable `summary`/`print` are where the original scale matters.
- **Mixed-MRF** discrete thresholds and **bgmCompare** use separate recode paths and are **follow-ups** (compare depends on the bgmCompare recode-map follow-up).

## Compatibility

Verified against `easybgm@update_easybgm`: it stores `extract_main_effects()` as `$thresholds` but never reads the labels/structure back, so changing the labels is safe.

## Tests

Unit tests for `ordinal_threshold_labels()` (original / 0-based / no-map / length-mismatch fallback) and an end-to-end test asserting `summary()` shows `A (3)`, `A (5)` for a `{1,3,5}` variable. Full suite green (single-core).