### PR TITLE
fix(diagnostics): integer matrix contract + bracketed fallback labels

### DIFF
--- a/R/mcmc_summary.R
+++ b/R/mcmc_summary.R
@@ -573,7 +573,7 @@ summarize_manual_compare = function(fit_or_array,
   result = cbind(mean = means, mcse = mcse, sd = sds, n_eff = ess, Rhat = rhat)
 
   if(is.null(param_names)) {
-    data.frame(parameter = paste0("param [", seq_len(nparam)), result, check.names = FALSE)
+    data.frame(parameter = paste0("param [", seq_len(nparam), "]"), result, check.names = FALSE)
   } else {
     data.frame(parameter = param_names, result, check.names = FALSE)
   }

--- a/R/nuts_diagnostics.R
+++ b/R/nuts_diagnostics.R
@@ -129,17 +129,20 @@ summarize_nuts_diagnostics = function(out, nuts_max_depth = 10, verbose = TRUE) 
     stop("No NUTS diagnostics found in output.")
   }
 
-  # Combine fields into matrices (chains x iterations)
-  combine_diag = function(field) {
-    do.call(rbind, lapply(nuts_chains, function(chain) as.numeric(chain[[field]])))
+  # Combine fields into matrices (chains x iterations). Count fields
+  # (treedepth, divergence flags) are integer per the return contract;
+  # energy and acceptance probabilities are real-valued.
+  combine_diag = function(field, integer = FALSE) {
+    coerce = if(integer) as.integer else as.numeric
+    do.call(rbind, lapply(nuts_chains, function(chain) coerce(chain[[field]])))
   }
 
-  treedepth_mat = combine_diag("treedepth__")
-  divergent_mat = combine_diag("divergent__")
+  treedepth_mat = combine_diag("treedepth__", integer = TRUE)
+  divergent_mat = combine_diag("divergent__", integer = TRUE)
   energy_mat = combine_diag("energy__")
 
   non_reversible_mat = if("non_reversible__" %in% names(nuts_chains[[1]])) {
-    combine_diag("non_reversible__")
+    combine_diag("non_reversible__", integer = TRUE)
   } else {
     matrix(0L, nrow = nrow(divergent_mat), ncol = ncol(divergent_mat))
   }

--- a/tests/testthat/test-mcmc-diagnostics.R
+++ b/tests/testthat/test-mcmc-diagnostics.R
@@ -462,3 +462,39 @@ test_that("NaN in one indicator parameter does not corrupt others", {
   expect_true(is.finite(result[1, "n_eff_mixt"]))
   expect_true(all(is.na(result[2, ]))) # bad parameter
 })
+
+
+# ---- NUTS diagnostics return-type contract --------------------------------- #
+
+test_that("summarize_nuts_diagnostics honors the integer matrix contract", {
+  mk_chain = function() {
+    list(
+      treedepth__ = c(2, 3, 2, 4),
+      divergent__ = c(0, 0, 1, 0),
+      energy__ = c(1.2, 0.8, 1.5, 0.9),
+      non_reversible__ = c(0, 1, 0, 0),
+      accept_prob__ = c(0.9, 0.8, 0.95, 0.7)
+    )
+  }
+  res = bgms:::summarize_nuts_diagnostics(
+    list(mk_chain(), mk_chain()),
+    nuts_max_depth = 4, verbose = FALSE
+  )
+  # Count fields are integer matrices; real-valued fields are double.
+  expect_true(is.integer(res$treedepth))
+  expect_true(is.integer(res$divergent))
+  expect_true(is.integer(res$non_reversible))
+  expect_true(is.double(res$energy))
+  expect_true(is.double(res$accept_prob))
+  # Exact integer tree-depth comparison: depth 4 hit once per chain.
+  expect_equal(res$summary$max_tree_depth_hits, 2L)
+})
+
+
+# ---- Compare fallback parameter labels ------------------------------------- #
+
+test_that("summarize_manual_compare brackets fallback parameter labels", {
+  arr = array(rnorm(5 * 2 * 3), dim = c(5, 2, 3))
+  res = bgms:::summarize_manual_compare(arr, "main_samples", param_names = NULL)
+  expect_equal(res$parameter, c("param [1]", "param [2]", "param [3]"))
+})


### PR DESCRIPTION
Two LOW-risk cosmetic fixes from the cleanup catalog (section A), bundled.

- **summarize_nuts_diagnostics()** — `combine_diag()` coerced every field to `double`, violating the documented integer-matrix contract for the treedepth / divergence / non-reversible count fields (and leaving the tree-depth-hit count as a float equality). Now coerces count fields to integer; energy and acceptance probabilities stay double.
- **summarize_manual_compare()** — the NULL-`param_names` fallback built `"param [k"` with no closing bracket. Added it. (Unreachable in the compare path, which always passes names, but the fallback is now correct.)

## Tests
- Integer-contract test: `is.integer()` on treedepth/divergent/non_reversible, `is.double()` on energy/accept_prob, exact tree-depth-hit count.
- Bracketed-label test: fallback labels are `param [1]`, `param [2]`, ...
