### PR TITLE
refactor(predict/extractors): de-duplicate simulate_predict + extractor blocks

### DIFF
--- a/R/bgmcompare-methods.r
+++ b/R/bgmcompare-methods.r
@@ -273,81 +273,17 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
 #' @export
 coef.bgmCompare = function(object, ...) {
   args = extract_arguments(object)
+  raw = get_raw_samples(object)
 
   var_names = args$data_columnnames
-  num_categories = as.integer(args$num_categories)
-  is_ordinal = as.logical(args$is_ordinal_variable)
-  num_groups = as.integer(args$num_groups)
   num_variables = as.integer(args$num_variables)
-  projection = args$projection # [num_groups x (num_groups-1)]
 
-  # ============================================================
-  # ---- main effects ----
-  raw = get_raw_samples(object)
-  array3d_main = samples_to_array3d(raw$main)
-  stopifnot(!is.null(array3d_main))
-  mean_main = apply(array3d_main, 3, mean)
-
-  stopifnot(length(mean_main) %% num_groups == 0L)
-  num_main = as.integer(length(mean_main) / num_groups)
-
-  main_mat = matrix(mean_main, nrow = num_main, ncol = num_groups, byrow = FALSE)
-
-  # row names in sampler row order
-  rownames(main_mat) = unlist(lapply(seq_len(num_variables), function(v) {
-    if(is_ordinal[v]) {
-      paste0(var_names[v], "(c", seq_len(num_categories[v]), ")")
-    } else {
-      c(
-        paste0(var_names[v], "(linear)"),
-        paste0(var_names[v], "(quadratic)")
-      )
-    }
-  }))
-  colnames(main_mat) = c("baseline", paste0("diff", seq_len(num_groups - 1L)))
-
-  # group-specific main effects: baseline + P %*% diffs
-  main_effects_groups = matrix(NA_real_, nrow = num_main, ncol = num_groups)
-  for(r in seq_len(num_main)) {
-    baseline = main_mat[r, 1]
-    diffs = main_mat[r, -1, drop = TRUE]
-    main_effects_groups[r, ] = baseline + as.vector(projection %*% diffs)
-  }
-  rownames(main_effects_groups) = rownames(main_mat)
-  colnames(main_effects_groups) = paste0("group", seq_len(num_groups))
-
-  # ============================================================
-  # ---- pairwise effects ----
-  array3d_pair = samples_to_array3d(raw$pairwise)
-  stopifnot(!is.null(array3d_pair))
-  mean_pair = apply(array3d_pair, 3, mean)
-
-  stopifnot(length(mean_pair) %% num_groups == 0L)
-  num_pair = as.integer(length(mean_pair) / num_groups)
-
-  pairwise_mat = matrix(mean_pair, nrow = num_pair, ncol = num_groups, byrow = FALSE)
-
-  # row names in sampler row order (upper-tri i<j)
-  pair_names = character()
-  if(num_variables >= 2L) {
-    for(i in 1L:(num_variables - 1L)) {
-      for(j in (i + 1L):num_variables) {
-        pair_names = c(pair_names, paste0(var_names[i], "-", var_names[j]))
-      }
-    }
-  }
-  rownames(pairwise_mat) = pair_names
-  colnames(pairwise_mat) = c("baseline", paste0("diff", seq_len(num_groups - 1L)))
-
-  # group-specific pairwise effects
-  pairwise_effects_groups = matrix(NA_real_, nrow = num_pair, ncol = num_groups)
-  for(r in seq_len(num_pair)) {
-    baseline = pairwise_mat[r, 1]
-    diffs = pairwise_mat[r, -1, drop = TRUE]
-    pairwise_effects_groups[r, ] = baseline + as.vector(projection %*% diffs)
-  }
-  rownames(pairwise_effects_groups) = rownames(pairwise_mat)
-  colnames(pairwise_effects_groups) = paste0("group", seq_len(num_groups))
+  # ---- baseline + group-specific main and pairwise effects ----
+  gp = .compute_group_param_matrices(args, raw)
+  main_mat = gp$main_mat
+  pairwise_mat = gp$pairwise_mat
+  main_effects_groups = gp$main_effects_groups
+  pairwise_effects_groups = gp$pairwise_effects_groups
 
   # ============================================================
   # ---- indicators (present only if selection was used) ----

--- a/R/bgmcompare-methods.r
+++ b/R/bgmcompare-methods.r
@@ -281,28 +281,10 @@ coef.bgmCompare = function(object, ...) {
   num_variables = as.integer(args$num_variables)
   projection = args$projection # [num_groups x (num_groups-1)]
 
-  # ---- helper: combine chains into [iter, chain, param], robust to vectors/1-col
-  to_array3d = function(xlist) {
-    if(is.null(xlist)) {
-      return(NULL)
-    }
-    stopifnot(length(xlist) >= 1)
-    mats = lapply(xlist, function(x) {
-      m = as.matrix(x)
-      if(is.null(dim(m))) m = matrix(m, ncol = 1L)
-      m
-    })
-    niter = nrow(mats[[1]])
-    nparam = ncol(mats[[1]])
-    arr = array(NA_real_, dim = c(niter, length(mats), nparam))
-    for(c in seq_along(mats)) arr[, c, ] = mats[[c]]
-    arr
-  }
-
   # ============================================================
   # ---- main effects ----
   raw = get_raw_samples(object)
-  array3d_main = to_array3d(raw$main)
+  array3d_main = samples_to_array3d(raw$main)
   stopifnot(!is.null(array3d_main))
   mean_main = apply(array3d_main, 3, mean)
 
@@ -336,7 +318,7 @@ coef.bgmCompare = function(object, ...) {
 
   # ============================================================
   # ---- pairwise effects ----
-  array3d_pair = to_array3d(raw$pairwise)
+  array3d_pair = samples_to_array3d(raw$pairwise)
   stopifnot(!is.null(array3d_pair))
   mean_pair = apply(array3d_pair, 3, mean)
 
@@ -370,7 +352,7 @@ coef.bgmCompare = function(object, ...) {
   # ============================================================
   # ---- indicators (present only if selection was used) ----
   indicators = NULL
-  array3d_ind = to_array3d(raw$indicator)
+  array3d_ind = samples_to_array3d(raw$indicator)
   if(!is.null(array3d_ind)) {
     mean_ind = apply(array3d_ind, 3, mean)
 

--- a/R/extractor_functions.R
+++ b/R/extractor_functions.R
@@ -2,6 +2,39 @@
 # Extractor Functions - S3 Generics and Methods
 # ==============================================================================
 
+
+# ------------------------------------------------------------------------------
+# samples_to_array3d()
+# ------------------------------------------------------------------------------
+# Stack a per-chain list of [iter x param] sample matrices into an
+# [iter x chain x param] array. Returns NULL for a NULL input (e.g. absent
+# indicator samples) and coerces any non-matrix element to a one-column
+# matrix. Several bgmCompare extractors defined this as a local closure; the
+# variants had drifted (only some handled NULL / vector inputs), so this is
+# the single hardened version.
+#
+# @param xlist  List of per-chain matrices, or NULL.
+#
+# Returns: [iter x chain x param] numeric array, or NULL.
+# ------------------------------------------------------------------------------
+samples_to_array3d = function(xlist) {
+  if(is.null(xlist)) {
+    return(NULL)
+  }
+  stopifnot(length(xlist) >= 1)
+  mats = lapply(xlist, function(x) {
+    m = as.matrix(x)
+    if(is.null(dim(m))) m = matrix(m, ncol = 1L)
+    m
+  })
+  niter = nrow(mats[[1]])
+  nparam = ncol(mats[[1]])
+  arr = array(NA_real_, dim = c(niter, length(mats), nparam))
+  for(c in seq_along(mats)) arr[, c, ] = mats[[c]]
+  arr
+}
+
+
 #' Extract Model Arguments
 #'
 #' @description
@@ -298,21 +331,10 @@ extract_posterior_inclusion_probabilities.bgmCompare = function(bgms_object) {
   # Handle legacy field name (no_variables -> num_variables in 0.1.6.0)
   num_variables = as.integer(arguments$num_variables %||% arguments$no_variables)
 
-  # ---- helper: combine chains into [iter, chain, param]
-  to_array3d = function(xlist) {
-    stopifnot(length(xlist) >= 1)
-    mats = lapply(xlist, as.matrix)
-    niter = nrow(mats[[1]])
-    nparam = ncol(mats[[1]])
-    arr = array(NA_real_, dim = c(niter, length(mats), nparam))
-    for(c in seq_along(mats)) arr[, c, ] = mats[[c]]
-    arr
-  }
-
   # Current format (0.1.6.0+)
   raw = get_raw_samples(bgms_object)
   if(!is.null(raw$indicator)) {
-    array3d_ind = to_array3d(raw$indicator)
+    array3d_ind = samples_to_array3d(raw$indicator)
     mean_ind = apply(array3d_ind, 3, mean)
 
     # reconstruct VxV matrix using the sampler's interleaved order:
@@ -749,21 +771,10 @@ extract_group_params.bgmCompare = function(bgms_object) {
   num_variables = as.integer(arguments$num_variables)
   projection = arguments$projection # [num_groups x (num_groups-1)]
 
-  # ---- helper: combine chains into [iter, chain, param]
-  to_array3d = function(xlist) {
-    stopifnot(length(xlist) >= 1)
-    mats = lapply(xlist, as.matrix)
-    niter = nrow(mats[[1]])
-    nparam = ncol(mats[[1]])
-    arr = array(NA_real_, dim = c(niter, length(mats), nparam))
-    for(c in seq_along(mats)) arr[, c, ] = mats[[c]]
-    arr
-  }
-
   # ============================================================
   # ---- main effects ----
   raw = get_raw_samples(bgms_object)
-  array3d_main = to_array3d(raw$main)
+  array3d_main = samples_to_array3d(raw$main)
   mean_main = apply(array3d_main, 3, mean)
 
   stopifnot(length(mean_main) %% num_groups == 0L)
@@ -796,7 +807,7 @@ extract_group_params.bgmCompare = function(bgms_object) {
 
   # ============================================================
   # ---- pairwise effects ----
-  array3d_pair = to_array3d(raw$pairwise)
+  array3d_pair = samples_to_array3d(raw$pairwise)
   mean_pair = apply(array3d_pair, 3, mean)
 
   stopifnot(length(mean_pair) %% num_groups == 0L)

--- a/R/extractor_functions.R
+++ b/R/extractor_functions.R
@@ -763,7 +763,23 @@ extract_group_params.bgmCompare = function(bgms_object) {
 }
 
 # Helper for current format (0.1.6+)
-.extract_group_params_current = function(bgms_object, arguments) {
+# ------------------------------------------------------------------------------
+# .compute_group_param_matrices()
+# ------------------------------------------------------------------------------
+# Shared bgmCompare group-parameter reconstruction. From the posterior-mean
+# main and pairwise samples, builds the [param x (baseline, diff...)] matrices
+# and the projection-expanded [param x group] effect matrices. Used by both
+# extract_group_params() (group effects only) and coef.bgmCompare() (which also
+# returns the raw baseline+diff matrices alongside the indicators).
+#
+# @param arguments  Fit arguments (data_columnnames, num_categories,
+#   is_ordinal_variable, num_groups, num_variables, projection).
+# @param raw        get_raw_samples() output (uses $main, $pairwise).
+#
+# Returns: list(main_mat, pairwise_mat, main_effects_groups,
+#   pairwise_effects_groups).
+# ------------------------------------------------------------------------------
+.compute_group_param_matrices = function(arguments, raw) {
   var_names = arguments$data_columnnames
   num_categories = as.integer(arguments$num_categories)
   is_ordinal = as.logical(arguments$is_ordinal_variable)
@@ -771,10 +787,9 @@ extract_group_params.bgmCompare = function(bgms_object) {
   num_variables = as.integer(arguments$num_variables)
   projection = arguments$projection # [num_groups x (num_groups-1)]
 
-  # ============================================================
   # ---- main effects ----
-  raw = get_raw_samples(bgms_object)
   array3d_main = samples_to_array3d(raw$main)
+  stopifnot(!is.null(array3d_main))
   mean_main = apply(array3d_main, 3, mean)
 
   stopifnot(length(mean_main) %% num_groups == 0L)
@@ -805,9 +820,9 @@ extract_group_params.bgmCompare = function(bgms_object) {
   rownames(main_effects_groups) = rownames(main_mat)
   colnames(main_effects_groups) = paste0("group", seq_len(num_groups))
 
-  # ============================================================
   # ---- pairwise effects ----
   array3d_pair = samples_to_array3d(raw$pairwise)
+  stopifnot(!is.null(array3d_pair))
   mean_pair = apply(array3d_pair, 3, mean)
 
   stopifnot(length(mean_pair) %% num_groups == 0L)
@@ -837,10 +852,20 @@ extract_group_params.bgmCompare = function(bgms_object) {
   rownames(pairwise_effects_groups) = rownames(pairwise_mat)
   colnames(pairwise_effects_groups) = paste0("group", seq_len(num_groups))
 
-  return(list(
+  list(
+    main_mat = main_mat,
+    pairwise_mat = pairwise_mat,
     main_effects_groups = main_effects_groups,
     pairwise_effects_groups = pairwise_effects_groups
-  ))
+  )
+}
+
+.extract_group_params_current = function(bgms_object, arguments) {
+  gp = .compute_group_param_matrices(arguments, get_raw_samples(bgms_object))
+  list(
+    main_effects_groups = gp$main_effects_groups,
+    pairwise_effects_groups = gp$pairwise_effects_groups
+  )
 }
 
 # Helper for legacy format (0.1.4--0.1.5)

--- a/R/simulate_predict.R
+++ b/R/simulate_predict.R
@@ -923,6 +923,35 @@ simulate.bgmCompare = function(object,
 }
 
 
+# ------------------------------------------------------------------------------
+# average_draws()
+# ------------------------------------------------------------------------------
+# Posterior-sample prediction averaging. Given a per-draw list (one element
+# per posterior draw, each itself a list indexed by predicted variable), stack
+# variable `v`'s per-draw matrices into an n x k x ndraws array and reduce to
+# posterior mean and sd matrices. Each per-draw matrix is n_obs x k, so the
+# array dims are read from the matrix itself (rather than re-deriving n_obs /
+# k at each call site, which had drifted across the three predict methods).
+#
+# @param per_draw_list  List of length ndraws; element i is a per-variable
+#   list of n_obs x k prediction matrices.
+# @param v              Index of the predicted variable to average.
+#
+# Returns: list(mean = n_obs x k matrix, sd = n_obs x k matrix).
+# ------------------------------------------------------------------------------
+average_draws = function(per_draw_list, v) {
+  var_mats = lapply(per_draw_list, `[[`, v)
+  arr = array(
+    unlist(var_mats),
+    dim = c(nrow(var_mats[[1]]), ncol(var_mats[[1]]), length(var_mats))
+  )
+  list(
+    mean = apply(arr, c(1, 2), mean),
+    sd = apply(arr, c(1, 2), sd)
+  )
+}
+
+
 # ==============================================================================
 #   predict.bgms() - S3 Method for Conditional Probability Prediction
 # ==============================================================================
@@ -1233,14 +1262,9 @@ predict.bgms = function(object,
     names(probs_sd) = data_columnnames[predict_vars]
 
     for(v in seq_along(predict_vars)) {
-      # Stack probabilities from all draws: n x categories x ndraws
-      var_probs = lapply(all_probs, `[[`, v)
-      prob_array = array(unlist(var_probs),
-        dim = c(nrow(newdata), ncol(var_probs[[1]]), ndraws)
-      )
-
-      probs[[v]] = apply(prob_array, c(1, 2), mean)
-      probs_sd[[v]] = apply(prob_array, c(1, 2), sd)
+      avg = average_draws(all_probs, v)
+      probs[[v]] = avg$mean
+      probs_sd[[v]] = avg$sd
 
       var_idx = predict_vars[v]
       n_cats = num_categories[var_idx] + 1
@@ -1708,14 +1732,9 @@ predict_bgms_ggm = function(object, newdata, predict_vars, data_columnnames,
     names(result_sd) = data_columnnames[predict_vars]
 
     for(v in seq_along(predict_vars)) {
-      # Stack predictions: n x 2 x ndraws
-      var_preds = lapply(all_preds, `[[`, v)
-      pred_array = array(unlist(var_preds),
-        dim = c(nrow(newdata), 2, ndraws)
-      )
-
-      result[[v]] = apply(pred_array, c(1, 2), mean)
-      result_sd[[v]] = apply(pred_array, c(1, 2), sd)
+      avg = average_draws(all_preds, v)
+      result[[v]] = avg$mean
+      result_sd[[v]] = avg$sd
 
       colnames(result[[v]]) = c("mean", "sd")
       colnames(result_sd[[v]]) = c("mean", "sd")
@@ -2038,14 +2057,9 @@ predict_bgms_mixed = function(object, newdata, predict_vars, arguments,
     names(probs_sd) = data_columnnames[predict_vars]
 
     for(k in seq_len(num_pv)) {
-      # Stack all draws into an array: n x ncol x ndraws
-      var_preds = lapply(all_results, `[[`, k)
-      pred_array = array(unlist(var_preds),
-        dim = c(nrow(var_preds[[1]]), ncol(var_preds[[1]]), ndraws)
-      )
-
-      probs[[k]] = apply(pred_array, c(1, 2), mean)
-      probs_sd[[k]] = apply(pred_array, c(1, 2), sd)
+      avg = average_draws(all_results, k)
+      probs[[k]] = avg$mean
+      probs_sd[[k]] = avg$sd
     }
 
     probs = format_mixed_predictions(

--- a/R/simulate_predict.R
+++ b/R/simulate_predict.R
@@ -880,22 +880,12 @@ simulate.bgmCompare = function(object,
     main_group = group_params$main_effects_groups[, group]
     pairwise_group = group_params$pairwise_effects_groups[, group]
 
-    # Reconstruct threshold matrix
-    max_cats = max(num_categories)
-    main = matrix(NA_real_, nrow = num_variables, ncol = max_cats)
-
-    pos = 1
-    for(v in seq_len(num_variables)) {
-      if(is_ordinal[v]) {
-        k = num_categories[v]
-        main[v, 1:k] = main_group[pos:(pos + k - 1)]
-        pos = pos + k
-      } else {
-        # Blume-Capel: 2 parameters
-        main[v, 1:2] = main_group[pos:(pos + 1)]
-        pos = pos + 2
-      }
-    }
+    # Reconstruct threshold matrix (variable_type is ifelse(is_ordinal,
+    # "ordinal", "blume-capel"), so reconstruct_main's blume-capel branch
+    # matches the per-variable parameter count exactly).
+    main = reconstruct_main(
+      main_group, num_variables, num_categories, variable_type
+    )
 
     # Reconstruct interaction matrix
     pairwise = matrix(0, nrow = num_variables, ncol = num_variables)
@@ -1471,22 +1461,12 @@ predict.bgmCompare = function(object,
     main_group = group_params$main_effects_groups[, group]
     pairwise_group = group_params$pairwise_effects_groups[, group]
 
-    # Reconstruct threshold matrix
-    max_cats = max(num_categories)
-    main = matrix(NA_real_, nrow = num_variables, ncol = max_cats)
-
-    pos = 1
-    for(v in seq_len(num_variables)) {
-      if(is_ordinal[v]) {
-        k = num_categories[v]
-        main[v, 1:k] = main_group[pos:(pos + k - 1)]
-        pos = pos + k
-      } else {
-        # Blume-Capel: 2 parameters
-        main[v, 1:2] = main_group[pos:(pos + 1)]
-        pos = pos + 2
-      }
-    }
+    # Reconstruct threshold matrix (variable_type is ifelse(is_ordinal,
+    # "ordinal", "blume-capel"), so reconstruct_main's blume-capel branch
+    # matches the per-variable parameter count exactly).
+    main = reconstruct_main(
+      main_group, num_variables, num_categories, variable_type
+    )
 
     # Reconstruct interaction matrix
     pairwise = matrix(0, nrow = num_variables, ncol = num_variables)


### PR DESCRIPTION
Second stage of section B (structural duplication) — the R duplication in `simulate_predict.R`, `extractor_functions.R`, and `bgmcompare-methods.r`. **Behavior-preserving**: every commit verified byte-identical against `main` via seeded A/B fits (see Verification).

## Commits
1. **average_draws** — the posterior-sample draw-averaging block (stack per-draw matrices → `n x k x ndraws` array → mean/sd over the draw margin) was duplicated across the OMRF, continuous, and mixed predict methods, with the array dims *drifting* (`nrow(newdata)` / hardcoded `2` vs the matrix's own dims). One helper, dims read from the matrix.
2. **reconstruct_main reuse** — `simulate.bgmCompare` and `predict.bgmCompare` each re-implemented the flat-vector → threshold-matrix reconstruction inline (branching on `is_ordinal`). Since compare sets `variable_type = ifelse(is_ordinal, "ordinal", "blume-capel")`, the existing `reconstruct_main` helper's branch matches exactly; both inline copies now call it.
3. **samples_to_array3d** — the `[iter x chain x param]` stacking closure was defined 3× and had drifted (only `coef`'s copy handled NULL / non-2D input). Promoted the hardened version to one module-level helper.
4. **.compute_group_param_matrices** — `coef.bgmCompare` and `.extract_group_params_current` shared ~80 lines reconstructing the baseline/diff and group-effect matrices. Extracted the shared core; coef additionally returns the raw matrices and the indicator matrix.

## Verification
Seeded A/B fits on this branch vs `main`, full-output diff:
- **predict + simulate** (posterior-sample where relevant): OMRF / GGM / mixed predict, and bgmCompare predict + simulate for both groups — all byte-identical (probabilities + response).
- **extractors**: `coef`, `extract_group_params`, `extract_posterior_inclusion_probabilities` — byte-identical with and without difference selection.
- Affected test files: extractor-functions / methods / predict-recode-map — 2,396 assertions pass, 0 failures (test-methods.R: 2,037, no skips).

## Scope
Clears every `simulate_predict.R` / extractor item in section B. Remaining B: `bgm_spec.R` builders, validator dedup (R), and the C++ sampler-math dedup (needs SBC).