### PR TITLE
feat(output): original-scale category labels for bgmCompare thresholds

### DIFF
--- a/R/build_output.R
+++ b/R/build_output.R
@@ -248,17 +248,36 @@ build_output = function(spec, raw) {
 # ordinal_threshold_labels()
 # ------------------------------------------------------------------------------
 # Labels for an ordinal variable's category thresholds (recoded categories
-# 1..K). When the fit carries a recode map (category_levels_v: the sorted
-# original training values, length K+1 with position 1 the reference category),
-# the original category values for categories 1..K are returned so output is in
-# the user's scale. Otherwise the rescored indices 1..K are used (older fits).
+# 1..K), in the user's original category scale when the fit carries a recode
+# map (category_levels_v). Two map forms are supported:
+#
+#   * OMRF / mixed-MRF: an UNNAMED vector of the sorted original training
+#     values, length K+1 with position 1 the reference category. The originals
+#     for categories 1..K are returned directly.
+#   * bgmCompare: a NAMED lookup, names = original values, values = the final
+#     0-based category. Cross-group collapse makes this many-to-one, so for
+#     each final category 1..K the contributing original values are joined with
+#     "/" (e.g. "4/5" when originals 4 and 5 merged into one category).
+#
+# Without a usable map (NULL, or an unnamed vector whose length != K+1) the
+# rescored indices 1..K are returned, matching older fits.
 ordinal_threshold_labels = function(num_categories_v, category_levels_v = NULL) {
-  if(!is.null(category_levels_v) &&
-    length(category_levels_v) == num_categories_v + 1L) {
-    category_levels_v[-1L] # drop the reference category (recoded 0)
-  } else {
-    seq_len(num_categories_v)
+  if(is.null(category_levels_v)) {
+    return(seq_len(num_categories_v))
   }
+  if(!is.null(names(category_levels_v))) {
+    finals = as.integer(category_levels_v)
+    originals = names(category_levels_v)
+    return(vapply(
+      seq_len(num_categories_v),
+      function(k) paste(originals[finals == k], collapse = "/"),
+      character(1)
+    ))
+  }
+  if(length(category_levels_v) == num_categories_v + 1L) {
+    return(category_levels_v[-1L]) # drop the reference category (recoded 0)
+  }
+  seq_len(num_categories_v)
 }
 
 
@@ -877,7 +896,8 @@ build_output_compare = function(spec, raw) {
     num_categories      = num_categories,
     is_ordinal_variable = is_ordinal_variable,
     num_variables       = num_variables,
-    num_groups          = num_groups
+    num_groups          = num_groups,
+    category_levels     = d$category_levels
   )
 
   # --- Lazy MCMC diagnostics cache --------------------------------------------
@@ -1097,6 +1117,9 @@ build_output_compare = function(spec, raw) {
 # @param is_ordinal_variable  Logical vector: TRUE = ordinal, FALSE = BC.
 # @param num_variables  Integer: number of variables.
 # @param num_groups  Integer: number of groups.
+# @param category_levels  Optional list of per-variable recode maps (named
+#   lookups from original category value to final 0-based category). When
+#   supplied, ordinal threshold names use the original category scale.
 #
 # Returns: named list with main_baseline, main_diff, pairwise_baseline,
 #   pairwise_diff, and indicators character vectors.
@@ -1106,13 +1129,17 @@ generate_param_names_bgmCompare = function(
   num_categories,
   is_ordinal_variable,
   num_variables,
-  num_groups
+  num_groups,
+  category_levels = NULL
 ) {
   # --- main baselines
   names_main_baseline = character()
   for(v in seq_len(num_variables)) {
     if(is_ordinal_variable[v]) {
-      cats = seq_len(num_categories[v])
+      cats = ordinal_threshold_labels(
+        num_categories[v],
+        if(!is.null(category_levels)) category_levels[[v]] else NULL
+      )
       names_main_baseline = c(
         names_main_baseline,
         paste0(data_columnnames[v], " (", cats, ")")
@@ -1131,7 +1158,10 @@ generate_param_names_bgmCompare = function(
   for(g in 2:num_groups) {
     for(v in seq_len(num_variables)) {
       if(is_ordinal_variable[v]) {
-        cats = seq_len(num_categories[v])
+        cats = ordinal_threshold_labels(
+          num_categories[v],
+          if(!is.null(category_levels)) category_levels[[v]] else NULL
+        )
         names_main_diff = c(
           names_main_diff,
           paste0(data_columnnames[v], " (diff", g - 1, "; ", cats, ")")

--- a/tests/testthat/test-original-scale-labels.R
+++ b/tests/testthat/test-original-scale-labels.R
@@ -16,8 +16,47 @@ test_that("ordinal_threshold_labels uses original category values when available
 test_that("ordinal_threshold_labels falls back to rescored indices without a map", {
   f = bgms:::ordinal_threshold_labels
   expect_equal(f(2, NULL), seq_len(2))
-  # Defensive: a map whose length does not match K+1 falls back, too.
+  # Defensive: an unnamed map whose length does not match K+1 falls back, too.
   expect_equal(f(2, c(1, 3)), seq_len(2))
+})
+
+test_that("ordinal_threshold_labels handles the bgmCompare named lookup", {
+  f = bgms:::ordinal_threshold_labels
+  # bgmCompare carries a NAMED lookup: names = original values, values = final
+  # 0-based category (many-to-one when categories collapse across groups).
+  # Bijective: originals {1,3,5} -> finals {0,1,2}; cats 1,2 are original 3,5.
+  bijective = c("1" = 0L, "3" = 1L, "5" = 2L)
+  expect_equal(f(2, bijective), c("3", "5"))
+  # Collapsed: originals {1,2,3,4,5}, with 4 and 5 merged into final 3.
+  # cat 3 spans both original values, joined with "/".
+  collapsed = c("1" = 0L, "2" = 1L, "3" = 2L, "4" = 3L, "5" = 3L)
+  expect_equal(f(3, collapsed), c("2", "3", "4/5"))
+})
+
+test_that("bgmCompare summary labels ordinal thresholds in the original scale", {
+  set.seed(1)
+  n = 30L
+  mk = function() {
+    cbind(
+      sample(c(1, 3, 5), n, TRUE),
+      sample(0:2, n, TRUE)
+    )
+  }
+  x = rbind(mk(), mk())
+  colnames(x) = c("A", "B")
+  group = rep(1:2, each = n)
+  fit = bgmCompare(
+    x = x, group_indicator = group,
+    difference_selection = FALSE,
+    iter = 50, warmup = 50, chains = 1, display_progress = "none"
+  )
+  rn = summary(fit)$main$parameter
+  # Variable A's baseline thresholds carry the original values 3 and 5.
+  expect_true(all(c("A (3)", "A (5)") %in% rn))
+  # Variable B is already 0-based, so its labels are unchanged.
+  expect_true(all(c("B (1)", "B (2)") %in% rn))
+  # Group-difference labels carry the original scale too.
+  expect_true(all(c("A (diff1; 3)", "A (diff1; 5)") %in% summary(fit)$main_diff$parameter))
 })
 
 test_that("summary labels ordinal thresholds in the original category scale", {


### PR DESCRIPTION
Completes the original-scale ordinal label work (after #115 OMRF and #117 mixed-MRF) for the bgmCompare model family.

## What

- `ordinal_threshold_labels()` now also accepts the bgmCompare **named** recode lookup (`names` = original category value, value = final 0-based category). Cross-group category collapse makes the map many-to-one, so each final category's label joins its contributing original values with `/` (e.g. `4/5` when originals 4 and 5 merged into one category). The unnamed OMRF/mixed sorted-original path is unchanged.
- `generate_param_names_bgmCompare()` takes the per-variable `category_levels` and uses it for both main-baseline and group-difference ordinal threshold names. Shared-column pairwise matrices stay positional, matching OMRF.

## Result

```
summary(fit)$main$parameter       -> "A (3)" "A (5)" "B (1)" "B (2)"
summary(fit)$main_diff$parameter  -> "A (diff1; 3)" "A (diff1; 5)" ...
```

## Tests

- Unit tests for the named lookup: bijective (`{1,3,5} -> 3,5`) and collapsed (`{1,2,3,4,5}` with `4/5` merged).
- End-to-end bgmCompare summary asserts original-scale labels on baseline and difference parameter columns.
- `test-bgmCompare.R` unaffected (one CRAN-only skip).
