### PR TITLE
refactor(priors): drop unused bgms_interaction_prior/bgms_threshold_prior class tags

### DIFF
--- a/R/priors.R
+++ b/R/priors.R
@@ -12,8 +12,9 @@
 #   - bgms_indicator_prior   : prior on inclusion indicators (edge selection,
 #                               difference selection)
 #
-# Legacy subclasses bgms_interaction_prior and bgms_threshold_prior are
-# retained for backward compatibility but are no longer distinct types.
+# Interaction vs threshold is determined by the bgm()/bgmCompare() argument
+# slot (interaction_prior / threshold_prior) and the prior's `family` field,
+# not by the prior's class.
 # ==============================================================================
 
 
@@ -59,7 +60,7 @@ cauchy_prior = function(scale = 1) {
       family = "cauchy",
       hyper.parameters = list(scale = scale)
     ),
-    class = c("bgms_interaction_prior", "bgms_parameter_prior")
+    class = "bgms_parameter_prior"
   )
 }
 
@@ -103,7 +104,7 @@ normal_prior = function(scale = 1) {
       family = "normal",
       hyper.parameters = list(scale = scale)
     ),
-    class = c("bgms_interaction_prior", "bgms_parameter_prior")
+    class = "bgms_parameter_prior"
   )
 }
 
@@ -151,7 +152,7 @@ beta_prime_prior = function(alpha = 0.5, beta = 0.5) {
       family = "beta-prime",
       hyper.parameters = list(alpha = alpha, beta = beta)
     ),
-    class = c("bgms_threshold_prior", "bgms_parameter_prior")
+    class = "bgms_parameter_prior"
   )
 }
 

--- a/tests/testthat/test-prior-interface.R
+++ b/tests/testthat/test-prior-interface.R
@@ -18,26 +18,23 @@
 # 1. Prior Constructor Tests
 # ==============================================================================
 
-test_that("cauchy_prior creates valid prior object with dual class", {
+test_that("cauchy_prior creates valid prior object (single class)", {
   p = cauchy_prior(scale = 2.5)
-  expect_s3_class(p, "bgms_parameter_prior")
-  expect_s3_class(p, "bgms_interaction_prior")
+  expect_identical(class(p), "bgms_parameter_prior")
   expect_equal(p$family, "cauchy")
   expect_equal(p$hyper.parameters$scale, 2.5)
 })
 
-test_that("normal_prior creates valid prior object with dual class", {
+test_that("normal_prior creates valid prior object (single class)", {
   p = normal_prior(scale = 0.5)
-  expect_s3_class(p, "bgms_parameter_prior")
-  expect_s3_class(p, "bgms_interaction_prior")
+  expect_identical(class(p), "bgms_parameter_prior")
   expect_equal(p$family, "normal")
   expect_equal(p$hyper.parameters$scale, 0.5)
 })
 
-test_that("beta_prime_prior creates valid prior object with dual class", {
+test_that("beta_prime_prior creates valid prior object (single class)", {
   p = beta_prime_prior(alpha = 1, beta = 1)
-  expect_s3_class(p, "bgms_parameter_prior")
-  expect_s3_class(p, "bgms_threshold_prior")
+  expect_identical(class(p), "bgms_parameter_prior")
   expect_equal(p$family, "beta-prime")
   expect_equal(p$hyper.parameters$alpha, 1)
   expect_equal(p$hyper.parameters$beta, 1)


### PR DESCRIPTION
Removes two vestigial S3 class tags from prior objects. Verified (with the maintainer) that they serve no purpose:

- **Routing** (interaction vs threshold) is by the `bgm()`/`bgmCompare()` **argument slot** -> `unpack_interaction_prior()` / `unpack_threshold_prior()`.
- **Type** is carried by the prior's `family` field, not the class.
- **Validation** checks the `bgms_parameter_prior` parent ([priors.R:489](R/priors.R)), never the subclass.
- **NUTS gradients** dispatch on the C++ `BaseParameterPrior` vtable (`grad()` is pure-virtual, implemented by all four families), so every family is gradient-safe in either slot regardless of the R class.
- The tags were also **inconsistent**: `normal_prior()` was tagged `bgms_interaction_prior` even though it's valid as a `threshold_prior`.
- **easybgm** (`update_easybgm` branch) does not reference them — checked directly.

Constructors (`cauchy_prior`, `normal_prior`, `beta_prime_prior`) now return the single `bgms_parameter_prior` class. Introduced in the **unreleased** 0.2.0, so no NEWS entry. Tests now assert the exact single class.

Verified: clean build, `test-prior-interface.R` passes, and a NUTS fit with `normal_prior` in the `threshold_prior` slot works.