### PR TITLE
fix(predict): recode bgmCompare newdata via the training category map

### DIFF
--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -1002,6 +1002,8 @@ build_spec_compare = function(x, y, group_indicator,
   }
 
   # --- Ordinal recoding (compare path) ----------------------------------------
+  # Keep the original category values to build the recode map for predict().
+  x_original = x
   ord = reformat_ordinal_data(
     x                 = x,
     is_ordinal        = is_ordinal,
@@ -1023,6 +1025,20 @@ build_spec_compare = function(x, y, group_indicator,
   num_categories = col$num_categories
   bc_final = col$baseline_category
   ordinal_variable = is_ordinal
+
+  # Recode map per ordinal variable: a named vector mapping each original
+  # category value to its final (collapsed) 0-based category. reformat + cross-
+  # group collapse can merge categories, so this is many-to-one in general --
+  # hence a lookup (names = original values) rather than a sorted-value vector.
+  category_levels = vector("list", ncol(x_recoded))
+  for(vi in seq_len(ncol(x_recoded))) {
+    if(ordinal_variable[vi]) {
+      pairs = unique(cbind(x_original[, vi], x_recoded[, vi]))
+      lookup = pairs[, 2]
+      names(lookup) = pairs[, 1]
+      category_levels[[vi]] = lookup[order(as.numeric(names(lookup)))]
+    }
+  }
 
   num_variables = ncol(x_recoded)
   num_groups = length(unique(group))
@@ -1122,6 +1138,7 @@ build_spec_compare = function(x, y, group_indicator,
       num_variables    = as.integer(num_variables),
       num_cases        = as.integer(nrow(observations)),
       num_categories   = as.integer(num_categories),
+      category_levels  = category_levels,
       group            = as.integer(group),
       num_groups       = as.integer(num_groups),
       group_indices    = group_indices,
@@ -1363,6 +1380,7 @@ build_arguments_compare = function(spec) {
     data_columnnames                   = spec$data$data_columnnames,
     projection                         = spec$data$projection,
     num_categories                     = spec$data$num_categories,
+    category_levels                    = spec$data$category_levels,
     is_ordinal_variable                = spec$variables$is_ordinal,
     group                              = sort(spec$data$group),
     pairwise_scaling_factors           = spec$prior$pairwise_scaling_factors,

--- a/R/simulate_predict.R
+++ b/R/simulate_predict.R
@@ -1434,9 +1434,10 @@ predict.bgmCompare = function(object,
     }
   }
 
-  # Recode data to 0-based integers
+  # Recode data to 0-based integers using the stored recode map when available.
   newdata_recoded = recode_data_for_prediction(
-    newdata, num_categories, is_ordinal
+    newdata, num_categories, is_ordinal,
+    category_levels = arguments$category_levels
   )
 
   if(method == "posterior-mean") {
@@ -1531,10 +1532,14 @@ reconstruct_main = function(main_vec, num_variables,
 
 
 # Helper function to recode newdata to the 0-based categories the model was
-# fitted on. When the fit carries a recode map (category_levels: the sorted
-# original training values per ordinal variable), each newdata value is mapped
-# through it exactly as bgm() recoded the training data --- so non-contiguous
-# training categories and newdata with a different range are handled correctly.
+# fitted on. When the fit carries a recode map (category_levels) per ordinal
+# variable, each newdata value is mapped through it exactly as the training data
+# was recoded -- so non-contiguous categories and newdata with a different range
+# are handled correctly. The map is either:
+#   - an unnamed sorted vector of original values (bgm/OMRF): recoded category =
+#     position - 1; or
+#   - a named vector lookup (bgmCompare): names are original values, values are
+#     the final (collapsed) categories, which may be many-to-one.
 # Fits without a map (older fits) fall back to the legacy subtract-minimum shift.
 recode_data_for_prediction = function(x, num_categories, is_ordinal,
                                       category_levels = NULL) {
@@ -1547,9 +1552,13 @@ recode_data_for_prediction = function(x, num_categories, is_ordinal,
     levels_v = if(!is.null(category_levels)) category_levels[[v]] else NULL
 
     if(!is.null(levels_v)) {
-      # Map original value -> 0-based category via its position in the training
-      # levels (match), matching reformat_ordinal_data()'s recoding.
-      recoded = match(x[, v], levels_v) - 1L
+      if(!is.null(names(levels_v))) {
+        # Named lookup (bgmCompare): map original value -> final category.
+        recoded = unname(levels_v[match(x[, v], as.numeric(names(levels_v)))])
+      } else {
+        # Sorted original values (OMRF): recoded category = position - 1.
+        recoded = match(x[, v], levels_v) - 1L
+      }
       observed = !is.na(x[, v])
       if(any(observed & is.na(recoded))) {
         warning(

--- a/tests/testthat/test-build-arguments.R
+++ b/tests/testthat/test-build-arguments.R
@@ -225,7 +225,7 @@ test_that("Compare build_arguments: all expected field names present", {
     "nuts_max_depth", "learn_mass_matrix",
     "num_chains", "num_groups",
     "data_columnnames", "projection",
-    "num_categories", "is_ordinal_variable",
+    "num_categories", "category_levels", "is_ordinal_variable",
     "group", "pairwise_scaling_factors",
     "model_type"
   )

--- a/tests/testthat/test-predict-recode-map.R
+++ b/tests/testthat/test-predict-recode-map.R
@@ -53,3 +53,34 @@ test_that("continuous/non-ordinal columns are left unchanged", {
   expect_equal(out[, 1], c(1.5, 2.5, 3.5))
   expect_equal(out[, 2], c(0, 1, 2))
 })
+
+# ------------------------------------------------------------------------------
+# bgmCompare uses a NAMED lookup (names = original values, values = final
+# collapsed categories) which may be many-to-one when cross-group collapsing
+# merged categories.
+# ------------------------------------------------------------------------------
+
+test_that("named lookup maps original values to final categories (bijective)", {
+  lk = c(0L, 1L, 2L)
+  names(lk) = c("1", "3", "5")
+  out = recode(matrix(c(1, 3, 5), ncol = 1), 2, TRUE, category_levels = list(lk))
+  expect_equal(out[, 1], c(0, 1, 2))
+})
+
+test_that("named lookup handles many-to-one (merged categories)", {
+  # original 1 and 3 both map to category 0 (merged); 5 -> 1.
+  lk = c(0L, 0L, 1L)
+  names(lk) = c("1", "3", "5")
+  out = recode(matrix(c(1, 3, 5, 1, 5), ncol = 1), 1, TRUE, category_levels = list(lk))
+  expect_equal(out[, 1], c(0, 0, 1, 0, 1))
+})
+
+test_that("named lookup warns + NA on values absent from the lookup", {
+  lk = c(0L, 1L)
+  names(lk) = c("1", "2")
+  expect_warning(
+    out <- recode(matrix(c(1, 9), ncol = 1), 1, TRUE, category_levels = list(lk)),
+    "not\\s+observed in the training data"
+  )
+  expect_true(is.na(out[2, 1]))
+})


### PR DESCRIPTION
The bgmCompare analogue of #114 (OMRF predict recoding).

## The bug

`predict.bgmCompare()` recoded `newdata` by subtracting each column's minimum, which does not reproduce how `bgmCompare()` recoded the training data: `reformat_ordinal_data()` (per-variable 0-based) followed by `collapse_categories_across_groups()` (drop categories not observed in all groups, then renumber). So predicted probabilities were computed against mismatched category indices whenever training categories were non-contiguous, collapsed across groups, or `newdata` spanned a different range.

## Why a lookup (not the OMRF approach)

Cross-group collapsing can **merge** categories, so the original→final category map is **many-to-one** in general. The position-based (`match`) recoding used for OMRF can't express that.

`build_spec_compare()` now builds, per ordinal variable, a **named lookup** (names = original values, values = final collapsed category) by pairing the pre-recode and post-collapse data, stores it on the spec, and exposes it via `build_arguments_compare()`. `predict.bgmCompare()` passes it to `recode_data_for_prediction()`, generalised to accept **either** form:

- unnamed sorted original values (bgm/OMRF): recoded category = `position - 1`;
- named lookup (bgmCompare): direct original → final category, many-to-one.

Newdata values absent from the lookup → `NA` with a warning; fits without a map fall back to the legacy subtract-minimum behaviour.

## Tests

New regression tests for the named-lookup recoding (bijective, many-to-one merged, out-of-range warning) plus the existing OMRF cases. Full suite green (single-core). The compare `arguments` gains a `category_levels` field (structure test updated) — relevant to the deferred compliance-fixture redesign.

## Follow-up

This closes the predict-recode bug for **both** model families. The remaining item is **original-scale category labels for mixed-MRF + bgmCompare** in `summary`/`print` (extending #115's `ordinal_threshold_labels()`); the compare label sites can now use this lookup.