### PR TITLE
refactor(output): de-duplicate build_output / mcmc_summary blocks

### DIFF
--- a/R/build_output.R
+++ b/R/build_output.R
@@ -200,6 +200,31 @@ build_raw_samples_list = function(raw, edge_selection, edge_prior,
 
 
 # ------------------------------------------------------------------
+# attach_diagnostic_traces
+# ------------------------------------------------------------------
+# Copy NUTS / adaptive-Metropolis diagnostic traces from a raw C++
+# chain onto the normalized chain list `res`, applying the trailing
+# "__" naming convention expected by summarize_nuts_diagnostics() and
+# summarize_am_diagnostics(). Each trace is attached only when present
+# on the raw chain. Returns `res` with the traces attached.
+#
+# @param res    Normalized chain list under construction.
+# @param chain  Raw per-chain C++ output.
+#
+# Returns: `res`, with any available diagnostic traces attached.
+# ------------------------------------------------------------------
+attach_diagnostic_traces = function(res, chain) {
+  if(!is.null(chain$treedepth)) res[["treedepth__"]] = chain$treedepth
+  if(!is.null(chain$divergent)) res[["divergent__"]] = chain$divergent
+  if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
+  if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
+  if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
+  if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
+  res
+}
+
+
+# ------------------------------------------------------------------
 # needs_easybgm_s3_compat
 # ------------------------------------------------------------------
 # Returns TRUE when easybgm is loaded at a version that overwrites
@@ -320,13 +345,7 @@ build_output_bgm = function(spec, raw) {
       if(!is.null(chain$allocation_samples)) {
         res$allocations = t(chain$allocation_samples)
       }
-      if(!is.null(chain$treedepth)) res[["treedepth__"]] = chain$treedepth
-      if(!is.null(chain$divergent)) res[["divergent__"]] = chain$divergent
-      if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
-      if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
-      if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
-      if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
-      res
+      attach_diagnostic_traces(res, chain)
     })
   } else {
     # OMRF: the first num_thresholds params are main effects, the rest are
@@ -348,13 +367,7 @@ build_output_bgm = function(spec, raw) {
       if(!is.null(chain$allocation_samples)) {
         res$allocations = t(chain$allocation_samples)
       }
-      if(!is.null(chain$treedepth)) res[["treedepth__"]] = chain$treedepth
-      if(!is.null(chain$divergent)) res[["divergent__"]] = chain$divergent
-      if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
-      if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
-      if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
-      if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
-      res
+      attach_diagnostic_traces(res, chain)
     })
   }
 
@@ -619,13 +632,7 @@ build_output_mixed_mrf = function(spec, raw) {
     if(!is.null(chain$allocation_samples)) {
       res$allocations = t(chain$allocation_samples)
     }
-    if(!is.null(chain$treedepth)) res[["treedepth__"]] = chain$treedepth
-    if(!is.null(chain$divergent)) res[["divergent__"]] = chain$divergent
-    if(!is.null(chain$non_reversible)) res[["non_reversible__"]] = chain$non_reversible
-    if(!is.null(chain$energy)) res[["energy__"]] = chain$energy
-    if(!is.null(chain$accept_prob)) res[["accept_prob__"]] = chain$accept_prob
-    if(!is.null(chain$am_accept_prob)) res[["am_accept_prob__"]] = chain$am_accept_prob
-    res
+    attach_diagnostic_traces(res, chain)
   })
 
   # --- Parameter names --------------------------------------------------------

--- a/R/build_output.R
+++ b/R/build_output.R
@@ -264,6 +264,34 @@ attach_sampler_diagnostics = function(results, raw, update_method,
 
 
 # ------------------------------------------------------------------
+# attach_sbm_posterior_summary
+# ------------------------------------------------------------------
+# Attach the Stochastic-Block posterior allocation summary (mean,
+# mode, and block count) to a results list. All three output builders
+# call posterior_summary_SBM() identically; they differ only in the
+# `arguments` they pass (bgm/mixed forward build_arguments(spec);
+# compare hand-builds list(dirichlet_alpha, lambda)), so that is an
+# argument here.
+#
+# @param results    Results list under construction.
+# @param raw        Normalized per-chain list (each carrying $allocations).
+# @param arguments  Argument list forwarded to posterior_summary_SBM().
+#
+# Returns: `results`, with the three SBM allocation fields attached.
+# ------------------------------------------------------------------
+attach_sbm_posterior_summary = function(results, raw, arguments) {
+  sbm_summary = posterior_summary_SBM(
+    allocations = lapply(raw, `[[`, "allocations"),
+    arguments = arguments
+  )
+  results$posterior_mean_allocations = sbm_summary$allocations_mean
+  results$posterior_mode_allocations = sbm_summary$allocations_mode
+  results$posterior_num_blocks = sbm_summary$blocks
+  results
+}
+
+
+# ------------------------------------------------------------------
 # needs_easybgm_s3_compat
 # ------------------------------------------------------------------
 # Returns TRUE when easybgm is loaded at a version that overwrites
@@ -553,15 +581,7 @@ build_output_bgm = function(spec, raw) {
 
     if(has_sbm) {
       results$posterior_mean_coclustering_matrix = co_occur_matrix
-
-      arguments = build_arguments(spec)
-      sbm_summary = posterior_summary_SBM(
-        allocations = lapply(raw, `[[`, "allocations"),
-        arguments   = arguments
-      )
-      results$posterior_mean_allocations = sbm_summary$allocations_mean
-      results$posterior_mode_allocations = sbm_summary$allocations_mode
-      results$posterior_num_blocks = sbm_summary$blocks
+      results = attach_sbm_posterior_summary(results, raw, build_arguments(spec))
     }
   }
 
@@ -835,15 +855,7 @@ build_output_mixed_mrf = function(spec, raw) {
 
     if(has_sbm) {
       results$posterior_mean_coclustering_matrix = co_occur_matrix
-
-      arguments = build_arguments(spec)
-      sbm_summary = posterior_summary_SBM(
-        allocations = lapply(raw, `[[`, "allocations"),
-        arguments   = arguments
-      )
-      results$posterior_mean_allocations = sbm_summary$allocations_mean
-      results$posterior_mode_allocations = sbm_summary$allocations_mode
-      results$posterior_num_blocks = sbm_summary$blocks
+      results = attach_sbm_posterior_summary(results, raw, build_arguments(spec))
     }
   }
 
@@ -1057,16 +1069,10 @@ build_output_compare = function(spec, raw) {
     results$posterior_summary_pairwise_allocations = sbm_convergence$sbm_summary
     results$posterior_mean_coclustering_matrix = sbm_convergence$co_occur_matrix
 
-    sbm_summary = posterior_summary_SBM(
-      allocations = lapply(raw, `[[`, "allocations"),
-      arguments = list(
-        dirichlet_alpha = p$dirichlet_alpha,
-        lambda          = p$lambda
-      )
+    results = attach_sbm_posterior_summary(
+      results, raw,
+      list(dirichlet_alpha = p$dirichlet_alpha, lambda = p$lambda)
     )
-    results$posterior_mean_allocations = sbm_summary$allocations_mean
-    results$posterior_mode_allocations = sbm_summary$allocations_mode
-    results$posterior_num_blocks = sbm_summary$blocks
   }
 
   # --- raw_samples ------------------------------------------------------------

--- a/R/build_output.R
+++ b/R/build_output.R
@@ -225,6 +225,45 @@ attach_diagnostic_traces = function(res, chain) {
 
 
 # ------------------------------------------------------------------
+# attach_sampler_diagnostics
+# ------------------------------------------------------------------
+# Attach the sampler-specific diagnostics block to a results list:
+# NUTS diagnostics under "nuts", adaptive-Metropolis diagnostics under
+# "adaptive-metropolis", nothing otherwise. The three output builders
+# differ only in the parameter-name vectors they pass to the AM
+# summary, so those are arguments.
+#
+# @param results        Results list under construction.
+# @param raw            Normalized per-chain list.
+# @param update_method  Sampler name from spec$sampler$update_method.
+# @param nuts_max_depth  Max tree depth (for the NUTS summary).
+# @param names_main     Main-effect parameter names (for the AM summary).
+# @param names_pairwise Pairwise parameter names (for the AM summary).
+# @param target_accept  Target acceptance (for the AM summary).
+#
+# Returns: `results`, with $nuts_diag or $am_diag attached as applicable.
+# ------------------------------------------------------------------
+attach_sampler_diagnostics = function(results, raw, update_method,
+                                      nuts_max_depth, names_main,
+                                      names_pairwise, target_accept) {
+  if(update_method == "nuts") {
+    results$nuts_diag = summarize_nuts_diagnostics(
+      raw,
+      nuts_max_depth = nuts_max_depth
+    )
+  } else if(update_method == "adaptive-metropolis") {
+    results$am_diag = summarize_am_diagnostics(
+      raw,
+      names_main = names_main,
+      names_pairwise = names_pairwise,
+      target_accept = target_accept
+    )
+  }
+  results
+}
+
+
+# ------------------------------------------------------------------
 # needs_easybgm_s3_compat
 # ------------------------------------------------------------------
 # Returns TRUE when easybgm is loaded at a version that overwrites
@@ -551,15 +590,12 @@ build_output_bgm = function(spec, raw) {
   }
   results$cache = cache
 
-  # --- NUTS diagnostics -------------------------------------------------------
-  if(s$update_method == "nuts") {
-    results$nuts_diag = summarize_nuts_diagnostics(
-      raw,
-      nuts_max_depth = s$nuts_max_depth
-    )
-  } else if(s$update_method == "adaptive-metropolis") {
-    results$am_diag = summarize_am_diagnostics(raw, names_main = names_main, names_pairwise = edge_names, target_accept = s$target_accept)
-  }
+  # --- Sampler diagnostics ----------------------------------------------------
+  results = attach_sampler_diagnostics(
+    results, raw, s$update_method, s$nuts_max_depth,
+    names_main = names_main, names_pairwise = edge_names,
+    target_accept = s$target_accept
+  )
 
   results$.bgm_spec = spec
   if(needs_easybgm_s3_compat()) {
@@ -833,15 +869,12 @@ build_output_mixed_mrf = function(spec, raw) {
     raw, edge_selection, edge_prior, names_main, edge_names, alloc_names
   )
 
-  # --- NUTS diagnostics -------------------------------------------------------
-  if(s$update_method == "nuts") {
-    results$nuts_diag = summarize_nuts_diagnostics(
-      raw,
-      nuts_max_depth = s$nuts_max_depth
-    )
-  } else if(s$update_method == "adaptive-metropolis") {
-    results$am_diag = summarize_am_diagnostics(raw, names_main = names_main, names_pairwise = edge_names, target_accept = s$target_accept)
-  }
+  # --- Sampler diagnostics ----------------------------------------------------
+  results = attach_sampler_diagnostics(
+    results, raw, s$update_method, s$nuts_max_depth,
+    names_main = names_main, names_pairwise = edge_names,
+    target_accept = s$target_accept
+  )
 
   results$.bgm_spec = spec
   if(needs_easybgm_s3_compat()) {
@@ -1069,20 +1102,13 @@ build_output_compare = function(spec, raw) {
   results$cache = cache
   class(results) = "bgmCompare"
 
-  # --- NUTS diagnostics -------------------------------------------------------
-  if(s$update_method == "nuts") {
-    results$nuts_diag = summarize_nuts_diagnostics(
-      raw,
-      nuts_max_depth = s$nuts_max_depth
-    )
-  } else if(s$update_method == "adaptive-metropolis") {
-    results$am_diag = summarize_am_diagnostics(
-      raw,
-      names_main     = c(names_all$main_baseline, names_all$main_diff),
-      names_pairwise = c(names_all$pairwise_baseline, names_all$pairwise_diff),
-      target_accept  = s$target_accept
-    )
-  }
+  # --- Sampler diagnostics ----------------------------------------------------
+  results = attach_sampler_diagnostics(
+    results, raw, s$update_method, s$nuts_max_depth,
+    names_main = c(names_all$main_baseline, names_all$main_diff),
+    names_pairwise = c(names_all$pairwise_baseline, names_all$pairwise_diff),
+    target_accept = s$target_accept
+  )
 
   results$.bgm_spec = spec
   if(needs_easybgm_s3_compat()) {

--- a/R/mcmc_summary.R
+++ b/R/mcmc_summary.R
@@ -532,20 +532,6 @@ posterior_summary_SBM = function(
 }
 
 
-# Combine MCMC chains for bgmCompare into a 3D array [niter x nchains x nparam]
-combine_chains_compare = function(fit, component) {
-  nchains = length(fit)
-  samples_list = lapply(fit, function(x) x[[component]])
-  niter = nrow(samples_list[[1]])
-  nparam = ncol(samples_list[[1]])
-  array3d = array(NA_real_, dim = c(niter, nchains, nparam))
-  for(i in seq_len(nchains)) {
-    array3d[, i, ] = samples_list[[i]]
-  }
-  array3d
-}
-
-
 summarize_manual_compare = function(fit_or_array,
                                     component = c("main_samples", "pairwise_samples"),
                                     param_names = NULL) {
@@ -555,7 +541,7 @@ summarize_manual_compare = function(fit_or_array,
   if(is.array(fit_or_array)) {
     array3d = fit_or_array
   } else {
-    array3d = combine_chains_compare(fit_or_array, component)
+    array3d = combine_chains(fit_or_array, component)
   }
 
   nparam = dim(array3d)[3]
@@ -581,7 +567,7 @@ summarize_manual_compare = function(fit_or_array,
 
 
 summarize_indicator_compare = function(fit, component = "indicator_samples", param_names = NULL) {
-  array3d = combine_chains_compare(fit, component)
+  array3d = combine_chains(fit, component)
   nparam = dim(array3d)[3]
 
   # Batch indicator ESS + transition counts via C++
@@ -693,8 +679,8 @@ summarize_main_diff_compare = function(
   num_groups,
   param_names = NULL
 ) {
-  main_effect_samples = combine_chains_compare(fit, "main_samples")
-  indicator_samples = combine_chains_compare(fit, "indicator_samples")
+  main_effect_samples = combine_chains(fit, "main_samples")
+  indicator_samples = combine_chains(fit, "indicator_samples")
 
   V = nrow(main_effect_indices)
   num_main = main_effect_indices[V, 2] + 1L # total rows in main-effects matrix
@@ -742,8 +728,8 @@ summarize_pairwise_diff_compare = function(
   num_groups,
   param_names = NULL
 ) {
-  pairwise_effect_samples = combine_chains_compare(fit, "pairwise_samples")
-  indicator_samples = combine_chains_compare(fit, "indicator_samples")
+  pairwise_effect_samples = combine_chains(fit, "pairwise_samples")
+  indicator_samples = combine_chains(fit, "indicator_samples")
 
   V = num_variables
   num_pair = max(pairwise_effect_indices, na.rm = TRUE) + 1L # total rows in pairwise-effects matrix
@@ -804,7 +790,7 @@ summarize_fit_compare = function(
 
 
   # --- main baseline
-  array3d_main = combine_chains_compare(fit, "main_samples")
+  array3d_main = combine_chains(fit, "main_samples")
   num_main = count_main(main_effect_indices)
   main_baseline = summarize_manual_compare(
     array3d_main[, , 1:num_main, drop = FALSE],
@@ -813,7 +799,7 @@ summarize_fit_compare = function(
   )
 
   # --- pairwise baseline
-  array3d_pair = combine_chains_compare(fit, "pairwise_samples")
+  array3d_pair = combine_chains(fit, "pairwise_samples")
   num_pair = count_pairwise(pairwise_effect_indices)
   pairwise_baseline = summarize_manual_compare(
     array3d_pair[, , 1:num_pair, drop = FALSE],


### PR DESCRIPTION
First stage of section B (structural duplication) from the cleanup catalog — the R output-assembly duplication in build_output.R and mcmc_summary.R. **Behavior-preserving**: every commit verified byte-identical against `main` (see Verification).

## Commits
1. **attach_diagnostic_traces** — the NUTS/AM diagnostic-trace rename block (`treedepth__`, `divergent__`, ...) was copy-pasted across the GGM and OMRF branches of `build_output_bgm` and in `build_output_mixed_mrf`. One helper. (compare's distinct, diagnostic-free normalization is left untouched — whether compare should surface NUTS/AM diagnostics is a separate behavior question, not a dedup.)
2. **drop combine_chains_compare** — was byte-identical to `combine_chains`; removed, 8 call sites repointed.
3. **attach_sampler_diagnostics** — the NUTS/AM diagnostics tail block ×3 → one helper. NUTS branch identical; AM branch differs only in the parameter-name vectors (compare uses combined baseline+diff names), passed as args.
4. **attach_sbm_posterior_summary** — the `posterior_summary_SBM` call + its 3 allocation-field assignments, duplicated ×3. One helper; the only per-builder difference (the `arguments` forwarded) is a parameter. The divergent co-clustering op is left inline.

## Verification
Fit identical seeded models on this branch and on `main`, then diff full outputs (raw samples, summaries, NUTS/AM diagnostics, posterior means, SBM allocation summaries). **All 9 cells byte-identical**: GGM-NUTS, GGM-AM, OMRF-AM, mixed-AM, compare, and the four Stochastic-Block paths (GGM/OMRF/mixed/compare SBM) — the latter exercising both the `build_arguments(spec)` and hand-built-args branches of helper 4.

## Scope
Covers all build_output.R / mcmc_summary.R items in section B. Remaining R dedup (simulate_predict.R, extractor_functions.R, bgm_spec.R builders, validators) and the C++ sampler-math dedup are separate stages.
