### PR TITLE
refactor(models): class-hierarchy dead-code removal (design Tier 0)

### DIFF
--- a/src/mcmc/samplers/nuts_adaptation.h
+++ b/src/mcmc/samplers/nuts_adaptation.h
@@ -134,7 +134,6 @@ public:
       inv_mass_(arma::ones<arma::vec>(dim)),
       step_size_(initial_step_size),
       target_accept_(target_accept),
-      finalized_mass_(false),
       mass_matrix_updated_(false) {}
 
   void update(const arma::vec& theta,
@@ -183,7 +182,6 @@ public:
   double current_step_size() const { return step_size_; }
   double final_step_size() const { return step_adapter.averaged(); }
   const arma::vec& inv_mass_diag() const { return inv_mass_; }
-  bool has_fixed_mass_matrix() const { return finalized_mass_; }
 
   /**
    * Check if the mass matrix was just updated and needs step size re-initialization.
@@ -219,6 +217,5 @@ private:
   arma::vec inv_mass_;
   double step_size_;
   double target_accept_;
-  bool finalized_mass_;
   bool mass_matrix_updated_;
 };

--- a/src/models/base_model.h
+++ b/src/models/base_model.h
@@ -16,9 +16,9 @@ struct WarmupSchedule;
  * Defines the virtual methods that the MCMC framework (MetropolisSampler,
  * NUTSSampler, ChainRunner) calls during sampling. Most methods are pure
  * virtual (`= 0`) so the compiler enforces implementation in every
- * subclass. The exceptions are gradient-only methods (gradient,
- * logp_and_gradient, set_vectorized_parameters) which throw at runtime
- * and are guarded by the has_gradient() capability query.
+ * subclass. The exceptions are gradient-only methods (logp_and_gradient,
+ * set_vectorized_parameters) which throw at runtime for models that do not
+ * support NUTS.
  *
  * Subclass hierarchy:
  *   - GGMModel      — Gaussian Graphical Model (precision matrix, Metropolis + NUTS)
@@ -26,15 +26,16 @@ struct WarmupSchedule;
  *   - MixedMRFModel — Mixed discrete + continuous MRF (Metropolis + NUTS)
  *
  * Methods fall into several groups:
- *   - **Capability queries** (has_gradient, has_adaptive_metropolis, etc.)
- *     — samplers inspect these to choose the right algorithm.
- *   - **Sampling steps** (do_one_metropolis_step, gradient, logp_and_gradient)
+ *   - **Capability queries** (has_edge_selection, has_constraints, has_missing_data)
+ *     — run/data-dependent toggles the runner and samplers branch on. (Sampler
+ *     choice itself is config-driven, not capability-driven.)
+ *   - **Sampling steps** (do_one_metropolis_step, logp_and_gradient)
  *     — called by the sampler each iteration.
  *   - **Edge selection** (update_edge_indicators)
  *     — spike-and-slab structure learning.
  *   - **Parameter access** (get/set_vectorized_parameters, get_full_vectorized_parameters)
  *     — used by NUTS for momentum-based proposals and by the runner for output.
- *   - **Adaptation** (set_step_size, set_inv_mass, tune_proposal_sd)
+ *   - **Adaptation** (set_inv_mass, tune_proposal_sd)
  *     — tuned during warmup.
  *   - **Missing data** (has_missing_data, impute_missing)
  *     — full-conditional imputation between iterations.
@@ -47,27 +48,12 @@ public:
     // Capability queries
     // =========================================================================
 
-    /** @return true if the model provides a gradient (enables NUTS). */
-    virtual bool has_gradient() const { return false; }
-    /** @return true if the model supports adaptive Metropolis. */
-    virtual bool has_adaptive_metropolis() const { return false; }
-    /** @return true if the model supports NUTS (default: same as has_gradient). */
-    virtual bool has_nuts() const { return has_gradient(); }
     /** @return true if the model supports edge selection (spike-and-slab). */
     virtual bool has_edge_selection() const { return false; }
 
     // =========================================================================
     // Core sampling methods
     // =========================================================================
-
-    /**
-     * Compute the gradient of the log-(pseudo)posterior.
-     * @param parameters  Vectorized parameters at which to evaluate
-     * @return Gradient vector
-     */
-    virtual arma::vec gradient(const arma::vec& parameters) {
-        throw std::runtime_error("Gradient not implemented for this model");
-    }
 
     /**
      * Combined log-(pseudo)posterior and gradient evaluation.
@@ -245,14 +231,6 @@ public:
     // =========================================================================
 
     /**
-     * Set the leapfrog step size for gradient-based samplers.
-     * @param step_size  New step size
-     */
-    virtual void set_step_size(double step_size) { step_size_ = step_size; }
-    /** @return Current leapfrog step size. */
-    virtual double get_step_size() const { return step_size_; }
-
-    /**
      * Set the inverse mass matrix diagonal for NUTS.
      * @param inv_mass  Diagonal elements of the inverse mass matrix
      */
@@ -412,8 +390,6 @@ public:
 
 protected:
     BaseModel() = default;
-    /// Leapfrog step size for NUTS.
-    double step_size_ = 0.1;
     /// Inverse mass matrix diagonal for NUTS.
     arma::vec inv_mass_;
 };

--- a/src/models/ggm/ggm_model.h
+++ b/src/models/ggm/ggm_model.h
@@ -156,10 +156,6 @@ public:
           theta_(other.theta_)
     {}
 
-    /** @return true (GGM supports NUTS via free-element Cholesky gradient). */
-    bool has_gradient()        const override { return true; }
-    /** @return true (GGM supports adaptive Metropolis). */
-    bool has_adaptive_metropolis()     const override { return true; }
     /** @return true when edge selection is enabled. */
     bool has_edge_selection()  const override { return edge_selection_; }
     /** @return true when missing-data imputation is active. */

--- a/src/models/mixed/mixed_mrf_gradient.cpp
+++ b/src/models/mixed/mixed_mrf_gradient.cpp
@@ -168,16 +168,6 @@ void MixedMRFModel::unvectorize_nuts_to_temps(
 
 
 // =============================================================================
-// gradient
-// =============================================================================
-
-arma::vec MixedMRFModel::gradient(const arma::vec& parameters) {
-    auto [logp, grad] = logp_and_gradient(parameters);
-    return grad;
-}
-
-
-// =============================================================================
 // logp_and_gradient — marginal pseudo-likelihood
 // =============================================================================
 // Computes the log pseudo-posterior and its gradient with respect to the

--- a/src/models/mixed/mixed_mrf_model.h
+++ b/src/models/mixed/mixed_mrf_model.h
@@ -88,10 +88,6 @@ public:
     // Capability queries
     // =========================================================================
 
-    /** @return true (MixedMRFModel supports NUTS gradient for the unconstrained block). */
-    bool has_gradient() const override { return true; }
-    /** @return true (supports adaptive Metropolis via Robbins-Monro). */
-    bool has_adaptive_metropolis() const override { return true; }
     /** @return true when edge selection is enabled. */
     bool has_edge_selection() const override { return edge_selection_; }
     /** @return true when missing-data imputation is active. */
@@ -102,13 +98,6 @@ public:
     // =========================================================================
     // Core sampling methods
     // =========================================================================
-
-    /**
-     * Compute gradient of the log pseudo-posterior (NUTS block only).
-     * @param parameters  NUTS-dimension parameter vector
-     * @return Gradient vector (same size as parameters)
-     */
-    arma::vec gradient(const arma::vec& parameters) override;
 
     /**
      * Combined log pseudo-posterior and gradient evaluation.

--- a/src/models/omrf/omrf_model.cpp
+++ b/src/models/omrf/omrf_model.cpp
@@ -38,7 +38,6 @@ OMRFModel::OMRFModel(
     threshold_prior_(std::move(threshold_prior)),
     edge_selection_(edge_selection),
     edge_selection_active_(false),
-    step_size_(0.1),
     has_missing_(false),
     gradient_cache_valid_(false)
 {
@@ -119,7 +118,6 @@ OMRFModel::OMRFModel(const OMRFModel& other)
       proposal_sd_main_(other.proposal_sd_main_),
       proposal_sd_pairwise_(other.proposal_sd_pairwise_),
       rng_(other.rng_),
-      step_size_(other.step_size_),
       inv_mass_(other.inv_mass_),
       has_missing_(other.has_missing_),
       missing_index_(other.missing_index_),
@@ -575,74 +573,6 @@ void OMRFModel::get_active_inv_mass_into(arma::vec& active_inv_mass) const {
 // Log-pseudoposterior computation
 // =============================================================================
 
-double OMRFModel::log_pseudoposterior_with_state(
-    const arma::mat& main_eff,
-    const arma::mat& pairwise_eff,
-    const arma::mat& residual_mat
-) const {
-    double log_post = 0.0;
-
-    // Main effect contributions (priors and sufficient statistics)
-    for (size_t v = 0; v < p_; ++v) {
-        int num_cats = num_categories_(v);
-
-        if (is_ordinal_variable_(v)) {
-            for (int c = 0; c < num_cats; ++c) {
-                log_post += threshold_prior_->logp(main_eff(v, c));
-                log_post += main_eff(v, c) * counts_per_category_(c + 1, v);
-            }
-        } else {
-            log_post += threshold_prior_->logp(main_eff(v, 0));
-            log_post += threshold_prior_->logp(main_eff(v, 1));
-            log_post += main_eff(v, 0) * blume_capel_stats_(0, v);
-            log_post += main_eff(v, 1) * blume_capel_stats_(1, v);
-        }
-    }
-
-    // Log-normalizer using joint logZ+probs helpers — fill-in-place into
-    // the model's persistent scratch (shared with logp_and_gradient since the
-    // two are not called concurrently within a single chain).
-    for (size_t v = 0; v < p_; ++v) {
-        int num_cats = num_categories_(v);
-        arma::vec residual_score = residual_mat.col(v);
-        arma::vec bound = num_cats * residual_score;
-
-        if (is_ordinal_variable_(v)) {
-            arma::vec main_param = main_eff.row(v).cols(0, num_cats - 1).t();
-            compute_logZ_and_probs_ordinal_into(
-                main_param, residual_score, bound, num_cats,
-                logz_out_, logz_scratch_);
-            log_post -= arma::accu(logz_out_.log_Z);
-        } else {
-            int ref = baseline_category_(v);
-            double lin = main_eff(v, 0), quad = main_eff(v, 1);
-            compute_logZ_and_probs_blume_capel_into(
-                residual_score, lin, quad, ref, num_cats, bound,
-                logz_out_, logz_scratch_);
-            log_post -= arma::accu(logz_out_.log_Z);
-        }
-    }
-
-    // Pairwise effect contributions: sufficient statistics + Cauchy prior
-    for (size_t v1 = 0; v1 < p_ - 1; ++v1) {
-        for (size_t v2 = v1 + 1; v2 < p_; ++v2) {
-            if (edge_indicators_(v1, v2) == 1) {
-                double effect = pairwise_eff(v1, v2);
-                log_post += 4.0 * pairwise_stats_(v1, v2) * effect;
-                log_post += interaction_prior_->logp(effect, pairwise_scaling_factors_(v1, v2));
-            }
-        }
-    }
-
-    return log_post;
-}
-
-
-double OMRFModel::log_pseudoposterior_internal() const {
-    return log_pseudoposterior_with_state(main_effects_, pairwise_effects_, residual_matrix_);
-}
-
-
 double OMRFModel::log_pseudoposterior_main_component(int variable, int category, int parameter) const {
     double log_posterior = 0.0;
 
@@ -679,36 +609,6 @@ double OMRFModel::log_pseudoposterior_main_component(int variable, int category,
     }
 
     return log_posterior;
-}
-
-
-double OMRFModel::log_pseudoposterior_pairwise_component(int var1, int var2) const {
-    double log_post = 4.0 * pairwise_effects_(var1, var2) * pairwise_stats_(var1, var2);
-
-    for (int var : {var1, var2}) {
-        int num_cats = num_categories_(var);
-        arma::vec residual_score = residual_matrix_.col(var);
-
-        if (is_ordinal_variable_(var)) {
-            arma::vec main_param = main_effects_.row(var).cols(0, num_cats - 1).t();
-            arma::vec bound = num_cats * residual_score;
-            arma::vec denom = compute_denom_ordinal(residual_score, main_param, bound);
-            log_post -= arma::accu(bound + ARMA_MY_LOG(denom));
-        } else {
-            arma::vec bound(n_);
-            arma::vec denom = compute_denom_blume_capel(
-                residual_score, main_effects_(var, 0), main_effects_(var, 1),
-                baseline_category_(var), num_cats, bound
-            );
-            log_post -= arma::accu(bound + ARMA_MY_LOG(denom));
-        }
-    }
-
-    if (edge_indicators_(var1, var2) == 1) {
-        log_post += interaction_prior_->logp(pairwise_effects_(var1, var2), pairwise_scaling_factors_(var1, var2));
-    }
-
-    return log_post;
 }
 
 
@@ -882,106 +782,6 @@ void OMRFModel::ensure_gradient_cache() {
 
     gradient_cache_valid_ = true;
 }
-
-arma::vec OMRFModel::gradient(const arma::vec& parameters) {
-    ensure_gradient_cache();
-
-    arma::mat temp_main = main_effects_;
-    arma::mat temp_pairwise = pairwise_effects_;
-    arma::mat temp_residual;
-    unvectorize_to_temps(parameters, temp_main, temp_pairwise, temp_residual);
-
-    const int num_variables = static_cast<int>(p_);
-
-    // Start with cached observed gradient
-    arma::vec gradient = grad_obs_cache_;
-
-    // ---- Expected statistics ----
-    int offset = 0;
-    for (int variable = 0; variable < num_variables; variable++) {
-        const int num_cats = num_categories_(variable);
-        arma::vec residual_score = temp_residual.col(variable);
-        arma::vec bound = num_cats * residual_score;
-
-        if (is_ordinal_variable_(variable)) {
-            arma::vec main_param = temp_main.row(variable).cols(0, num_cats - 1).t();
-            arma::mat probs = compute_probs_ordinal(
-                main_param, residual_score, bound, num_cats
-            );
-
-            // Main effects gradient
-            for (int cat = 0; cat < num_cats; cat++) {
-                gradient(offset + cat) -= arma::accu(probs.col(cat + 1));
-            }
-
-            // Pairwise gradient (vectorized using BLAS)
-            arma::vec weights = arma::regspace<arma::vec>(1, num_cats);
-            arma::vec E = probs.cols(1, num_cats) * weights;
-            arma::vec pw_grad = observations_double_t_ * E;
-            for (int j = 0; j < num_variables; j++) {
-                if (edge_indicators_(variable, j) == 0 || variable == j) continue;
-                int location = (variable < j) ? index_matrix_cache_(variable, j) : index_matrix_cache_(j, variable);
-                gradient(location) -= 2.0 * pw_grad(j);
-            }
-            offset += num_cats;
-        } else {
-            const int ref = baseline_category_(variable);
-            const double lin_eff = temp_main(variable, 0);
-            const double quad_eff = temp_main(variable, 1);
-
-            arma::mat probs = compute_probs_blume_capel(
-                residual_score, lin_eff, quad_eff, ref, num_cats, bound
-            );
-
-            arma::vec score = arma::regspace<arma::vec>(0, num_cats) - static_cast<double>(ref);
-            arma::vec sq_score = arma::square(score);
-
-            // Main effects gradient
-            gradient(offset) -= arma::accu(probs * score);
-            gradient(offset + 1) -= arma::accu(probs * sq_score);
-
-            // Pairwise gradient (vectorized using BLAS)
-            arma::vec E = probs * score;
-            arma::vec pw_grad = observations_double_t_ * E;
-            for (int j = 0; j < num_variables; j++) {
-                if (edge_indicators_(variable, j) == 0 || variable == j) continue;
-                int location = (variable < j)
-                    ? index_matrix_cache_(variable, j)
-                    : index_matrix_cache_(j, variable);
-                gradient(location) -= 2.0 * pw_grad(j);
-            }
-            offset += 2;
-        }
-    }
-
-    // ---- Priors ----
-    offset = 0;
-    for (int variable = 0; variable < num_variables; variable++) {
-        if (is_ordinal_variable_(variable)) {
-            const int num_cats = num_categories_(variable);
-            for (int cat = 0; cat < num_cats; cat++) {
-                gradient(offset + cat) += threshold_prior_->grad(temp_main(variable, cat));
-            }
-            offset += num_cats;
-        } else {
-            for (int k = 0; k < 2; k++) {
-                gradient(offset + k) += threshold_prior_->grad(temp_main(variable, k));
-            }
-            offset += 2;
-        }
-    }
-    for (int i = 0; i < num_variables - 1; i++) {
-        for (int j = i + 1; j < num_variables; j++) {
-            if (edge_indicators_(i, j) == 0) continue;
-            int location = index_matrix_cache_(i, j);
-            const double effect = temp_pairwise(i, j);
-            gradient(location) += interaction_prior_->grad(effect, pairwise_scaling_factors_(i, j));
-        }
-    }
-
-    return gradient;
-}
-
 
 std::pair<double, arma::vec> OMRFModel::logp_and_gradient(const arma::vec& parameters) {
     ensure_gradient_cache();

--- a/src/models/omrf/omrf_model.h
+++ b/src/models/omrf/omrf_model.h
@@ -62,19 +62,10 @@ public:
     // BaseModel interface implementation
     // =========================================================================
 
-    /** @return true (OMRF supports gradient computation). */
-    bool has_gradient()    const override { return true; }
-    /** @return true (OMRF supports adaptive Metropolis). */
-    bool has_adaptive_metropolis() const override { return true; }
     /** @return true when edge selection is enabled. */
     bool has_edge_selection() const override { return edge_selection_; }
     /** @return true when missing-data imputation is active. */
     bool has_missing_data() const override { return has_missing_; }
-
-    /**
-     * Compute gradient of log-pseudoposterior
-     */
-    arma::vec gradient(const arma::vec& parameters) override;
 
     /**
      * Combined log-posterior and gradient evaluation (more efficient)
@@ -228,13 +219,6 @@ public:
     /** @return Number of observations (shorthand for interface compatibility). */
     size_t get_n() const { return n_; }
 
-    /**
-     * Set the NUTS leapfrog step size.
-     * @param step_size  New step size
-     */
-    void set_step_size(double step_size) override { step_size_ = step_size; }
-    /** @return Current NUTS leapfrog step size. */
-    double get_step_size() const override { return step_size_; }
     /**
      * Set the inverse mass matrix diagonal for NUTS.
      * @param inv_mass  Diagonal elements of the inverse mass matrix
@@ -402,28 +386,9 @@ private:
     // -------------------------------------------------------------------------
 
     /**
-     * Full log-pseudoposterior (internal, uses current state)
-     */
-    double log_pseudoposterior_internal() const;
-
-    /**
-     * Full log-pseudoposterior with external state (avoids modifying model)
-     */
-    double log_pseudoposterior_with_state(
-        const arma::mat& main_eff,
-        const arma::mat& pairwise_eff,
-        const arma::mat& residual_mat
-    ) const;
-
-    /**
      * Log-posterior for single main effect component
      */
     double log_pseudoposterior_main_component(int variable, int category, int parameter) const;
-
-    /**
-     * Log-posterior for single pairwise interaction
-     */
-    double log_pseudoposterior_pairwise_component(int var1, int var2) const;
 
     /**
      * Log-likelihood ratio for variable update


### PR DESCRIPTION
First, lowest-risk step from the model/sampler class-design review ([2026-06-04_class-design-review.md](dev/plans/backlog/2026-06-04_class-design-review.md)): remove verified-dead code from the hierarchy. **No behavior change** — every removal is zero-caller, confirmed by grep + clean build + full test pass. No SBC required.

## Removed
- **BaseModel:** the dead capability-query flags `has_gradient`/`has_nuts`/`has_adaptive_metropolis` (sampler dispatch is config-driven, not capability-driven — zero callers); the throwing standalone `gradient()` virtual (NUTS uses only `logp_and_gradient`/`_full`); the dead `set_step_size`/`get_step_size` accessors + the write-only `step_size_` member.
- **GGM / OMRF / Mixed:** the matching capability / gradient / step-size overrides.
- **OMRF:** the dead standalone `gradient()` body (~100 lines) and the transitively-dead scalar-normalizer trio (`log_pseudoposterior_with_state`/`_internal`/`_pairwise_component`, ~90 lines).
- **NUTSAdaptationController:** unused `has_fixed_mass_matrix()` + the never-set `finalized_mass_`. (`target_acceptance()` **kept** — bgmCompare reuses the shared controller and calls it.)

Net **−287 lines**; `BaseModel`'s virtual surface visibly shrinks.

## Verification
`load_all` clean; all three model families run under both samplers; `test-bgm`, `test-bgmCompare`, `test-methods`, `test-mcmc-diagnostics`, `test-validate-sampler` all green (2362 pass / 0 fail).

