### PR TITLE
fix(bgmCompare): correct deprecation version 0.3.0 -> 0.2.0

### DIFF
--- a/R/bgmCompare.R
+++ b/R/bgmCompare.R
@@ -307,7 +307,7 @@ bgmCompare = function(
 
   if(hasArg(pairwise_scale)) {
     lifecycle::deprecate_warn(
-      "0.3.0", "bgmCompare(pairwise_scale =)",
+      "0.2.0", "bgmCompare(pairwise_scale =)",
       "bgmCompare(interaction_prior =)"
     )
     if(identical(interaction_prior, cauchy_prior(scale = 1))) {
@@ -330,7 +330,7 @@ bgmCompare = function(
 
   if(hasArg(main_alpha) || hasArg(main_beta)) {
     lifecycle::deprecate_warn(
-      "0.3.0", "bgmCompare(main_alpha =)",
+      "0.2.0", "bgmCompare(main_alpha =)",
       "bgmCompare(threshold_prior =)"
     )
     if(identical(threshold_prior, beta_prime_prior(0.5, 0.5))) {
@@ -352,7 +352,7 @@ bgmCompare = function(
   # --- Handle difference_prior: accept both string (deprecated) and object ------
   if(is.character(difference_prior)) {
     lifecycle::deprecate_warn(
-      "0.3.0", "bgmCompare(difference_prior = 'must be a prior object')",
+      "0.2.0", "bgmCompare(difference_prior = 'must be a prior object')",
       "bgmCompare(difference_prior = 'bernoulli_prior()')"
     )
     difference_prior_str = match.arg(difference_prior,
@@ -370,7 +370,7 @@ bgmCompare = function(
   } else {
     if(hasArg(difference_probability)) {
       lifecycle::deprecate_warn(
-        "0.3.0", "bgmCompare(difference_probability =)",
+        "0.2.0", "bgmCompare(difference_probability =)",
         "bgmCompare(difference_prior = 'bernoulli_prior()')"
       )
     }


### PR DESCRIPTION
Four `lifecycle::deprecate_warn()` calls in `bgmCompare()` cited `"0.3.0"` — a version that doesn't exist (current release is **0.2.0.0**) — for the *same* argument renames that `bgm()` correctly dates `"0.2.0"`:

| arg | bgmCompare (was) | bgm (correct) |
|---|---|---|
| `pairwise_scale` | 0.3.0 → 0.2.0 | 0.2.0 |
| `main_alpha` | 0.3.0 → 0.2.0 | 0.2.0 |
| `difference_prior` (string form) | 0.3.0 → 0.2.0 | (edge_prior) 0.2.0 |
| `difference_probability` | 0.3.0 → 0.2.0 | (inclusion_probability) 0.2.0 |

This is the source of the `"...must be a prior object as of bgms 0.3.0"` warning. R-only, parses cleanly; no compile/SBC needed.

Found during the architecture/documentation audit (see `dev/plans/backlog/2026-06-02_architecture-audit.md`, item D1).