### PR TITLE
docs: align documentation with .github/copilot-instructions.md

### DIFF
--- a/R/bgm.R
+++ b/R/bgm.R
@@ -1,4 +1,4 @@
-#' Bayesian Estimation or Edge Selection for Markov Random Fields
+#' @title Bayesian Estimation or Edge Selection for Markov Random Fields
 #'
 #' @description
 #' The \code{bgm} function estimates the pseudoposterior distribution of the

--- a/R/bgmCompare.R
+++ b/R/bgmCompare.R
@@ -1,4 +1,4 @@
-#' Bayesian Estimation and Variable Selection for Group Differences in Markov Random Fields
+#' @title Bayesian Estimation and Variable Selection for Group Differences in Markov Random Fields
 #'
 #' @description
 #' The \code{bgmCompare} function estimates group differences in category

--- a/R/extractor_functions.R
+++ b/R/extractor_functions.R
@@ -35,7 +35,7 @@ samples_to_array3d = function(xlist) {
 }
 
 
-#' Extract Model Arguments
+#' @title Extract Model Arguments
 #'
 #' @description
 #' Retrieves the arguments used when fitting a model with [bgm()] or
@@ -75,7 +75,7 @@ extract_arguments.bgmCompare = function(bgms_object) {
   return(bgms_object$arguments)
 }
 
-#' Extract Indicator Samples
+#' @title Extract Indicator Samples
 #'
 #' @description
 #' Retrieves posterior samples of inclusion indicators from a model fitted
@@ -171,7 +171,7 @@ extract_indicators.bgmCompare = function(bgms_object) {
   stop("No indicator samples found in fit object.")
 }
 
-#' Extract Posterior Inclusion Probabilities
+#' @title Extract Posterior Inclusion Probabilities
 #'
 #' @description
 #' Computes posterior inclusion probabilities from a model fitted with
@@ -242,7 +242,7 @@ extract_posterior_inclusion_probabilities.bgms = function(bgms_object) {
 }
 
 
-#' Extract Stochastic Block Model Summaries
+#' @title Extract Stochastic Block Model Summaries
 #'
 #' @description
 #' Retrieves posterior summaries from a model fitted with the Stochastic
@@ -384,7 +384,7 @@ extract_posterior_inclusion_probabilities.bgmCompare = function(bgms_object) {
   stop("No indicator samples found in fit object.")
 }
 
-#' Extract Indicator Prior Structure
+#' @title Extract Indicator Prior Structure
 #'
 #' @description
 #' Retrieves the prior specification used for inclusion indicators in a
@@ -445,7 +445,7 @@ extract_indicator_priors.bgmCompare = function(bgms_object) {
 }
 
 
-#' Extract Pairwise Interaction Samples
+#' @title Extract Pairwise Interaction Samples
 #'
 #' @description
 #' Retrieves posterior samples of pairwise interaction parameters from a
@@ -716,7 +716,7 @@ extract_category_thresholds = function(bgms_object) {
   extract_main_effects(bgms_object)
 }
 
-#' Extract Group-Specific Parameters
+#' @title Extract Group-Specific Parameters
 #'
 #' @description
 #' Computes group-specific parameter estimates by combining baseline
@@ -953,7 +953,7 @@ extract_group_params.bgmCompare = function(bgms_object) {
   ))
 }
 
-#' Deprecated: Use extract_indicators instead
+#' @title Deprecated: Use extract_indicators instead
 #' @param bgms_object A bgms or bgmCompare object.
 #' @keywords internal
 #' @export
@@ -962,7 +962,7 @@ extract_edge_indicators = function(bgms_object) {
   extract_indicators(bgms_object)
 }
 
-#' Deprecated: Use extract_main_effects instead
+#' @title Deprecated: Use extract_main_effects instead
 #' @param bgms_object A bgms or bgmCompare object.
 #' @keywords internal
 #' @export
@@ -976,7 +976,7 @@ extract_pairwise_thresholds = function(bgms_object) {
 # extract_rhat() - R-hat Convergence Diagnostics
 # ------------------------------------------------------------------------------
 
-#' Extract R-hat Convergence Diagnostics
+#' @title Extract R-hat Convergence Diagnostics
 #'
 #' @description
 #' Retrieves R-hat convergence diagnostics for all parameters from a
@@ -1082,7 +1082,7 @@ extract_rhat.bgmCompare = function(bgms_object) {
 # extract_ess() - Effective Sample Size
 # ------------------------------------------------------------------------------
 
-#' Extract Effective Sample Size
+#' @title Extract Effective Sample Size
 #'
 #' @description
 #' Retrieves effective sample size estimates for all parameters from a

--- a/R/extractor_functions.R
+++ b/R/extractor_functions.R
@@ -562,7 +562,7 @@ extract_pairwise_interactions.bgmCompare = function(bgms_object) {
   stop("No pairwise interaction samples found in fit object.")
 }
 
-#' Extract Main Effect Estimates
+#' @title Extract Main Effect Estimates
 #'
 #' @description
 #' Retrieves main-effect parameters from a model fitted with [bgm()]
@@ -690,7 +690,7 @@ extract_main_effects.bgmCompare = function(bgms_object) {
 }
 
 
-#' Extract Category Threshold Estimates
+#' @title Extract Category Threshold Estimates
 #'
 #' @description
 #' `r lifecycle::badge("deprecated")`
@@ -1184,7 +1184,7 @@ extract_ess.bgmCompare = function(bgms_object) {
 }
 
 
-#' Extract Posterior Mean Precision Matrix
+#' @title Extract Posterior Mean Precision Matrix
 #'
 #' @description
 #' Retrieves the posterior mean precision matrix from a model fitted with
@@ -1254,7 +1254,7 @@ extract_precision.bgms = function(bgms_object) {
 }
 
 
-#' Extract Posterior Mean Partial Correlations
+#' @title Extract Posterior Mean Partial Correlations
 #'
 #' @description
 #' Computes the posterior mean partial correlation matrix from a model fitted
@@ -1313,7 +1313,7 @@ extract_partial_correlations.bgms = function(bgms_object) {
 }
 
 
-#' Extract Posterior Mean Log-Odds (Pairwise Interactions)
+#' @title Extract Posterior Mean Log-Odds (Pairwise Interactions)
 #'
 #' @description
 #' Retrieves the posterior mean pairwise interaction matrix for discrete

--- a/R/priors.R
+++ b/R/priors.R
@@ -24,7 +24,7 @@
 # Parameter priors (interactions, thresholds, means)
 # ==============================================================================
 
-#' Cauchy Prior for Model Parameters
+#' @title Cauchy Prior for Model Parameters
 #'
 #' @description
 #' Specifies a Cauchy(0, scale) prior on model parameters.
@@ -67,7 +67,7 @@ cauchy_prior = function(scale = 1) {
 }
 
 
-#' Normal Prior for Model Parameters
+#' @title Normal Prior for Model Parameters
 #'
 #' @description
 #' Specifies a Normal(0, scale) prior on model parameters.
@@ -111,7 +111,7 @@ normal_prior = function(scale = 1) {
 }
 
 
-#' Beta-Prime Prior for Model Parameters
+#' @title Beta-Prime Prior for Model Parameters
 #'
 #' @description
 #' Specifies a beta-prime prior on model parameters.
@@ -163,7 +163,7 @@ beta_prime_prior = function(alpha = 0.5, beta = 0.5) {
 # Scale priors (positive parameters: precision diagonal)
 # ==============================================================================
 
-#' Gamma Prior for Scale Parameters
+#' @title Gamma Prior for Scale Parameters
 #'
 #' @description
 #' Specifies a Gamma(shape, rate) prior for positive scale parameters such as
@@ -210,7 +210,7 @@ gamma_prior = function(shape = 1, rate = 1) {
 }
 
 
-#' Exponential Prior for Scale Parameters
+#' @title Exponential Prior for Scale Parameters
 #'
 #' @description
 #' Specifies an Exponential(rate) prior for positive scale parameters.
@@ -256,7 +256,7 @@ exponential_prior = function(rate = 1) {
 # Indicator priors (selection: edges, differences)
 # ==============================================================================
 
-#' Bernoulli Prior for Inclusion Indicators
+#' @title Bernoulli Prior for Inclusion Indicators
 #'
 #' @description
 #' Specifies a Bernoulli prior for inclusion indicators with a fixed
@@ -293,7 +293,7 @@ bernoulli_prior = function(inclusion_probability = 0.5) {
 }
 
 
-#' Beta-Bernoulli Prior for Inclusion Indicators
+#' @title Beta-Bernoulli Prior for Inclusion Indicators
 #'
 #' @description
 #' Specifies a Beta-Bernoulli prior for inclusion indicators. The inclusion
@@ -341,7 +341,7 @@ beta_bernoulli_prior = function(alpha = 1, beta = 1) {
 }
 
 
-#' Stochastic Block Model Prior for Inclusion Indicators
+#' @title Stochastic Block Model Prior for Inclusion Indicators
 #'
 #' @description
 #' Specifies a Stochastic Block Model (SBM) prior for inclusion indicators.

--- a/R/sample_ggm_prior.R
+++ b/R/sample_ggm_prior.R
@@ -1,5 +1,6 @@
-#' Sample from the GGM (Partial-Association) Prior
+#' @title Sample from the GGM (Partial-Association) Prior
 #'
+#' @description
 #' Draws from the prior of a Gaussian graphical model. The likelihood is
 #' omitted (\eqn{n = 0}, \eqn{S = 0}), so the chain targets the prior alone.
 #' Two specifications are supported via the \code{spec} argument:
@@ -21,6 +22,7 @@
 #'     calibration of \code{\link{bgm}}'s default sampler.
 #' }
 #'
+#' @details
 #' The priors are specified on the partial-association scale
 #' \eqn{K_{yy} = -K/2}: \code{interaction_prior} acts on
 #' \eqn{K_{yy,ij} = -K_{ij}/2}, and \code{precision_scale_prior} acts on

--- a/R/simulate_mrf.R
+++ b/R/simulate_mrf.R
@@ -5,8 +5,7 @@
 # methods and shared helpers stay in simulate_predict.R.
 
 
-
-#' Simulate Observations from a Markov Random Field
+#' @title Simulate Observations from a Markov Random Field
 #'
 #' @description
 #' `simulate_mrf()` generates observations from a Markov Random
@@ -487,7 +486,7 @@ simulate_mrf = function(num_states,
 #   mrfSampler() - Deprecated Wrapper for simulate_mrf()
 # ==============================================================================
 
-#' Sample observations from the ordinal MRF
+#' @title Sample observations from the ordinal MRF
 #'
 #' @description
 #' `r lifecycle::badge("deprecated")`
@@ -526,4 +525,3 @@ mrfSampler = function(num_states,
     seed = seed
   )
 }
-

--- a/src/models/mixed/mixed_mrf_gradient.cpp
+++ b/src/models/mixed/mixed_mrf_gradient.cpp
@@ -1,11 +1,9 @@
-/**
- * mixed_mrf_gradient.cpp — MixedMRFModel gradient engine (NUTS support).
- *
- * `gradient`, `logp_and_gradient`, and the full-space variant, plus the gradient-cache
- * bookkeeping (`ensure_gradient_cache`, `invalidate_gradient_cache`) and the
- * NUTS-vector → working-temps unpacking. Pairs with the constrained-NUTS projection
- * cache in mixed_mrf_model.cpp.
- */
+// mixed_mrf_gradient.cpp — MixedMRFModel gradient engine (NUTS support).
+//
+// gradient, logp_and_gradient, and the full-space variant, plus the gradient-cache
+// bookkeeping (ensure_gradient_cache, invalidate_gradient_cache) and the
+// NUTS-vector -> working-temps unpacking. Pairs with the constrained-NUTS projection
+// cache in mixed_mrf_model.cpp.
 #include <RcppArmadillo.h>
 #include "models/mixed/mixed_mrf_model.h"
 #include "utils/variable_helpers.h"

--- a/src/models/mixed/mixed_mrf_likelihoods.cpp
+++ b/src/models/mixed/mixed_mrf_likelihoods.cpp
@@ -1,11 +1,9 @@
-/**
- * mixed_mrf_likelihoods.cpp — MixedMRFModel likelihood terms.
- *
- * The two log-likelihood contributions of the mixed model: `log_conditional_ggm`
- * (continuous block conditional on the discrete state) and `log_marginal_omrf`
- * (discrete block). Consumed by the gradient and Metropolis update bodies in the
- * sibling translation units.
- */
+// mixed_mrf_likelihoods.cpp — MixedMRFModel likelihood terms.
+//
+// The two log-likelihood contributions of the mixed model: log_conditional_ggm
+// (continuous block conditional on the discrete state) and log_marginal_omrf
+// (discrete block). Consumed by the gradient and Metropolis update bodies in the
+// sibling translation units.
 #include <RcppArmadillo.h>
 #include "models/mixed/mixed_mrf_model.h"
 #include "utils/variable_helpers.h"

--- a/src/models/mixed/mixed_mrf_metropolis.cpp
+++ b/src/models/mixed/mixed_mrf_metropolis.cpp
@@ -1,12 +1,10 @@
-/**
- * mixed_mrf_metropolis.cpp — MixedMRFModel within-model MH updates.
- *
- * The per-parameter Metropolis-Hastings sweeps (main effects, discrete/cross/continuous
- * pairwise effects, edge indicators, continuous mean) and the rank-2 precision math they
- * rely on: `get_precision_constants`, `log_det_ratio_yy_*`, `log_ggm_ratio_*`, and the
- * `cholesky_update_after_precision_*` helpers. The load-bearing `std::abs` sign convention
- * in the det-ratio helpers must be preserved (see architecture.md, Numerical Considerations).
- */
+// mixed_mrf_metropolis.cpp — MixedMRFModel within-model MH updates.
+//
+// The per-parameter Metropolis-Hastings sweeps (main effects, discrete/cross/continuous
+// pairwise effects, edge indicators, continuous mean) and the rank-2 precision math they
+// rely on: get_precision_constants, log_det_ratio_yy_*, log_ggm_ratio_*, and the
+// cholesky_update_after_precision_* helpers. The load-bearing std::abs sign convention
+// in the det-ratio helpers must be preserved (see architecture.md, Numerical Considerations).
 #include <RcppArmadillo.h>
 #include <utility>
 #include "models/mixed/mixed_mrf_model.h"

--- a/src/models/mixed/mixed_mrf_model.cpp
+++ b/src/models/mixed/mixed_mrf_model.cpp
@@ -1,12 +1,10 @@
-/**
- * mixed_mrf_model.cpp — MixedMRFModel core.
- *
- * Construction, sufficient statistics, parameter (de)vectorization, the
- * `do_one_metropolis_step` driver, missing-data imputation, proposal-SD tuning,
- * and the position/momentum projection cache for constrained NUTS. The likelihood,
- * gradient, and within-model MH update bodies live in the sibling translation units
- * (mixed_mrf_likelihoods.cpp, mixed_mrf_gradient.cpp, mixed_mrf_metropolis.cpp).
- */
+// mixed_mrf_model.cpp — MixedMRFModel core.
+//
+// Construction, sufficient statistics, parameter (de)vectorization, the
+// do_one_metropolis_step driver, missing-data imputation, proposal-SD tuning,
+// and the position/momentum projection cache for constrained NUTS. The likelihood,
+// gradient, and within-model MH update bodies live in the sibling translation units
+// (mixed_mrf_likelihoods.cpp, mixed_mrf_gradient.cpp, mixed_mrf_metropolis.cpp).
 #include <RcppArmadillo.h>
 #include "models/mixed/mixed_mrf_model.h"
 #include "math/explog_macros.h"


### PR DESCRIPTION
Brings the cleanup's documentation into line with the house AI-agent guidelines in `.github/copilot-instructions.md`, which weren't used as the rubric during S2/S8.

## Fixes
1. **No Doxygen in `.cpp`** (C++ Tier 4 / "Do not"). The four `mixed_mrf_*.cpp` module headers added in S2 used `/** */` — the only such blocks in any `.cpp`. Converted to `//` comments (content preserved).
2. **Explicit `@title` on every exported function** (Tier 1). All 29 exported functions now carry an explicit `@title`: the 5 extractors S8 had stripped it from, plus a package-wide rollout to the other ~24 (8 prior constructors, `bgm`, `bgmCompare`, `sample_ggm_prior`, `simulate_mrf`, `mrfSampler`, and the remaining extractors). Titles converted in place from the bare first line — wording unchanged. `sample_ggm_prior` also gets explicit `@description`/`@details` so its three-part doc isn't folded into the title.

## Verification
- `roxygen2::roxygenise()` — warning-free; **generated `man/` is byte-identical** (pure source-style change, no rendered-doc difference).
- `styler::style_file(..., style = bgms_style)` — clean (only collapsed two stray blank lines); `lintr::lint()` — 0 lints on all edited files.
- `devtools::load_all()` — clean compile.

(Recorded a memory to consult `.github/copilot-instructions.md` up front in future doc work — root cause was not using it as the rubric.)