### PR TITLE
fix(mixed): Cholesky drift-guard on precision update (align with GGM)

### DIFF
--- a/src/models/mixed/mixed_mrf_metropolis.cpp
+++ b/src/models/mixed/mixed_mrf_metropolis.cpp
@@ -369,9 +369,16 @@ void MixedMRFModel::cholesky_update_after_precision_edge(
     cholesky_update(cholesky_of_precision_, cont_u1_);
     cholesky_downdate(cholesky_of_precision_, cont_u2_);
 
-    arma::inv(inv_cholesky_of_precision_, arma::trimatu(cholesky_of_precision_));
-    covariance_continuous_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
-    log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
+    // Update the inverse Cholesky; if the rank-2 update has drifted into
+    // ill-conditioning, rebuild the decomposition from scratch (mirrors
+    // GGMModel's drift-guard). pairwise_effects_continuous_ already holds the
+    // accepted value here, so the rebuild reconstructs the accepted state.
+    if (arma::inv(inv_cholesky_of_precision_, arma::trimatu(cholesky_of_precision_))) {
+        covariance_continuous_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
+        log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
+    } else {
+        recompute_pairwise_effects_continuous_decomposition();
+    }
 
     cont_vf1_[i] = 0.0;
     cont_vf1_[j] = 0.0;
@@ -397,9 +404,14 @@ void MixedMRFModel::cholesky_update_after_precision_diag(double old_ii, int i) {
     else
         cholesky_update(cholesky_of_precision_, cont_vf1_);
 
-    arma::inv(inv_cholesky_of_precision_, arma::trimatu(cholesky_of_precision_));
-    covariance_continuous_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
-    log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
+    // Update the inverse Cholesky; fall back to a full rebuild on drift
+    // (mirrors GGMModel's drift-guard).
+    if (arma::inv(inv_cholesky_of_precision_, arma::trimatu(cholesky_of_precision_))) {
+        covariance_continuous_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
+        log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
+    } else {
+        recompute_pairwise_effects_continuous_decomposition();
+    }
 
     cont_vf1_[i] = 0.0;
 }


### PR DESCRIPTION
Closes a robustness asymmetry surfaced by the class-design review: `MixedMRFModel`'s per-step rank-1/2 Cholesky updates computed the inverse with an **unchecked `arma::inv`** and no fallback, while `GGMModel` guards the equivalent step (`arma::solve(...fast)` + `ok` check → `refresh_cholesky()` on failure). The guard was added to GGM and never carried over to Mixed — maintainer confirmed the omission was **not deliberate**.

## Change
In `cholesky_update_after_precision_edge`/`_diag`, capture `arma::inv`'s success flag and on failure rebuild via `recompute_pairwise_effects_continuous_decomposition()`. `pairwise_effects_continuous_` already holds the accepted value when these run (set at mixed_mrf_metropolis.cpp:496-498/576/804-806, before the chol-update call at :500/578/810), so the rebuild reconstructs the accepted state consistently. `recompute_..._decomposition()` itself is left unguarded (it *is* the from-scratch rebuild).

## Behavior / risk
**Common case is bit-identical** — same `arma::inv` call, same covariance/log-det on success. The guard only changes the previously-broken near-singular path: where the old code silently propagated a bad inverse into the next accept/reject, it now rebuilds cleanly (matching GGM). So this can only *improve* correctness on ill-conditioned updates.

## Verification
`load_all` clean; all mixed test files green (gradient, pfaffian, leapfrog, likelihood, simulate-predict, nuts, rattle — 0 failures).

A **mixed-MRF SBC run is the formal gate** before merge (the change is confined to the near-singular path, but it touches the MH accept hot path).