### PR TITLE
test/ci: repair compliance suite; demote weekly-compliance to placeholder until 0.2.0 on CRAN

### DIFF
--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -20,6 +20,8 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::remotes
 
       - name: Install mixedGM (needed for cross-package tests)
         run: Rscript -e 'remotes::install_github("MaartenMarsman/mixedGM")'

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -21,10 +21,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::remotes
-
-      - name: Install mixedGM (needed for cross-package tests)
-        run: Rscript -e 'remotes::install_github("MaartenMarsman/mixedGM")'
+          extra-packages: local::.
 
       - name: Generate compliance fixtures (if missing)
         run: |


### PR DESCRIPTION
The weekly-compliance job had been red since April. Investigating it surfaced a chain of issues — fixed the real ones, and demoted the CI job to a placeholder because bitwise-in-CI is fundamentally unworkable until there's a matching CRAN release.

## Genuine fixes (kept)
- **CI infra:** the job died before running anything — `remotes` missing, a 404ing/unused `mixedGM` install, and `library(bgms)` with the package never installed. (Moot now that the job is a placeholder, but the diagnosis drove the rest.)
- **Stale output-property names:** the harness read `fit$posterior_coclustering_matrix` (renamed → `posterior_mean_coclustering_matrix` in 0.2.0) and `fit$posterior_mean_indicator` for bgmCompare (gone; bgmCompare has only `posterior_summary_indicator`). Updated to the current API. *(Confirmed these were renames, not removals, and not from this session's refactors.)*
- **Config drift → single source of truth:** `generate_fixtures.R` and `test_compliance.R` duplicated the config matrix in different formats and had diverged (test side pinned the CRAN-era `target_accept=0.6/0.65`; generator used the default). Extracted a shared `tests/compliance/config_defs.R` both source, with `target_accept` pinned explicitly per config (NUTS 0.80, adaptive-metropolis 0.44).
- **Re-baselined fixtures to the current 0.2.0 build** (bitwise-vs-CRAN-0.1.6.3 is no longer meaningful).

## Why the CI job is now a placeholder
Bitwise compliance against committed fixtures can't run in CI: NUTS leapfrog trajectories are chaotically FP-sensitive, so fixtures reproduce bitwise **only on the machine that generated them** — verified: ubuntu CI 0/32, macOS CI 8/32, vs **32/32 on the generating machine**. So the bitwise check is inherently local (`test_compliance.R`, documented LOCAL-ONLY).

`weekly-compliance.yaml` is reduced to a green placeholder that documents the planned replacement: **once 0.2.0 is on CRAN**, install the CRAN release + dev build on one runner and diff them bitwise on the fly — same FP environment, so differences are real code changes; platform-independent; no committed fixtures.

## Not in scope
- Continuous **GGM / mixed-MRF** configs (suite is discrete-only; the CRAN baseline predated them) — add when the CRAN-vs-dev job lands.
- The **nightly-validation** failures (2 Rhat-threshold tests + ~964 deprecation warnings) are a separate S9 thread.