### PR TITLE
feat(output): original-scale category labels for mixed-MRF thresholds

### DIFF
--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -822,6 +822,9 @@ build_spec_mixed_mrf = function(x, data_columnnames, num_variables,
       num_continuous = as.integer(q),
       num_cases = as.integer(nrow(x_disc_recoded)),
       num_categories = as.integer(num_categories),
+      # Recode map (sorted original values per discrete variable) for original-
+      # scale threshold labels; NULL for Blume-Capel.
+      category_levels = ord$category_levels,
       discrete_indices = disc_idx,
       continuous_indices = cont_idx
     ),
@@ -1320,6 +1323,7 @@ build_arguments_mixed_mrf = function(spec) {
     nuts_max_depth               = spec$sampler$nuts_max_depth,
     num_chains                   = spec$sampler$chains,
     num_categories               = spec$data$num_categories,
+    category_levels              = spec$data$category_levels,
     data_columnnames             = spec$data$data_columnnames,
     data_columnnames_discrete    = spec$data$data_columnnames_discrete,
     data_columnnames_continuous  = spec$data$data_columnnames_continuous,

--- a/R/build_output.R
+++ b/R/build_output.R
@@ -633,7 +633,10 @@ build_output_mixed_mrf = function(spec, raw) {
   names_main = character()
   for(si in seq_len(p)) {
     if(is_ordinal[si]) {
-      cats = seq_len(num_categories[si])
+      cats = ordinal_threshold_labels(
+        num_categories[si],
+        if(!is.null(d$category_levels)) d$category_levels[[si]] else NULL
+      )
       names_main = c(names_main, paste0(disc_names[si], " (", cats, ")"))
     } else {
       names_main = c(

--- a/tests/testthat/test-original-scale-labels.R
+++ b/tests/testthat/test-original-scale-labels.R
@@ -35,3 +35,19 @@ test_that("summary labels ordinal thresholds in the original category scale", {
   # Variable B is 0-based, so labels are unchanged.
   expect_true(all(c("B (1)", "B (2)") %in% rn))
 })
+
+test_that("mixed-MRF discrete thresholds use the original category scale", {
+  set.seed(1)
+  n = 80L
+  x = cbind(sample(c(1, 3, 5), n, TRUE), rnorm(n))
+  colnames(x) = c("D", "C")
+  fit = bgm(x,
+    variable_type = c("ordinal", "continuous"),
+    iter = 80, warmup = 80, chains = 1, display_progress = "none"
+  )
+  rn = rownames(summary(fit)$main)
+  # Discrete variable D's thresholds carry the original values 3 and 5;
+  # the continuous variable keeps its (mean) label.
+  expect_true(all(c("D (3)", "D (5)") %in% rn))
+  expect_true("C (mean)" %in% rn)
+})


### PR DESCRIPTION
Extends #115 (OMRF original-scale threshold labels) to **mixed-MRF** models.

## What

Discrete category thresholds in `summary()`/`print()` now use the original category values instead of the rescored indices:

```
# mixed model, discrete variable observed at {1,3,5}
before:  D (1)   D (2)   C (mean)
after:   D (3)   D (5)   C (mean)
```

Continuous variables keep their `(mean)`/`(precision)` labels; 0-based discrete data is unchanged.

## How

`build_spec_mixed_mrf()` recodes discrete variables with `reformat_ordinal_data()` (the same path as OMRF), so `category_levels` is already produced. It is now stored on the spec, exposed via `build_arguments_mixed_mrf()`, and consumed by the shared `ordinal_threshold_labels()` helper (added in #115) in the mixed main-effect naming.

## Scope

OMRF (#115) and mixed-MRF (this) are done. **bgmCompare** label sites still show rescored indices — that's the remaining follow-up; it consumes the bgmCompare recode map from #116.

## Tests

End-to-end mixed-MRF label test (discrete `{1,3,5}` → `D (3)`, `D (5)`; continuous → `C (mean)`). Full suite green (single-core). The mixed `arguments` gains a `category_levels` field.