### PR TITLE
feat(ggm): add a Gibbs sampler for Gaussian graphical models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 ## New features
 
 * Gaussian graphical models (GGM): `bgm(x, variable_type = "continuous")` fits a GGM with Bayesian edge selection. Sampling uses NUTS on a free-element Cholesky (theta-space) parameterization of the precision matrix, which keeps the precision matrix positive-definite by construction; adaptive-metropolis is also available.
+* GGM Gibbs sampler: `update_method = "gibbs"` fits a GGM with a conjugate row-by-row update of the precision matrix, with or without edge selection. It needs no step-size or proposal tuning and supports a Normal or Cauchy prior on the edges. Continuous data only.
 * Mixed MRF models: `bgm()` accepts a per-variable `variable_type` vector that mixes `"ordinal"`, `"blume-capel"`, and `"continuous"` types to estimate networks with both discrete and continuous variables. `simulate.bgms()` and `predict.bgms()` also support mixed models.
 * Missing data imputation: `na_action = "impute"` integrates over missing values during MCMC sampling for ordinal, continuous, and mixed models.
 * `extract_precision()`: extract posterior precision matrix samples from GGM and mixed models.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,6 +17,10 @@ rcpp_ieee754_log <- function(x) {
     .Call(`_bgms_rcpp_ieee754_log`, x)
 }
 
+ggm_test_gibbs_sweep <- function(suf_stat, n, edge_indicators, pairwise_scale, gamma_shape, gamma_rate, n_sweeps, seed) {
+    .Call(`_bgms_ggm_test_gibbs_sweep`, suf_stat, n, edge_indicators, pairwise_scale, gamma_shape, gamma_rate, n_sweeps, seed)
+}
+
 ggm_test_logp_and_gradient <- function(theta, suf_stat, n, edge_indicators, pairwise_scale) {
     .Call(`_bgms_ggm_test_logp_and_gradient`, theta, suf_stat, n, edge_indicators, pairwise_scale)
 }

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -211,10 +211,13 @@
 #'       graphical model uses a free-element Cholesky parameterization that keeps
 #'       the precision matrix positive-definite; the mixed model uses RATTLE
 #'       constrained integration when excluded edges impose constraints.}
-#'     \item{"gibbs"}{An exact Gibbs sampler for the Gaussian graphical model.
-#'       Available only for all-continuous data on a fixed graph
-#'       (\code{edge_selection = FALSE}) with a Normal or Cauchy (slab)
-#'       interaction prior and a Gamma scale prior on the precision diagonal.}
+#'     \item{"gibbs"}{A Gibbs sampler for the Gaussian graphical model, with a
+#'       conjugate row-block draw of the precision matrix. Available only for
+#'       all-continuous data with a Normal or Cauchy (slab) interaction prior
+#'       and a Gamma scale prior on the precision diagonal. Edge selection is
+#'       supported with a Normal slab (the graph is updated by a
+#'       Metropolis--Hastings between-step); a Cauchy slab requires a fixed
+#'       graph (\code{edge_selection = FALSE}).}
 #'   }
 #'   Default: \code{"nuts"}.
 #'

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -215,9 +215,9 @@
 #'       conjugate row-block draw of the precision matrix. Available only for
 #'       all-continuous data with a Normal or Cauchy (slab) interaction prior
 #'       and a Gamma scale prior on the precision diagonal. Edge selection is
-#'       supported with a Normal slab (the graph is updated by a full-conditional
-#'       birth/death between-step); a Cauchy slab requires a fixed graph
-#'       (\code{edge_selection = FALSE}).}
+#'       supported for both slabs; the graph is updated by a full-conditional
+#'       birth/death between-step (a Cauchy slab uses its scale-mixture
+#'       representation).}
 #'   }
 #'   Default: \code{"nuts"}.
 #'

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -213,9 +213,8 @@
 #'       constrained integration when excluded edges impose constraints.}
 #'     \item{"gibbs"}{An exact Gibbs sampler for the Gaussian graphical model.
 #'       Available only for all-continuous data on a fixed graph
-#'       (\code{edge_selection = FALSE}) with a Normal (slab) interaction prior,
-#'       a Gamma(shape = 1) scale prior on the precision diagonal, and
-#'       \code{delta = 0}.}
+#'       (\code{edge_selection = FALSE}) with a Normal or Cauchy (slab)
+#'       interaction prior and a Gamma scale prior on the precision diagonal.}
 #'   }
 #'   Default: \code{"nuts"}.
 #'

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -215,9 +215,10 @@
 #'       conjugate row-block draw of the precision matrix. Available only for
 #'       all-continuous data with a Normal or Cauchy (slab) interaction prior
 #'       and a Gamma scale prior on the precision diagonal. Edge selection is
-#'       supported with a Normal slab (the graph is updated by a
-#'       Metropolis--Hastings between-step); a Cauchy slab requires a fixed
-#'       graph (\code{edge_selection = FALSE}).}
+#'       supported with a Normal slab and a Gamma scale prior of shape 1 (the
+#'       graph is updated by a full-conditional birth/death between-step); a
+#'       Cauchy slab or a shape other than 1 requires a fixed graph
+#'       (\code{edge_selection = FALSE}).}
 #'   }
 #'   Default: \code{"nuts"}.
 #'

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -211,6 +211,11 @@
 #'       graphical model uses a free-element Cholesky parameterization that keeps
 #'       the precision matrix positive-definite; the mixed model uses RATTLE
 #'       constrained integration when excluded edges impose constraints.}
+#'     \item{"gibbs"}{An exact Gibbs sampler for the Gaussian graphical model.
+#'       Available only for all-continuous data on a fixed graph
+#'       (\code{edge_selection = FALSE}) with a Normal (slab) interaction prior,
+#'       a Gamma(shape = 1) scale prior on the precision diagonal, and
+#'       \code{delta = 0}.}
 #'   }
 #'   Default: \code{"nuts"}.
 #'
@@ -350,7 +355,7 @@ bgm = function(
   edge_selection = TRUE,
   edge_prior = bernoulli_prior(0.5),
   na_action = c("listwise", "impute"),
-  update_method = c("nuts", "adaptive-metropolis"),
+  update_method = c("nuts", "adaptive-metropolis", "gibbs"),
   target_accept,
   nuts_max_depth = 10,
   learn_mass_matrix = TRUE,

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -215,9 +215,8 @@
 #'       conjugate row-block draw of the precision matrix. Available only for
 #'       all-continuous data with a Normal or Cauchy (slab) interaction prior
 #'       and a Gamma scale prior on the precision diagonal. Edge selection is
-#'       supported with a Normal slab and a Gamma scale prior of shape 1 (the
-#'       graph is updated by a full-conditional birth/death between-step); a
-#'       Cauchy slab or a shape other than 1 requires a fixed graph
+#'       supported with a Normal slab (the graph is updated by a full-conditional
+#'       birth/death between-step); a Cauchy slab requires a fixed graph
 #'       (\code{edge_selection = FALSE}).}
 #'   }
 #'   Default: \code{"nuts"}.

--- a/R/bgmCompare.R
+++ b/R/bgmCompare.R
@@ -236,6 +236,9 @@ bgmCompare = function(
   options(bgms.verbose = verbose)
   on.exit(options(bgms.verbose = old_verbose), add = TRUE)
 
+  # bgmCompare supports only NUTS and adaptive-Metropolis.
+  update_method = match.arg(update_method)
+
   if(hasArg(main_difference_model)) {
     lifecycle::deprecate_warn("0.1.6.0", "bgmCompare(main_difference_model =)")
   }

--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -352,14 +352,8 @@ bgm_spec = function(x,
   # where p is the dimension of the continuous precision matrix. For models
   # without a continuous block (omrf, compare) the tilt has no target, so
   # NULL resolves to 0.
-  # The exact conjugate Gibbs sampler is defined only at delta = 0, so the
-  # tilt defaults off for "gibbs" (and an explicit positive delta is rejected
-  # below).
-  um = match.arg(update_method, c("nuts", "adaptive-metropolis", "gibbs"))
   if(is.null(delta)) {
-    delta = if(um == "gibbs") {
-      0
-    } else if(model_type == "ggm") {
+    delta = if(model_type == "ggm") {
       0.5 * log(max(num_variables, 1))
     } else if(model_type == "mixed_mrf") {
       0.5 * log(max(sum(!is_ordinal), 1))
@@ -372,12 +366,6 @@ bgm_spec = function(x,
   if(!is.numeric(delta) || length(delta) != 1L || is.na(delta) ||
     !is.finite(delta) || delta < 0) {
     stop("'delta' must be a single finite non-negative numeric, or NULL.")
-  }
-  if(um == "gibbs" && delta > 0) {
-    stop(
-      "update_method = \"gibbs\" requires delta = 0. The Gibbs sampler does ",
-      "not support a determinant tilt; set delta = 0 or use another method."
-    )
   }
   if(delta > 0 && model_type %in% c("omrf", "compare")) {
     stop(

--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -296,7 +296,8 @@ bgm_spec = function(x,
                     # Sampler
                     update_method = c(
                       "nuts",
-                      "adaptive-metropolis"
+                      "adaptive-metropolis",
+                      "gibbs"
                     ),
                     target_accept = NULL,
                     iter = 10000L,

--- a/R/bgm_spec.R
+++ b/R/bgm_spec.R
@@ -352,8 +352,14 @@ bgm_spec = function(x,
   # where p is the dimension of the continuous precision matrix. For models
   # without a continuous block (omrf, compare) the tilt has no target, so
   # NULL resolves to 0.
+  # The exact conjugate Gibbs sampler is defined only at delta = 0, so the
+  # tilt defaults off for "gibbs" (and an explicit positive delta is rejected
+  # below).
+  um = match.arg(update_method, c("nuts", "adaptive-metropolis", "gibbs"))
   if(is.null(delta)) {
-    delta = if(model_type == "ggm") {
+    delta = if(um == "gibbs") {
+      0
+    } else if(model_type == "ggm") {
       0.5 * log(max(num_variables, 1))
     } else if(model_type == "mixed_mrf") {
       0.5 * log(max(sum(!is_ordinal), 1))
@@ -366,6 +372,12 @@ bgm_spec = function(x,
   if(!is.numeric(delta) || length(delta) != 1L || is.na(delta) ||
     !is.finite(delta) || delta < 0) {
     stop("'delta' must be a single finite non-negative numeric, or NULL.")
+  }
+  if(um == "gibbs" && delta > 0) {
+    stop(
+      "update_method = \"gibbs\" requires delta = 0. The Gibbs sampler does ",
+      "not support a determinant tilt; set delta = 0 or use another method."
+    )
   }
   if(delta > 0 && model_type %in% c("omrf", "compare")) {
     stop(

--- a/R/validate_sampler.R
+++ b/R/validate_sampler.R
@@ -128,9 +128,10 @@ validate_sampler = function(update_method,
     target_accept = switch(update_method,
       "adaptive-metropolis" = 0.44,
       "nuts"                = 0.80,
-      # Exact draw: no acceptance target. Kept numeric (0.44, inert) so the
-      # downstream numeric contract holds; unused by the Gibbs path.
-      "gibbs"               = 0.44
+      # Exact draw: no acceptance target. NA_real_ records that honestly (not a
+      # fake 0.44); it stays numeric length-1 for the downstream contract and is
+      # unused by the Gibbs path (the C++ side ignores target_accept for gibbs).
+      "gibbs"               = NA_real_
     )
   }
 

--- a/R/validate_sampler.R
+++ b/R/validate_sampler.R
@@ -108,21 +108,15 @@ validate_sampler = function(update_method,
     choices = c("nuts", "adaptive-metropolis", "gibbs")
   )
 
-  # "gibbs" is the exact conjugate row-block Gibbs sampler for the Gaussian
-  # graphical model only, and only on a fixed graph (no edge selection).
-  if(update_method == "gibbs") {
-    if(!is_continuous) {
-      stop(
-        "update_method = \"gibbs\" is available only for the Gaussian ",
-        "graphical model (all-continuous data)."
-      )
-    }
-    if(edge_selection) {
-      stop(
-        "update_method = \"gibbs\" requires a fixed graph; set ",
-        "edge_selection = FALSE (edge-selection support is not yet available)."
-      )
-    }
+  # "gibbs" is the conjugate row-block Gibbs sampler for the Gaussian graphical
+  # model only. With edge selection it keeps the Roverato between-step (the
+  # Cauchy slab is not yet supported there; that is checked in C++, where the
+  # slab type is known).
+  if(update_method == "gibbs" && !is_continuous) {
+    stop(
+      "update_method = \"gibbs\" is available only for the Gaussian ",
+      "graphical model (all-continuous data)."
+    )
   }
 
   # --- target_accept ----------------------------------------------------------

--- a/R/validate_sampler.R
+++ b/R/validate_sampler.R
@@ -109,9 +109,10 @@ validate_sampler = function(update_method,
   )
 
   # "gibbs" is the conjugate row-block Gibbs sampler for the Gaussian graphical
-  # model only. With edge selection it keeps the Roverato between-step (the
-  # Cauchy slab is not yet supported there; that is checked in C++, where the
-  # slab type is known).
+  # model only. With edge selection it adds or removes edges with a
+  # full-conditional birth/death step, for both the Normal and Cauchy slabs.
+  # The slab type is not gated here; the C++ side checks that the priors are
+  # supported (a Normal or Cauchy slab with a Gamma diagonal).
   if(update_method == "gibbs" && !is_continuous) {
     stop(
       "update_method = \"gibbs\" is available only for the Gaussian ",

--- a/R/validate_sampler.R
+++ b/R/validate_sampler.R
@@ -105,8 +105,25 @@ validate_sampler = function(update_method,
   # --- update_method ----------------------------------------------------------
   update_method = match.arg(
     update_method,
-    choices = c("nuts", "adaptive-metropolis")
+    choices = c("nuts", "adaptive-metropolis", "gibbs")
   )
+
+  # "gibbs" is the exact conjugate row-block Gibbs sampler for the Gaussian
+  # graphical model only, and only on a fixed graph (no edge selection).
+  if(update_method == "gibbs") {
+    if(!is_continuous) {
+      stop(
+        "update_method = \"gibbs\" is available only for the Gaussian ",
+        "graphical model (all-continuous data)."
+      )
+    }
+    if(edge_selection) {
+      stop(
+        "update_method = \"gibbs\" requires a fixed graph; set ",
+        "edge_selection = FALSE (edge-selection support is not yet available)."
+      )
+    }
+  }
 
   # --- target_accept ----------------------------------------------------------
   if(!is.null(target_accept)) {
@@ -115,7 +132,10 @@ validate_sampler = function(update_method,
   } else {
     target_accept = switch(update_method,
       "adaptive-metropolis" = 0.44,
-      "nuts"                = 0.80
+      "nuts"                = 0.80,
+      # Exact draw: no acceptance target. Kept numeric (0.44, inert) so the
+      # downstream numeric contract holds; unused by the Gibbs path.
+      "gibbs"               = 0.44
     )
   }
 

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -18,7 +18,7 @@ bgm(
   edge_selection = TRUE,
   edge_prior = bernoulli_prior(0.5),
   na_action = c("listwise", "impute"),
-  update_method = c("nuts", "adaptive-metropolis"),
+  update_method = c("nuts", "adaptive-metropolis", "gibbs"),
   target_accept,
   nuts_max_depth = 10,
   learn_mass_matrix = TRUE,
@@ -162,6 +162,11 @@ for all variable types, including under edge selection. The Gaussian
 graphical model uses a free-element Cholesky parameterization that keeps
 the precision matrix positive-definite; the mixed model uses RATTLE
 constrained integration when excluded edges impose constraints.}
+\item{"gibbs"}{An exact Gibbs sampler for the Gaussian graphical model.
+Available only for all-continuous data on a fixed graph
+(\code{edge_selection = FALSE}) with a Normal (slab) interaction prior,
+a Gamma(shape = 1) scale prior on the precision diagonal, and
+\code{delta = 0}.}
 }
 Default: \code{"nuts"}.}
 

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -166,9 +166,9 @@ constrained integration when excluded edges impose constraints.}
 conjugate row-block draw of the precision matrix. Available only for
 all-continuous data with a Normal or Cauchy (slab) interaction prior
 and a Gamma scale prior on the precision diagonal. Edge selection is
-supported with a Normal slab (the graph is updated by a full-conditional
-birth/death between-step); a Cauchy slab requires a fixed graph
-(\code{edge_selection = FALSE}).}
+supported for both slabs; the graph is updated by a full-conditional
+birth/death between-step (a Cauchy slab uses its scale-mixture
+representation).}
 }
 Default: \code{"nuts"}.}
 

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -166,9 +166,8 @@ constrained integration when excluded edges impose constraints.}
 conjugate row-block draw of the precision matrix. Available only for
 all-continuous data with a Normal or Cauchy (slab) interaction prior
 and a Gamma scale prior on the precision diagonal. Edge selection is
-supported with a Normal slab and a Gamma scale prior of shape 1 (the
-graph is updated by a full-conditional birth/death between-step); a
-Cauchy slab or a shape other than 1 requires a fixed graph
+supported with a Normal slab (the graph is updated by a full-conditional
+birth/death between-step); a Cauchy slab requires a fixed graph
 (\code{edge_selection = FALSE}).}
 }
 Default: \code{"nuts"}.}

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -162,10 +162,13 @@ for all variable types, including under edge selection. The Gaussian
 graphical model uses a free-element Cholesky parameterization that keeps
 the precision matrix positive-definite; the mixed model uses RATTLE
 constrained integration when excluded edges impose constraints.}
-\item{"gibbs"}{An exact Gibbs sampler for the Gaussian graphical model.
-Available only for all-continuous data on a fixed graph
-(\code{edge_selection = FALSE}) with a Normal or Cauchy (slab)
-interaction prior and a Gamma scale prior on the precision diagonal.}
+\item{"gibbs"}{A Gibbs sampler for the Gaussian graphical model, with a
+conjugate row-block draw of the precision matrix. Available only for
+all-continuous data with a Normal or Cauchy (slab) interaction prior
+and a Gamma scale prior on the precision diagonal. Edge selection is
+supported with a Normal slab (the graph is updated by a
+Metropolis--Hastings between-step); a Cauchy slab requires a fixed
+graph (\code{edge_selection = FALSE}).}
 }
 Default: \code{"nuts"}.}
 

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -164,9 +164,8 @@ the precision matrix positive-definite; the mixed model uses RATTLE
 constrained integration when excluded edges impose constraints.}
 \item{"gibbs"}{An exact Gibbs sampler for the Gaussian graphical model.
 Available only for all-continuous data on a fixed graph
-(\code{edge_selection = FALSE}) with a Normal (slab) interaction prior,
-a Gamma(shape = 1) scale prior on the precision diagonal, and
-\code{delta = 0}.}
+(\code{edge_selection = FALSE}) with a Normal or Cauchy (slab)
+interaction prior and a Gamma scale prior on the precision diagonal.}
 }
 Default: \code{"nuts"}.}
 

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -166,9 +166,10 @@ constrained integration when excluded edges impose constraints.}
 conjugate row-block draw of the precision matrix. Available only for
 all-continuous data with a Normal or Cauchy (slab) interaction prior
 and a Gamma scale prior on the precision diagonal. Edge selection is
-supported with a Normal slab (the graph is updated by a
-Metropolis--Hastings between-step); a Cauchy slab requires a fixed
-graph (\code{edge_selection = FALSE}).}
+supported with a Normal slab and a Gamma scale prior of shape 1 (the
+graph is updated by a full-conditional birth/death between-step); a
+Cauchy slab or a shape other than 1 requires a fixed graph
+(\code{edge_selection = FALSE}).}
 }
 Default: \code{"nuts"}.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -98,6 +98,24 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// ggm_test_gibbs_sweep
+Rcpp::List ggm_test_gibbs_sweep(const arma::mat& suf_stat, int n, const arma::imat& edge_indicators, double pairwise_scale, double gamma_shape, double gamma_rate, int n_sweeps, int seed);
+RcppExport SEXP _bgms_ggm_test_gibbs_sweep(SEXP suf_statSEXP, SEXP nSEXP, SEXP edge_indicatorsSEXP, SEXP pairwise_scaleSEXP, SEXP gamma_shapeSEXP, SEXP gamma_rateSEXP, SEXP n_sweepsSEXP, SEXP seedSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::mat& >::type suf_stat(suf_statSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    Rcpp::traits::input_parameter< const arma::imat& >::type edge_indicators(edge_indicatorsSEXP);
+    Rcpp::traits::input_parameter< double >::type pairwise_scale(pairwise_scaleSEXP);
+    Rcpp::traits::input_parameter< double >::type gamma_shape(gamma_shapeSEXP);
+    Rcpp::traits::input_parameter< double >::type gamma_rate(gamma_rateSEXP);
+    Rcpp::traits::input_parameter< int >::type n_sweeps(n_sweepsSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    rcpp_result_gen = Rcpp::wrap(ggm_test_gibbs_sweep(suf_stat, n, edge_indicators, pairwise_scale, gamma_shape, gamma_rate, n_sweeps, seed));
+    return rcpp_result_gen;
+END_RCPP
+}
 // ggm_test_logp_and_gradient
 Rcpp::List ggm_test_logp_and_gradient(const arma::vec& theta, const arma::mat& suf_stat, int n, const arma::imat& edge_indicators, double pairwise_scale);
 RcppExport SEXP _bgms_ggm_test_logp_and_gradient(SEXP thetaSEXP, SEXP suf_statSEXP, SEXP nSEXP, SEXP edge_indicatorsSEXP, SEXP pairwise_scaleSEXP) {
@@ -697,6 +715,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_bgms_get_explog_switch", (DL_FUNC) &_bgms_get_explog_switch, 0},
     {"_bgms_rcpp_ieee754_exp", (DL_FUNC) &_bgms_rcpp_ieee754_exp, 1},
     {"_bgms_rcpp_ieee754_log", (DL_FUNC) &_bgms_rcpp_ieee754_log, 1},
+    {"_bgms_ggm_test_gibbs_sweep", (DL_FUNC) &_bgms_ggm_test_gibbs_sweep, 8},
     {"_bgms_ggm_test_logp_and_gradient", (DL_FUNC) &_bgms_ggm_test_logp_and_gradient, 5},
     {"_bgms_ggm_test_forward_map", (DL_FUNC) &_bgms_ggm_test_forward_map, 2},
     {"_bgms_sample_ggm_prior", (DL_FUNC) &_bgms_sample_ggm_prior, 14},

--- a/src/ggm_gibbs_test_interface.cpp
+++ b/src/ggm_gibbs_test_interface.cpp
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------------
+// ggm_gibbs_test_interface.cpp
+//
+// R-facing test entries for the GGM row-block Gibbs sampler. Kept separate from
+// the sampler dispatch (chain_runner) and from ggm_gradient_interface.cpp (which
+// exposes the NUTS gradient): this file only drives the conjugate within-step in
+// isolation so its full-conditional math can be validated without the
+// between-step, edge moves, or warmup machinery.
+// -----------------------------------------------------------------------------
+
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
+
+#include "models/ggm/ggm_model.h"
+#include "priors/parameter_prior.h"
+
+// -----------------------------------------------------------------------------
+// ggm_test_gibbs_sweep:
+//   Construct a GGM with a Normal slab and Gamma(alpha=1) diagonal prior, then
+//   run n_sweeps full row-block Gibbs sweeps via GGMModel::do_one_gibbs_step()
+//   -- the same sweep the GibbsSampler drives in a real run. The graph is fixed
+//   (no edge selection). Returns the p x p precision matrix K after every sweep.
+// -----------------------------------------------------------------------------
+
+// [[Rcpp::export(name = "ggm_test_gibbs_sweep")]]
+Rcpp::List ggm_test_gibbs_sweep(
+    const arma::mat& suf_stat,
+    int n,
+    const arma::imat& edge_indicators,
+    double pairwise_scale,
+    double gamma_shape,
+    double gamma_rate,
+    int n_sweeps,
+    int seed)
+{
+    const int p = edge_indicators.n_rows;
+    auto ip = create_parameter_prior("normal", pairwise_scale);
+    auto dp = create_scale_prior("gamma", gamma_shape, gamma_rate);
+
+    arma::mat inc_prob(p, p, arma::fill::value(0.5));
+    GGMModel model(n, suf_stat, inc_prob, edge_indicators,
+                   /*edge_selection=*/false, std::move(ip), std::move(dp));
+    model.set_determinant_tilt(0.0);
+    model.set_seed(seed);
+
+    if (!model.row_block_gibbs_eligible()) {
+        Rcpp::stop("ggm_test_gibbs_sweep: model is not eligible "
+                   "(requires Normal slab, Gamma alpha=1, delta=0).");
+    }
+
+    arma::cube K_samples(p, p, n_sweeps);
+    for (int s = 0; s < n_sweeps; ++s) {
+        model.do_one_gibbs_step(s);
+        K_samples.slice(s) = model.get_precision_matrix();
+    }
+
+    return Rcpp::List::create(
+        Rcpp::Named("K_samples") = K_samples
+    );
+}

--- a/src/mcmc/execution/chain_runner.cpp
+++ b/src/mcmc/execution/chain_runner.cpp
@@ -4,6 +4,7 @@
 #include <tbb/global_control.h>
 #include "mcmc/samplers/nuts_sampler.h"
 #include "mcmc/samplers/metropolis_sampler.h"
+#include "mcmc/samplers/gibbs_sampler.h"
 
 
 namespace {
@@ -29,6 +30,8 @@ SamplerSpec resolve_sampler_spec(const std::string& sampler_type) {
         return SamplerSpec{SamplerKind::NUTS, /*learn_sd=*/true, /*nuts_diag=*/true, /*am_diag=*/false};
     } else if (sampler_type == "adaptive-metropolis") {
         return SamplerSpec{SamplerKind::AdaptiveMetropolis, /*learn_sd=*/false, /*nuts_diag=*/false, /*am_diag=*/true};
+    } else if (sampler_type == "gibbs") {
+        return SamplerSpec{SamplerKind::Gibbs, /*learn_sd=*/false, /*nuts_diag=*/false, /*am_diag=*/false};
     } else {
         Rcpp::stop("Unknown sampler_type: '%s'", sampler_type.c_str());
     }
@@ -40,6 +43,8 @@ std::unique_ptr<SamplerBase> create_sampler(SamplerKind kind, const SamplerConfi
             return std::make_unique<NUTSSampler>(config, schedule);
         case SamplerKind::AdaptiveMetropolis:
             return std::make_unique<MetropolisSampler>(config, schedule);
+        case SamplerKind::Gibbs:
+            return std::make_unique<GibbsSampler>(config, schedule);
     }
     Rcpp::stop("Unhandled SamplerKind");  // unreachable: kind comes from resolve_sampler_spec
 }

--- a/src/mcmc/execution/chain_runner.h
+++ b/src/mcmc/execution/chain_runner.h
@@ -15,7 +15,7 @@
 
 
 /** Which concrete sampler a run uses. */
-enum class SamplerKind { NUTS, AdaptiveMetropolis };
+enum class SamplerKind { NUTS, AdaptiveMetropolis, Gibbs };
 
 /**
  * Behavioral descriptor for a sampler type. resolve_sampler_spec is the single

--- a/src/mcmc/samplers/gibbs_sampler.h
+++ b/src/mcmc/samplers/gibbs_sampler.h
@@ -8,59 +8,37 @@
 /**
  * GibbsSampler - conjugate Gibbs within-step for the GGM
  *
- * On a fixed graph the within-step is an exact conjugate row sweep from the
- * first iteration. With edge selection the between-step is a Roverato birth /
- * death move (driven by the chain runner) whose proposal SD needs tuning, so
- * warmup runs the adaptive-Metropolis within-step to tune those proposal SDs,
- * and production switches to the conjugate Gibbs sweep with the SDs frozen.
+ * The within-step is an exact conjugate row sweep. With edge selection the
+ * between-step (driven by the chain runner) uses the full-conditional edge
+ * birth/death proposal, which needs no tuning, so the Gibbs sweep runs from the
+ * first iteration with no warmup staging.
  *
- * The actual sweep logic (do_one_metropolis_step, do_one_gibbs_step) is
- * model-specific; this is a thin wrapper providing the uniform sampler
- * interface. Only constructed for models whose full-conditionals are
- * conjugate (currently the GGM); create_sampler gates this.
+ * The sweep logic (do_one_gibbs_step) is model-specific; this is a thin wrapper
+ * providing the uniform sampler interface. Only constructed for models whose
+ * full-conditionals are conjugate (currently the GGM); create_sampler gates it.
  */
 class GibbsSampler : public SamplerBase {
 public:
     /**
-     * Construct a Gibbs sampler.
-     * @param config    Sampler configuration; supplies the warmup length.
-     * @param schedule  Shared warmup schedule (used to set up adaptation).
+     * @param config    Sampler configuration (unused; the draw is exact).
+     * @param schedule  Shared warmup schedule (unused; no adaptation).
      */
-    GibbsSampler(const SamplerConfig& config, WarmupSchedule& schedule)
-        : schedule_(schedule), warmup_(config.no_warmup), initialized_(false) {}
-
-    /**
-     * Set up Metropolis adaptation, used to tune the between-step proposal SDs
-     * during warmup when edge selection is active.
-     */
-    void initialize(BaseModel& model) override {
-        if (initialized_) return;
-        model.init_metropolis_adaptation(schedule_);
-        initialized_ = true;
+    GibbsSampler(const SamplerConfig& config, WarmupSchedule& schedule) {
+        (void)config;
+        (void)schedule;
     }
 
-    /**
-     * One step. With edge selection, warmup uses the adaptive-Metropolis
-     * within-step (tuning the proposal SDs the between-step reuses) and
-     * production uses the exact conjugate Gibbs sweep. On a fixed graph the
-     * Gibbs sweep is used throughout.
-     */
+    /** Switch the model's between-step to the full-conditional edge proposal. */
+    void initialize(BaseModel& model) override {
+        model.set_conjugate_edge_proposal(true);
+    }
+
+    /** One conjugate Gibbs sweep; the exact draw always "accepts". */
     StepResult step(BaseModel& model, int iteration) override {
-        if (!initialized_) initialize(model);
+        model.do_one_gibbs_step(iteration);
 
         StepResult result;
-        if (model.has_edge_selection() && iteration < warmup_) {
-            model.do_one_metropolis_step(iteration);
-            result.accept_prob = model.last_metropolis_mean_accept_prob();
-        } else {
-            model.do_one_gibbs_step(iteration);
-            result.accept_prob = 1.0;
-        }
+        result.accept_prob = 1.0;
         return result;
     }
-
-private:
-    WarmupSchedule& schedule_;
-    int warmup_;
-    bool initialized_;
 };

--- a/src/mcmc/samplers/gibbs_sampler.h
+++ b/src/mcmc/samplers/gibbs_sampler.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "mcmc/samplers/sampler_base.h"
+#include "mcmc/execution/sampler_config.h"
+#include "mcmc/execution/warmup_schedule.h"
+#include "models/base_model.h"
+
+/**
+ * GibbsSampler - exact conjugate Gibbs sampler
+ *
+ * Delegates to the model's full-conditional Gibbs sweep. Because each draw is
+ * exact there is no proposal-SD adaptation and no warmup tuning; this is a
+ * thin wrapper that provides a uniform interface consistent with the other
+ * samplers (Metropolis, NUTS), while the actual sweep logic
+ * (do_one_gibbs_step) is model-specific.
+ *
+ * Only constructed for models whose full-conditionals are conjugate (currently
+ * the GGM row-block Gibbs within-step); create_sampler gates this.
+ */
+class GibbsSampler : public SamplerBase {
+public:
+    /**
+     * Construct a Gibbs sampler.
+     * @param config    Sampler configuration (unused; the draw is exact).
+     * @param schedule  Shared warmup schedule (unused; no adaptation).
+     */
+    GibbsSampler(const SamplerConfig& config, WarmupSchedule& schedule) {
+        (void)config;
+        (void)schedule;
+    }
+
+    /**
+     * Perform one Gibbs sweep.
+     *
+     * The draw is exact, so the reported acceptance probability is always 1.
+     */
+    StepResult step(BaseModel& model, int iteration) override {
+        model.do_one_gibbs_step(iteration);
+
+        StepResult result;
+        result.accept_prob = 1.0;
+        return result;
+    }
+};

--- a/src/mcmc/samplers/gibbs_sampler.h
+++ b/src/mcmc/samplers/gibbs_sampler.h
@@ -6,39 +6,61 @@
 #include "models/base_model.h"
 
 /**
- * GibbsSampler - exact conjugate Gibbs sampler
+ * GibbsSampler - conjugate Gibbs within-step for the GGM
  *
- * Delegates to the model's full-conditional Gibbs sweep. Because each draw is
- * exact there is no proposal-SD adaptation and no warmup tuning; this is a
- * thin wrapper that provides a uniform interface consistent with the other
- * samplers (Metropolis, NUTS), while the actual sweep logic
- * (do_one_gibbs_step) is model-specific.
+ * On a fixed graph the within-step is an exact conjugate row sweep from the
+ * first iteration. With edge selection the between-step is a Roverato birth /
+ * death move (driven by the chain runner) whose proposal SD needs tuning, so
+ * warmup runs the adaptive-Metropolis within-step to tune those proposal SDs,
+ * and production switches to the conjugate Gibbs sweep with the SDs frozen.
  *
- * Only constructed for models whose full-conditionals are conjugate (currently
- * the GGM row-block Gibbs within-step); create_sampler gates this.
+ * The actual sweep logic (do_one_metropolis_step, do_one_gibbs_step) is
+ * model-specific; this is a thin wrapper providing the uniform sampler
+ * interface. Only constructed for models whose full-conditionals are
+ * conjugate (currently the GGM); create_sampler gates this.
  */
 class GibbsSampler : public SamplerBase {
 public:
     /**
      * Construct a Gibbs sampler.
-     * @param config    Sampler configuration (unused; the draw is exact).
-     * @param schedule  Shared warmup schedule (unused; no adaptation).
+     * @param config    Sampler configuration; supplies the warmup length.
+     * @param schedule  Shared warmup schedule (used to set up adaptation).
      */
-    GibbsSampler(const SamplerConfig& config, WarmupSchedule& schedule) {
-        (void)config;
-        (void)schedule;
+    GibbsSampler(const SamplerConfig& config, WarmupSchedule& schedule)
+        : schedule_(schedule), warmup_(config.no_warmup), initialized_(false) {}
+
+    /**
+     * Set up Metropolis adaptation, used to tune the between-step proposal SDs
+     * during warmup when edge selection is active.
+     */
+    void initialize(BaseModel& model) override {
+        if (initialized_) return;
+        model.init_metropolis_adaptation(schedule_);
+        initialized_ = true;
     }
 
     /**
-     * Perform one Gibbs sweep.
-     *
-     * The draw is exact, so the reported acceptance probability is always 1.
+     * One step. With edge selection, warmup uses the adaptive-Metropolis
+     * within-step (tuning the proposal SDs the between-step reuses) and
+     * production uses the exact conjugate Gibbs sweep. On a fixed graph the
+     * Gibbs sweep is used throughout.
      */
     StepResult step(BaseModel& model, int iteration) override {
-        model.do_one_gibbs_step(iteration);
+        if (!initialized_) initialize(model);
 
         StepResult result;
-        result.accept_prob = 1.0;
+        if (model.has_edge_selection() && iteration < warmup_) {
+            model.do_one_metropolis_step(iteration);
+            result.accept_prob = model.last_metropolis_mean_accept_prob();
+        } else {
+            model.do_one_gibbs_step(iteration);
+            result.accept_prob = 1.0;
+        }
         return result;
     }
+
+private:
+    WarmupSchedule& schedule_;
+    int warmup_;
+    bool initialized_;
 };

--- a/src/models/base_model.h
+++ b/src/models/base_model.h
@@ -94,6 +94,13 @@ public:
     }
 
     /**
+     * Enable the full-conditional edge birth/death proposal for the between-model
+     * step, used by the Gibbs sampler in place of the random-walk Roverato
+     * proposal (which needs tuning). Default no-op; only the GGM overrides it.
+     */
+    virtual void set_conjugate_edge_proposal(bool /*enable*/) {}
+
+    /**
      * Mean Metropolis acceptance probability across all components updated
      * in the most recent do_one_metropolis_step() call.
      *

--- a/src/models/base_model.h
+++ b/src/models/base_model.h
@@ -80,6 +80,20 @@ public:
     virtual void do_one_metropolis_step(int iteration = -1) = 0;
 
     /**
+     * Perform one full Gibbs sweep over all parameters.
+     *
+     * Default throws: only models with an exact conjugate full-conditional
+     * sweep (currently GGM row-block Gibbs) override this. The GibbsSampler
+     * wrapper is only constructed for models that support it.
+     *
+     * @param iteration  Current iteration index (unused by exact samplers;
+     *                   kept for interface symmetry with the Metropolis step).
+     */
+    virtual void do_one_gibbs_step(int /*iteration*/ = -1) {
+        throw std::runtime_error("do_one_gibbs_step not implemented for this model");
+    }
+
+    /**
      * Mean Metropolis acceptance probability across all components updated
      * in the most recent do_one_metropolis_step() call.
      *

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -352,12 +352,17 @@ void GGMModel::refresh_cauchy_omega_() {
     const double two_sig2 = 2.0 * sigma * sigma;
     for (size_t i = 0; i + 1 < p_; ++i) {
         for (size_t j = i + 1; j < p_; ++j) {
-            if (edge_indicators_(i, j) == 0) continue;   // K_ij = 0: omega inert
-            const double kyy = -0.5 * precision_matrix_(i, j);
-            // omega | K ~ InvGamma(1, 1/2 + kyy^2 / (2 sigma^2)); draw as
-            // 1 / Gamma(1, rate) since InvGamma(a, b) = 1 / Gamma(a, b).
-            const double rate = 0.5 + kyy * kyy / two_sig2;
-            const double w = 1.0 / rgamma(rng_, 1.0, rate);
+            double w;
+            if (edge_indicators_(i, j) == 1) {
+                // Active: omega | K ~ InvGamma(1, 1/2 + kyy^2/(2 sigma^2)),
+                // drawn as 1 / Gamma(1, rate) since InvGamma(a, b) = 1/Gamma(a, b).
+                const double kyy = -0.5 * precision_matrix_(i, j);
+                w = 1.0 / rgamma(rng_, 1.0, 0.5 + kyy * kyy / two_sig2);
+            } else {
+                // Inactive (K_ij = 0): omega ~ prior InvGamma(1/2, 1/2). Kept
+                // fresh so an edge-selection add can condition on a valid weight.
+                w = 1.0 / rgamma(rng_, 0.5, 0.5);
+            }
             omega_(i, j) = w;
             omega_(j, i) = w;
         }
@@ -766,20 +771,27 @@ void GGMModel::update_edge_indicator_conjugate(size_t i, size_t j) {
     const double beta0 = diagp->rate();
     const double alpha = diagp->shape();
 
+    // Conditional on the Cauchy scale-mixture weight omega (= 1 for a Normal
+    // slab), k_ij has slab variance 4 sigma^2 omega, so the slab precision is
+    // inv_4s2 / omega. Everything else is the Normal-slab move.
+    const double w = slab_is_cauchy_() ? omega_(i, j) : 1.0;
+    const double inv_4s2w = inv_4s2 / w;
+
     // Gaussian full conditional of phi (rest of K fixed, edge present):
-    //   Q  = c2^2/(4 sigma^2) + beta0 + S_jj
-    //   mu = -c2 (S_ij + c1/(4 sigma^2)) / Q
-    const double Q  = c2 * c2 * inv_4s2 + beta0 + suf_stat_(j, j);
-    const double mu = -c2 * (suf_stat_(i, j) + c1 * inv_4s2) / Q;
+    //   Q  = c2^2/(4 sigma^2 omega) + beta0 + S_jj
+    //   mu = -c2 (S_ij + c1/(4 sigma^2 omega)) / Q
+    const double Q  = c2 * c2 * inv_4s2w + beta0 + suf_stat_(j, j);
+    const double mu = -c2 * (suf_stat_(i, j) + c1 * inv_4s2w) / Q;
 
     // Proposal ordinate at the spike phi_0 = -c1/c2, on the k_ij scale
-    // (q(0) = q_phi(phi_0)/c2), and the slab density at k_ij = 0 (the -log 2 is
-    // the |dK_yy/dK_ij| = 1/2 Jacobian, since the slab is in K_yy coordinates).
+    // (q(0) = q_phi(phi_0)/c2), and the (conditional Gaussian) slab density of
+    // k_ij at 0: N(0; 0, 4 sigma^2 omega).
     const double phi0 = -c1 / c2;
     const double d = phi0 - mu;
     const double log_q0 = 0.5 * (MY_LOG(Q) - MY_LOG(2.0 * arma::datum::pi))
                           - 0.5 * Q * d * d - MY_LOG(c2);
-    const double log_pslab0 = interaction_prior_->logp(0.0) - MY_LOG(2.0);
+    const double log_pslab0 =
+        -0.5 * MY_LOG(2.0 * arma::datum::pi * 4.0 * sigma * sigma * w);
     const double log_odds = MY_LOG(inclusion_probability_(i, j))
                             - MY_LOG(1.0 - inclusion_probability_(i, j));
 

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -322,28 +322,62 @@ void GGMModel::apply_rank2_chol_smw_update_()
 }
 
 bool GGMModel::row_block_gibbs_eligible() {
-    // Normal slab + Gamma(alpha=1, .) on K_ii/2 + zero determinant tilt is
-    // the exact-conjugate scope. Other prior families and alpha/delta values
-    // are handled by post-step corrections ported in later commits.
-    if (dynamic_cast<const NormalPrior*>(interaction_prior_.get()) == nullptr)
-        return false;
-    const auto* diag = dynamic_cast<const GammaScalePrior*>(diagonal_prior_.get());
-    if (diag == nullptr) return false;
-    if (std::abs(diag->shape() - 1.0) > 1e-12) return false;
-    if (determinant_tilt_ != 0.0) return false;
+    // Scope: a Normal or Cauchy slab on the off-diagonals and any Gamma(., .)
+    // on K_ii/2. The determinant tilt is a shift in the xi Gamma shape; a
+    // Gamma shape != 1 is an independent-MH correction; a Cauchy slab is the
+    // scale-mixture-of-normals with a per-edge weight omega. None of these
+    // gate eligibility.
+    const bool normal = dynamic_cast<const NormalPrior*>(interaction_prior_.get()) != nullptr;
+    const bool cauchy = dynamic_cast<const CauchyPrior*>(interaction_prior_.get()) != nullptr;
+    if (!normal && !cauchy) return false;
+    if (dynamic_cast<const GammaScalePrior*>(diagonal_prior_.get()) == nullptr) return false;
     return true;
 }
 
+double GGMModel::slab_scale_() const {
+    if (const auto* n = dynamic_cast<const NormalPrior*>(interaction_prior_.get()))
+        return n->scale();
+    if (const auto* c = dynamic_cast<const CauchyPrior*>(interaction_prior_.get()))
+        return c->scale();
+    return 1.0;  // unreachable once row_block_gibbs_eligible() holds
+}
+
+bool GGMModel::slab_is_cauchy_() const {
+    return dynamic_cast<const CauchyPrior*>(interaction_prior_.get()) != nullptr;
+}
+
+void GGMModel::refresh_cauchy_omega_() {
+    if (!slab_is_cauchy_()) return;
+    const double sigma = slab_scale_();
+    const double two_sig2 = 2.0 * sigma * sigma;
+    for (size_t i = 0; i + 1 < p_; ++i) {
+        for (size_t j = i + 1; j < p_; ++j) {
+            if (edge_indicators_(i, j) == 0) continue;   // K_ij = 0: omega inert
+            const double kyy = -0.5 * precision_matrix_(i, j);
+            // omega | K ~ InvGamma(1, 1/2 + kyy^2 / (2 sigma^2)); draw as
+            // 1 / Gamma(1, rate) since InvGamma(a, b) = 1 / Gamma(a, b).
+            const double rate = 0.5 + kyy * kyy / two_sig2;
+            const double w = 1.0 / rgamma(rng_, 1.0, rate);
+            omega_(i, j) = w;
+            omega_(j, i) = w;
+        }
+    }
+}
+
 void GGMModel::update_row_block_gibbs(size_t i) {
-    // Conjugate Gaussian-Gamma draw of (beta = K_{N_i, i}, kii = K_{i,i}) given
-    // A = K_{-i, -i}, S, and the Normal-slab x Gamma(alpha=1) prior. delta = 0
-    // here; the determinant-tilt shape shift lands in a later commit.
+    // Gaussian-Gamma draw of (beta = K_{N_i, i}, kii = K_{i,i}) given
+    // A = K_{-i, -i}, S, and the slab x Gamma prior. The determinant tilt
+    // enters as a shift in the xi shape; a Gamma shape alpha != 1 is corrected
+    // by an independent-MH accept below; a Cauchy slab enters through the
+    // per-edge weights omega_ (fixed at 1 for a Normal slab).
     //
-    // Slab sigma and diagonal Gamma rate beta0 are read directly from the
-    // (already eligibility-checked) priors: Normal slab std on K_yy_ij = -K_ij/2,
-    // Gamma rate on K_ii/2.
-    const double sigma = static_cast<const NormalPrior*>(interaction_prior_.get())->scale();
-    const double beta0 = static_cast<const GammaScalePrior*>(diagonal_prior_.get())->rate();
+    // Slab sigma (std on K_yy_ij = -K_ij/2), diagonal Gamma rate beta0, and
+    // shape alpha are read from the (already eligibility-checked) priors.
+    const auto* diag  = static_cast<const GammaScalePrior*>(diagonal_prior_.get());
+    const double sigma = slab_scale_();
+    const double beta0 = diag->rate();
+    const double alpha = diag->shape();
+    const bool   cauchy = slab_is_cauchy_();
     const double s_ii  = suf_stat_(i, i);
 
     // Active neighbour set N_i (in row order).
@@ -359,8 +393,10 @@ void GGMModel::update_row_block_gibbs(size_t i) {
     arma::vec beta_old(q);
     for (size_t k = 0; k < q; ++k) beta_old(k) = precision_matrix_(i, Ni[k]);
 
-    // xi shape alpha = 1, delta = 0 -> n/2 + 1.
-    const double xi_shape = static_cast<double>(n_) / 2.0 + 1.0;
+    // xi shape: n/2 + delta + 1 (alpha = 1). The determinant tilt |K|^delta
+    // contributes delta * log(xi) to the K_ii log-kernel (|K| = |A| * xi), so
+    // it shifts the Gamma shape and leaves the rate unchanged.
+    const double xi_shape = static_cast<double>(n_) / 2.0 + determinant_tilt_ + 1.0;
     const double xi_rate  = (beta0 + s_ii) / 2.0;
 
     arma::vec beta_new(q, arma::fill::zeros);
@@ -383,10 +419,16 @@ void GGMModel::update_row_block_gibbs(size_t i) {
             }
         }
 
-        // M = (beta0 + S_ii) C + (1/(4 sigma^2)) I -- symmetric positive-definite.
+        // M = (beta0 + S_ii) C + diag(1/(4 sigma^2 omega_k)) -- symmetric PD.
+        // The slab precision on K_ij is 1/(4 sigma^2) since K_yy_ij = -K_ij/2;
+        // the Cauchy scale-mixture divides it by the per-edge weight omega_k
+        // (omega = 1 recovers the Normal slab).
         const double inv_4sig2 = 1.0 / (4.0 * sigma * sigma);
         arma::mat M = (beta0 + s_ii) * C;
-        for (size_t k = 0; k < q; ++k) M(k, k) += inv_4sig2;
+        for (size_t k = 0; k < q; ++k) {
+            const double w_k = cauchy ? omega_(i, Ni[k]) : 1.0;
+            M(k, k) += inv_4sig2 / w_k;
+        }
 
         arma::mat L_M;
         if (!arma::chol(L_M, M, "lower")) {
@@ -412,6 +454,18 @@ void GGMModel::update_row_block_gibbs(size_t i) {
         // xi ~ Gamma; K_{i,i} = xi + beta^T C beta.
         const double xi = rgamma(rng_, xi_shape, xi_rate);
         kii_new = xi + arma::as_scalar(beta_new.t() * C * beta_new);
+    }
+
+    // Gamma shape alpha != 1: the prior carries an extra (kii/2)^(alpha-1)
+    // factor that does not factorize across (beta, xi). Treat the alpha = 1
+    // joint draw as an independent-MH proposal; the beta and S_ii factors
+    // cancel, leaving the ratio (kii_new/kii_old)^(alpha-1). The guard keeps
+    // the alpha = 1 path free of the runif draw.
+    if (std::abs(alpha - 1.0) > 1e-12) {
+        const double log_mh = (alpha - 1.0) * (std::log(kii_new) - std::log(kii_old));
+        if (MY_LOG(runif(rng_)) >= log_mh) {
+            return;  // reject: leave precision_matrix_, chol(K), Sigma unchanged
+        }
     }
 
     // Write the new K column / row, then apply the symmetric rank-2 update to
@@ -440,11 +494,13 @@ void GGMModel::update_row_block_gibbs(size_t i) {
 }
 
 void GGMModel::do_one_gibbs_step(int /*iteration*/) {
-    // One full sweep: each column of K drawn from its exact conjugate
-    // full-conditional. No proposal adaptation (the draw is exact).
+    // One full sweep: each column of K drawn from its full-conditional. For a
+    // Cauchy slab, alternate the row sweep (conditional on omega) with a
+    // refresh of the scale-mixture weights omega (conditional on K).
     for (size_t i = 0; i < p_; ++i) {
         update_row_block_gibbs(i);
     }
+    refresh_cauchy_omega_();
 }
 
 double GGMModel::ggm_diag_move(size_t i) {

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -288,6 +288,18 @@ void GGMModel::cholesky_update_after_edge(double omega_ij_old, double omega_jj_o
     vf2_[i] = v2_[0];
     vf2_[j] = v2_[1];
 
+    apply_rank2_chol_smw_update_();
+
+    // reset for next iteration
+    vf1_[i] = 0.0;
+    vf1_[j] = 0.0;
+    vf2_[i] = 0.0;
+    vf2_[j] = 0.0;
+
+}
+
+void GGMModel::apply_rank2_chol_smw_update_()
+{
     // we now have
     // aOmega_prop - (aOmega + vf1 %*% t(vf2) + vf2 %*% t(vf1))
 
@@ -307,13 +319,132 @@ void GGMModel::cholesky_update_after_edge(double omega_ij_old, double omega_jj_o
     } else {
         covariance_matrix_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
     }
+}
 
-    // reset for next iteration
+bool GGMModel::row_block_gibbs_eligible() {
+    // Normal slab + Gamma(alpha=1, .) on K_ii/2 + zero determinant tilt is
+    // the exact-conjugate scope. Other prior families and alpha/delta values
+    // are handled by post-step corrections ported in later commits.
+    if (dynamic_cast<const NormalPrior*>(interaction_prior_.get()) == nullptr)
+        return false;
+    const auto* diag = dynamic_cast<const GammaScalePrior*>(diagonal_prior_.get());
+    if (diag == nullptr) return false;
+    if (std::abs(diag->shape() - 1.0) > 1e-12) return false;
+    if (determinant_tilt_ != 0.0) return false;
+    return true;
+}
+
+void GGMModel::update_row_block_gibbs(size_t i) {
+    // Conjugate Gaussian-Gamma draw of (beta = K_{N_i, i}, kii = K_{i,i}) given
+    // A = K_{-i, -i}, S, and the Normal-slab x Gamma(alpha=1) prior. delta = 0
+    // here; the determinant-tilt shape shift lands in a later commit.
+    //
+    // Slab sigma and diagonal Gamma rate beta0 are read directly from the
+    // (already eligibility-checked) priors: Normal slab std on K_yy_ij = -K_ij/2,
+    // Gamma rate on K_ii/2.
+    const double sigma = static_cast<const NormalPrior*>(interaction_prior_.get())->scale();
+    const double beta0 = static_cast<const GammaScalePrior*>(diagonal_prior_.get())->rate();
+    const double s_ii  = suf_stat_(i, i);
+
+    // Active neighbour set N_i (in row order).
+    std::vector<size_t> Ni;
+    Ni.reserve(p_ - 1);
+    for (size_t k = 0; k < p_; ++k) {
+        if (k != i && edge_indicators_(i, k) == 1) Ni.push_back(k);
+    }
+    const size_t q = Ni.size();
+
+    // Stash old K column entries so the rank-2 update can encode the delta.
+    const double kii_old = precision_matrix_(i, i);
+    arma::vec beta_old(q);
+    for (size_t k = 0; k < q; ++k) beta_old(k) = precision_matrix_(i, Ni[k]);
+
+    // xi shape alpha = 1, delta = 0 -> n/2 + 1.
+    const double xi_shape = static_cast<double>(n_) / 2.0 + 1.0;
+    const double xi_rate  = (beta0 + s_ii) / 2.0;
+
+    arma::vec beta_new(q, arma::fill::zeros);
+    double kii_new;
+
+    if (q == 0) {
+        // No active neighbours: K_{i,i} = xi, no beta draw.
+        kii_new = rgamma(rng_, xi_shape, xi_rate);
+    } else {
+        // C = (A^{-1})_{N_i, N_i} via Schur on Sigma:
+        //   C_{kl} = Sigma_{N_i[k], N_i[l]} - Sigma_{N_i[k], i} Sigma_{i, N_i[l]} / Sigma_{ii}
+        const double sigma_ii = covariance_matrix_(i, i);
+        arma::vec sigma_iNi(q);
+        for (size_t k = 0; k < q; ++k) sigma_iNi(k) = covariance_matrix_(i, Ni[k]);
+        arma::mat C(q, q);
+        for (size_t k = 0; k < q; ++k) {
+            for (size_t l = 0; l < q; ++l) {
+                C(k, l) = covariance_matrix_(Ni[k], Ni[l])
+                          - sigma_iNi(k) * sigma_iNi(l) / sigma_ii;
+            }
+        }
+
+        // M = (beta0 + S_ii) C + (1/(4 sigma^2)) I -- symmetric positive-definite.
+        const double inv_4sig2 = 1.0 / (4.0 * sigma * sigma);
+        arma::mat M = (beta0 + s_ii) * C;
+        for (size_t k = 0; k < q; ++k) M(k, k) += inv_4sig2;
+
+        arma::mat L_M;
+        if (!arma::chol(L_M, M, "lower")) {
+            // M is PD by construction (C PD as submatrix of A^{-1}, prior
+            // precision > 0). A failure here means numerical trouble; skip
+            // this row's update rather than corrupt K.
+            return;
+        }
+
+        // S_{N_i, i} vector.
+        arma::vec s_Ni_i(q);
+        for (size_t k = 0; k < q; ++k) s_Ni_i(k) = suf_stat_(Ni[k], i);
+
+        // Mean mu = -M^{-1} S_{N_i, i}. Two triangular solves: L y = -S, L^T mu = y.
+        arma::vec y  = arma::solve(arma::trimatl(L_M), -s_Ni_i);
+        arma::vec mu = arma::solve(arma::trimatu(L_M.t()), y);
+
+        // beta = mu + L^{-T} z, z ~ N(0, I_q): one triangular solve.
+        arma::vec z = arma_rnorm_vec(rng_, q);
+        arma::vec w = arma::solve(arma::trimatu(L_M.t()), z);
+        beta_new = mu + w;
+
+        // xi ~ Gamma; K_{i,i} = xi + beta^T C beta.
+        const double xi = rgamma(rng_, xi_shape, xi_rate);
+        kii_new = xi + arma::as_scalar(beta_new.t() * C * beta_new);
+    }
+
+    // Write the new K column / row, then apply the symmetric rank-2 update to
+    // chol(K) and Sigma. The rank-2 decomposition is
+    //   Delta K = e_i vf2^T + vf2 e_i^T,
+    //   (vf2)_i      = (kii_new - kii_old) / 2,
+    //   (vf2)_{N_i} = beta_new - beta_old,
+    //   (vf2)_k      = 0  otherwise
+    // which reproduces the sparse column-change at row/col i without touching
+    // the (k, l) entries off row i.
+    precision_matrix_(i, i) = kii_new;
+    for (size_t k = 0; k < q; ++k) {
+        precision_matrix_(i, Ni[k]) = beta_new(k);
+        precision_matrix_(Ni[k], i) = beta_new(k);
+    }
+
+    vf1_[i] = 1.0;
+    vf2_[i] = (kii_new - kii_old) / 2.0;
+    for (size_t k = 0; k < q; ++k) vf2_[Ni[k]] = beta_new(k) - beta_old(k);
+
+    apply_rank2_chol_smw_update_();
+
     vf1_[i] = 0.0;
-    vf1_[j] = 0.0;
     vf2_[i] = 0.0;
-    vf2_[j] = 0.0;
+    for (size_t k = 0; k < q; ++k) vf2_[Ni[k]] = 0.0;
+}
 
+void GGMModel::do_one_gibbs_step(int /*iteration*/) {
+    // One full sweep: each column of K drawn from its exact conjugate
+    // full-conditional. No proposal adaptation (the draw is exact).
+    for (size_t i = 0; i < p_; ++i) {
+        update_row_block_gibbs(i);
+    }
 }
 
 double GGMModel::ggm_diag_move(size_t i) {

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -762,8 +762,9 @@ void GGMModel::update_edge_indicator_conjugate(size_t i, size_t j) {
     const double c2 = constants_[3];               // > 0
     const double sigma  = slab_scale_();
     const double inv_4s2 = 1.0 / (4.0 * sigma * sigma);
-    const double beta0 =
-        static_cast<const GammaScalePrior*>(diagonal_prior_.get())->rate();
+    const auto* diagp = static_cast<const GammaScalePrior*>(diagonal_prior_.get());
+    const double beta0 = diagp->rate();
+    const double alpha = diagp->shape();
 
     // Gaussian full conditional of phi (rest of K fixed, edge present):
     //   Q  = c2^2/(4 sigma^2) + beta0 + S_jj
@@ -783,15 +784,23 @@ void GGMModel::update_edge_indicator_conjugate(size_t i, size_t j) {
                             - MY_LOG(1.0 - inclusion_probability_(i, j));
 
     // A_add = odds * p_slab(0) / q(0); delete accepts with the reciprocal.
+    // For a Gamma shape alpha != 1 the alpha = 1 Gaussian is an independence
+    // proposal; the target's extra (k_jj/2)^(alpha-1) factor adds the
+    // correction (k_jj/k_jj(0))^(alpha-1) (the 1/2 cancels in the ratio),
+    // where k_jj(0) = constants_[5] is the spike diagonal.
     const double log_A_add = log_odds + log_pslab0 - log_q0;
+    const bool alpha_ne_1 = std::abs(alpha - 1.0) > 1e-12;
 
     if (edge_indicators_(i, j) == 0) {
-        // Add: draw phi* from the full conditional, then accept (independently
-        // of phi*).
+        // Add: draw phi* from the full conditional, then accept.
         const double phi_star = rnorm(rng_, mu, 1.0 / std::sqrt(Q));
-        if (MY_LOG(runif(rng_)) < log_A_add) {
-            const double kij = c1 + c2 * phi_star;
-            const double kjj = constrained_diagonal(kij);
+        const double kij = c1 + c2 * phi_star;
+        const double kjj = constrained_diagonal(kij);
+        double log_A = log_A_add;
+        if (alpha_ne_1) {
+            log_A += (alpha - 1.0) * (MY_LOG(kjj) - MY_LOG(constants_[5]));
+        }
+        if (MY_LOG(runif(rng_)) < log_A) {
             const double omega_ij_old = precision_matrix_(i, j);
             const double omega_jj_old = precision_matrix_(j, j);
             precision_proposal_(i, j) = kij;
@@ -805,8 +814,15 @@ void GGMModel::update_edge_indicator_conjugate(size_t i, size_t j) {
             invalidate_gradient_cache();
         }
     } else {
-        // Delete: deterministic to the spike; accept with 1 / A_add.
-        if (MY_LOG(runif(rng_)) < -log_A_add) {
+        // Delete: deterministic to the spike; accept with 1 / A_add evaluated
+        // at the current slab state, so the alpha correction uses the current
+        // diagonal against the spike diagonal.
+        double log_A = -log_A_add;
+        if (alpha_ne_1) {
+            log_A -= (alpha - 1.0)
+                     * (MY_LOG(precision_matrix_(j, j)) - MY_LOG(constants_[5]));
+        }
+        if (MY_LOG(runif(rng_)) < log_A) {
             const double kjj = constants_[5];      // constrained_diagonal(0)
             const double omega_ij_old = precision_matrix_(i, j);
             const double omega_jj_old = precision_matrix_(j, j);

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -742,7 +742,84 @@ void GGMModel::update_edge_indicators() {
             }
             acc += cols_in_row;
         }
-        update_edge_indicator_parameter_pair(i, j);
+        if (use_conjugate_edge_proposal_) {
+            update_edge_indicator_conjugate(i, j);
+        } else {
+            update_edge_indicator_parameter_pair(i, j);
+        }
+    }
+}
+
+void GGMModel::update_edge_indicator_conjugate(size_t i, size_t j) {
+    // Full-conditional (MoMS) edge birth/death for the joint spec, Normal slab,
+    // alpha = 1. The cofactor move preserves |K| (the determinant tilt and the
+    // likelihood determinant cancel), so F(phi) is Gaussian in the cofactor
+    // coordinate and the proposal is its exact conditional. The acceptance then
+    // reduces to the inclusion odds times p_slab(0)/q(0) and does not depend on
+    // the proposed value.
+    get_constants(i, j);
+    const double c1 = constants_[2];
+    const double c2 = constants_[3];               // > 0
+    const double sigma  = slab_scale_();
+    const double inv_4s2 = 1.0 / (4.0 * sigma * sigma);
+    const double beta0 =
+        static_cast<const GammaScalePrior*>(diagonal_prior_.get())->rate();
+
+    // Gaussian full conditional of phi (rest of K fixed, edge present):
+    //   Q  = c2^2/(4 sigma^2) + beta0 + S_jj
+    //   mu = -c2 (S_ij + c1/(4 sigma^2)) / Q
+    const double Q  = c2 * c2 * inv_4s2 + beta0 + suf_stat_(j, j);
+    const double mu = -c2 * (suf_stat_(i, j) + c1 * inv_4s2) / Q;
+
+    // Proposal ordinate at the spike phi_0 = -c1/c2, on the k_ij scale
+    // (q(0) = q_phi(phi_0)/c2), and the slab density at k_ij = 0 (the -log 2 is
+    // the |dK_yy/dK_ij| = 1/2 Jacobian, since the slab is in K_yy coordinates).
+    const double phi0 = -c1 / c2;
+    const double d = phi0 - mu;
+    const double log_q0 = 0.5 * (MY_LOG(Q) - MY_LOG(2.0 * arma::datum::pi))
+                          - 0.5 * Q * d * d - MY_LOG(c2);
+    const double log_pslab0 = interaction_prior_->logp(0.0) - MY_LOG(2.0);
+    const double log_odds = MY_LOG(inclusion_probability_(i, j))
+                            - MY_LOG(1.0 - inclusion_probability_(i, j));
+
+    // A_add = odds * p_slab(0) / q(0); delete accepts with the reciprocal.
+    const double log_A_add = log_odds + log_pslab0 - log_q0;
+
+    if (edge_indicators_(i, j) == 0) {
+        // Add: draw phi* from the full conditional, then accept (independently
+        // of phi*).
+        const double phi_star = rnorm(rng_, mu, 1.0 / std::sqrt(Q));
+        if (MY_LOG(runif(rng_)) < log_A_add) {
+            const double kij = c1 + c2 * phi_star;
+            const double kjj = constrained_diagonal(kij);
+            const double omega_ij_old = precision_matrix_(i, j);
+            const double omega_jj_old = precision_matrix_(j, j);
+            precision_proposal_(i, j) = kij;
+            precision_proposal_(j, j) = kjj;
+            precision_matrix_(i, j) = kij;
+            precision_matrix_(j, i) = kij;
+            precision_matrix_(j, j) = kjj;
+            edge_indicators_(i, j) = 1;
+            edge_indicators_(j, i) = 1;
+            cholesky_update_after_edge(omega_ij_old, omega_jj_old, i, j);
+            invalidate_gradient_cache();
+        }
+    } else {
+        // Delete: deterministic to the spike; accept with 1 / A_add.
+        if (MY_LOG(runif(rng_)) < -log_A_add) {
+            const double kjj = constants_[5];      // constrained_diagonal(0)
+            const double omega_ij_old = precision_matrix_(i, j);
+            const double omega_jj_old = precision_matrix_(j, j);
+            precision_proposal_(i, j) = 0.0;
+            precision_proposal_(j, j) = kjj;
+            precision_matrix_(i, j) = 0.0;
+            precision_matrix_(j, i) = 0.0;
+            precision_matrix_(j, j) = kjj;
+            edge_indicators_(i, j) = 0;
+            edge_indicators_(j, i) = 0;
+            cholesky_update_after_edge(omega_ij_old, omega_jj_old, i, j);
+            invalidate_gradient_cache();
+        }
     }
 }
 

--- a/src/models/ggm/ggm_model.h
+++ b/src/models/ggm/ggm_model.h
@@ -99,6 +99,7 @@ public:
         cholesky_of_precision_(arma::eye<arma::mat>(p_, p_)),
         inv_cholesky_of_precision_(arma::eye<arma::mat>(p_, p_)),
         covariance_matrix_(arma::eye<arma::mat>(p_, p_)),
+        omega_(arma::ones<arma::mat>(p_, p_)),
         edge_indicators_(initial_edge_indicators),
         vectorized_parameters_(dim_),
         vectorized_indicator_parameters_(edge_selection_ ? dim_ : 0),
@@ -130,6 +131,7 @@ public:
           cholesky_of_precision_(other.cholesky_of_precision_),
           inv_cholesky_of_precision_(other.inv_cholesky_of_precision_),
           covariance_matrix_(other.covariance_matrix_),
+          omega_(other.omega_),
           edge_indicators_(other.edge_indicators_),
           vectorized_parameters_(other.vectorized_parameters_),
           vectorized_indicator_parameters_(other.vectorized_indicator_parameters_),
@@ -460,6 +462,11 @@ private:
     /// Precision matrix Omega, its Cholesky factor R (Omega = R'R),
     /// inverse Cholesky factor, and covariance matrix.
     arma::mat precision_matrix_, cholesky_of_precision_, inv_cholesky_of_precision_, covariance_matrix_;
+    /// Per-edge scale-mixture weight for the Cauchy slab: K_yy_ij | omega_ij ~
+    /// N(0, sigma^2 omega_ij), omega_ij ~ InvGamma(1/2, 1/2). Fixed at 1 for a
+    /// Normal slab (the mixture collapses to the plain Normal). Used only by
+    /// the row-block Gibbs within-step.
+    arma::mat omega_;
     /// Current edge-indicator matrix (p x p, symmetric, 0/1).
     arma::imat edge_indicators_;
     /// Pre-allocated storage returned by get_vectorized_parameters().
@@ -549,10 +556,16 @@ private:
      * K_yy_ij = -K_ij/2 and Gamma(alpha = 1, beta0) prior on K_ii/2, the
      * conditional (beta, xi = kii - beta^T C beta) is conjugate:
      *
-     *   xi   | rest ~ Gamma(n/2 + 1, (beta0 + S_ii)/2)
+     *   xi   | rest ~ Gamma(n/2 + delta + 1, (beta0 + S_ii)/2)
      *   beta | rest ~ N(-M^{-1} S_{N_i, i}, M^{-1}),
-     *     M = (beta0 + S_ii) C + (1/(4 sigma^2)) I,
+     *     M = (beta0 + S_ii) C + diag(1/(4 sigma^2 omega_k)),
      *     C = (A^{-1})_{N_i, N_i} = Sigma_{N_i, N_i} - Sigma_{N_i, i} Sigma_{i, N_i}/Sigma_ii.
+     *
+     * The determinant tilt delta enters as a shift in the xi Gamma shape. A
+     * Gamma shape alpha != 1 on the diagonal is handled by an independent-MH
+     * accept on (kii_new/kii_old)^(alpha-1) around the alpha = 1 proposal. A
+     * Cauchy slab enters through the scale-mixture weights omega_k (fixed at 1
+     * for a Normal slab), refreshed per sweep by do_one_gibbs_step().
      *
      * Precondition: row_block_gibbs_eligible() == true; covariance_matrix_
      * holds K^{-1} up to date with precision_matrix_.
@@ -560,6 +573,20 @@ private:
      * @param i  Row index.
      */
     void update_row_block_gibbs(size_t i);
+
+    /** @return the slab scale sigma on K_yy (Normal or Cauchy interaction prior). */
+    double slab_scale_() const;
+
+    /** @return true when the interaction (slab) prior is Cauchy. */
+    bool slab_is_cauchy_() const;
+
+    /**
+     * Refresh the Cauchy scale-mixture weights omega_ from the current K.
+     * With all of K held fixed, each active edge weight is a closed-form draw
+     *   omega_ij | K ~ InvGamma(1, 1/2 + K_yy_ij^2 / (2 sigma^2)),
+     * K_yy_ij = -K_ij/2. No-op for a Normal slab.
+     */
+    void refresh_cauchy_omega_();
 
     /**
      * Propose a new diagonal precision entry on the log scale.

--- a/src/models/ggm/ggm_model.h
+++ b/src/models/ggm/ggm_model.h
@@ -290,6 +290,11 @@ public:
      */
     void do_one_gibbs_step(int iteration = -1) override;
 
+    /** Enable the full-conditional edge birth/death proposal (Gibbs path). */
+    void set_conjugate_edge_proposal(bool enable) override {
+        use_conjugate_edge_proposal_ = enable;
+    }
+
     /**
      * @return Active theta dimension: p + |E| (diagonals + included edges).
      *
@@ -454,6 +459,9 @@ private:
     /// initialize_precision_from_mle to zero the excluded entries and restore
     /// positive-definiteness.
     bool has_sparse_graph_ = false;
+    /// Use the full-conditional edge birth/death proposal (Gibbs sampler) in
+    /// place of the random-walk Roverato proposal. Set by the GibbsSampler.
+    bool use_conjugate_edge_proposal_ = false;
     /// Prior on off-diagonal precision elements (interactions).
     std::unique_ptr<BaseParameterPrior> interaction_prior_;
     /// Prior on diagonal precision elements (scale).
@@ -623,6 +631,17 @@ private:
      * @param j  Column index
      */
     void update_edge_indicator_parameter_pair(size_t i, size_t j);
+
+    /**
+     * Full-conditional edge birth/death for the joint spec (Normal slab,
+     * alpha = 1). The cofactor move preserves |K|, so F(phi) is Gaussian and
+     * the proposal is the exact conditional of the toggled coordinate; the
+     * acceptance reduces to the inclusion odds times p_slab(0)/q(0),
+     * independent of the proposed value. No proposal-SD tuning. Used by the
+     * Gibbs sampler in place of update_edge_indicator_parameter_pair.
+     * Source: Z manuscript, "Single-edge updates".
+     */
+    void update_edge_indicator_conjugate(size_t i, size_t j);
 
     /**
      * Precompute reparameterization constants for the (i, j) element.

--- a/src/models/ggm/ggm_model.h
+++ b/src/models/ggm/ggm_model.h
@@ -199,11 +199,11 @@ public:
     void init_metropolis_adaptation(const WarmupSchedule& schedule) override;
 
     /**
-     * @return true iff the conjugate row-block Gibbs within-step is exact:
-     * Normal slab on K_yy off-diagonals, Gamma(alpha = 1, .) on K_ii/2, and
-     * determinant tilt delta == 0. Other prior families (or alpha != 1,
-     * delta != 0) need the post-step correction extensions ported later and
-     * return false here for now.
+     * @return true iff the row-block Gibbs within-step supports the current
+     * priors: a Normal or Cauchy slab on the K_yy off-diagonals and a Gamma
+     * prior on K_ii/2. The Gamma shape (alpha != 1) and the determinant tilt
+     * (delta != 0) do NOT gate eligibility -- they are handled by the
+     * independent-MH correction and the xi Gamma-shape shift, respectively.
      */
     bool row_block_gibbs_eligible();
 

--- a/src/models/ggm/ggm_model.h
+++ b/src/models/ggm/ggm_model.h
@@ -197,6 +197,15 @@ public:
     void init_metropolis_adaptation(const WarmupSchedule& schedule) override;
 
     /**
+     * @return true iff the conjugate row-block Gibbs within-step is exact:
+     * Normal slab on K_yy off-diagonals, Gamma(alpha = 1, .) on K_ii/2, and
+     * determinant tilt delta == 0. Other prior families (or alpha != 1,
+     * delta != 0) need the post-step correction extensions ported later and
+     * return false here for now.
+     */
+    bool row_block_gibbs_eligible();
+
+    /**
      * Set the determinant-tilt exponent delta. Adds delta * log|K| to the
      * log-prior, pushing the chain away from the PD-cone boundary. delta = 0
      * (default) recovers the untilted target. Currently consumed only by
@@ -263,6 +272,21 @@ public:
      * @param iteration  Current iteration index (for Robbins-Monro adaptation)
      */
     void do_one_metropolis_step(int iteration = -1) override;
+
+    /**
+     * Perform one full row-block Gibbs sweep.
+     *
+     * Iterates over rows i = 0..p-1, drawing each column of K from its exact
+     * conjugate full-conditional via update_row_block_gibbs(i). No proposal
+     * adaptation (the draw is exact); edge-indicator add-delete moves are
+     * handled separately in update_edge_indicators().
+     *
+     * Precondition: row_block_gibbs_eligible() == true.
+     *
+     * @param iteration  Current iteration index (unused; kept for interface
+     *                   symmetry with do_one_metropolis_step).
+     */
+    void do_one_gibbs_step(int iteration = -1) override;
 
     /**
      * @return Active theta dimension: p + |E| (diagonals + included edges).
@@ -344,6 +368,11 @@ public:
     /** @return Mutable reference to the prior inclusion-probability matrix. */
     arma::mat& get_inclusion_probability() override {
         return inclusion_probability_;
+    }
+
+    /** @return const reference to the current precision matrix K. */
+    const arma::mat& get_precision_matrix() const {
+        return precision_matrix_;
     }
 
     /** @return Number of variables (p). */
@@ -508,6 +537,31 @@ private:
     double update_edge_parameter(size_t i, size_t j);
 
     /**
+     * Closed-form Gibbs draw for row i of K given the rest of K and the graph.
+     * The per-row primitive driven by do_one_gibbs_step().
+     *
+     * Origin: Wang's row-by-row block Gibbs update for Gaussian graphical
+     * models (each column of the precision matrix sampled from its exact
+     * full-conditional).
+     *
+     * Partitions K with A = K_{-i,-i}, beta = K_{N_i, i}, kii = K_{i,i}, where
+     * N_i is the active neighbour set of i. With Normal slab N(0, sigma^2) on
+     * K_yy_ij = -K_ij/2 and Gamma(alpha = 1, beta0) prior on K_ii/2, the
+     * conditional (beta, xi = kii - beta^T C beta) is conjugate:
+     *
+     *   xi   | rest ~ Gamma(n/2 + 1, (beta0 + S_ii)/2)
+     *   beta | rest ~ N(-M^{-1} S_{N_i, i}, M^{-1}),
+     *     M = (beta0 + S_ii) C + (1/(4 sigma^2)) I,
+     *     C = (A^{-1})_{N_i, N_i} = Sigma_{N_i, N_i} - Sigma_{N_i, i} Sigma_{i, N_i}/Sigma_ii.
+     *
+     * Precondition: row_block_gibbs_eligible() == true; covariance_matrix_
+     * holds K^{-1} up to date with precision_matrix_.
+     *
+     * @param i  Row index.
+     */
+    void update_row_block_gibbs(size_t i);
+
+    /**
      * Propose a new diagonal precision entry on the log scale.
      * Accepts or rejects with a Metropolis ratio using the Gaussian
      * likelihood, a Gamma(1,1) prior, and a Jacobian correction.
@@ -623,6 +677,24 @@ private:
      * @param j             Column index
      */
     void cholesky_update_after_edge(double omega_ij_old, double omega_jj_old, size_t i, size_t j);
+
+    /**
+     * Apply a symmetric rank-2 update to K, refresh chol(K), and refresh Sigma.
+     *
+     * Given vf1_, vf2_ of length p, this carries out
+     *   K_new     = K_old + vf1 vf2^T + vf2 vf1^T
+     *   chol(K)  <- Givens update + downdate on u1 = (vf1+vf2)/sqrt2, u2 = (vf1-vf2)/sqrt2
+     *   Sigma    <- inv(L) inv(L)^T, with a fallback to refresh_cholesky() when
+     *               accumulated updates make the triangular inverse fail.
+     *
+     * Inputs are taken from the model's vf1_, vf2_ scratch members so callers
+     * can populate them in-place without an extra copy. The helper does not
+     * touch precision_matrix_ -- the caller must already have written the
+     * post-update entries it represents. Generic in vf1, vf2: the edge update
+     * passes sparse 2-entry vectors; the row-block Gibbs sweep reuses it with
+     * full-vector inputs.
+     */
+    void apply_rank2_chol_smw_update_();
 
     /**
      * Update the Cholesky factor after changing a diagonal element.

--- a/src/priors/parameter_prior.h
+++ b/src/priors/parameter_prior.h
@@ -118,6 +118,9 @@ public:
         return std::make_unique<NormalPrior>(*this);
     }
 
+    /** @return the slab standard deviation. */
+    double scale() const { return scale_; }
+
 private:
     double scale_;
 };
@@ -177,6 +180,11 @@ public:
     std::unique_ptr<BaseParameterPrior> clone() const override {
         return std::make_unique<GammaScalePrior>(*this);
     }
+
+    /** @return the Gamma shape parameter. */
+    double shape() const { return shape_; }
+    /** @return the Gamma rate parameter. */
+    double rate() const { return rate_; }
 
 private:
     double shape_;

--- a/src/priors/parameter_prior.h
+++ b/src/priors/parameter_prior.h
@@ -83,6 +83,9 @@ public:
         return std::make_unique<CauchyPrior>(*this);
     }
 
+    /** @return the slab scale. */
+    double scale() const { return scale_; }
+
 private:
     double scale_;
 };

--- a/src/rng/rng_utils.h
+++ b/src/rng/rng_utils.h
@@ -29,6 +29,7 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/exponential_distribution.hpp>
 #include <boost/random/beta_distribution.hpp>
+#include <boost/random/gamma_distribution.hpp>
 
 // [[Rcpp::depends(dqrng, BH)]]
 
@@ -116,6 +117,17 @@ inline double rbeta(SafeRNG& rng, double a, double b) {
  */
 inline double rexp(SafeRNG& rng, double lambda) {
   return boost::random::exponential_distribution<double>(lambda)(rng.eng);
+}
+
+/**
+ * Draw from Gamma(shape, rate).
+ * @param rng    Random number generator
+ * @param shape  Shape parameter (alpha)
+ * @param rate   Rate parameter (beta); mean = shape / rate
+ * @return A gamma-distributed variate. boost parameterizes by scale = 1/rate.
+ */
+inline double rgamma(SafeRNG& rng, double shape, double rate) {
+  return boost::random::gamma_distribution<double>(shape, 1.0 / rate)(rng.eng);
 }
 
 // ============================================================

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -77,13 +77,28 @@ Rcpp::List sample_ggm(
     //     between-model MH proposal SDs, which are still 1-D componentwise
     //     RW MH. Hardcode 0.44 there to keep stage-3b RM on the right
     //     fixed point.
-    const double mh_target = (sampler_type == "nuts") ? 0.44 : target_acceptance;
+    //   - Under "gibbs": the within-step draw is exact (no MH tuning); the
+    //     target is inert, so use the same 0.44 fixed point.
+    const double mh_target =
+        (sampler_type == "adaptive-metropolis") ? target_acceptance : 0.44;
     model.set_metropolis_target_accept(mh_target);
 
     // Determinant-tilt prior on |K|: shifts both NUTS and MH targets by
     // delta * log|K|. delta = 0 is the default (untilted). Consumed by
     // both gradient paths and all four MH ratios in GGMModel.
     model.set_determinant_tilt(delta);
+
+    // The row-block Gibbs sampler is exact only in the conjugate prior scope
+    // (Normal slab, Gamma(shape = 1) on the precision diagonal, delta = 0).
+    // Fail fast with a clear message rather than let update_row_block_gibbs
+    // cast a mismatched prior.
+    if (sampler_type == "gibbs" && !model.row_block_gibbs_eligible()) {
+        Rcpp::stop(
+            "update_method = \"gibbs\" needs a Normal interaction (slab) prior, "
+            "a Gamma(shape = 1) scale prior on the precision diagonal, and "
+            "delta = 0. The current priors do not meet this; use another "
+            "update method or adjust the priors.");
+    }
 
     // Set up missing data imputation (same pattern as OMRF)
     if (na_impute && missing_index_nullable.isNotNull()) {

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -110,12 +110,6 @@ Rcpp::List sample_ggm(
             "a Cauchy slab with edge selection is not yet supported. Use a "
             "Normal slab or set edge_selection = FALSE.");
     }
-    if (sampler_type == "gibbs" && edge_selection && std::abs(s_shape - 1.0) > 1e-12) {
-        Rcpp::stop(
-            "update_method = \"gibbs\" with edge selection needs the Gamma "
-            "scale prior shape = 1; a shape != 1 with edge selection is not yet "
-            "supported. Set the scale prior shape to 1 or edge_selection = FALSE.");
-    }
 
     // Set up missing data imputation (same pattern as OMRF)
     if (na_impute && missing_index_nullable.isNotNull()) {

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -110,6 +110,12 @@ Rcpp::List sample_ggm(
             "a Cauchy slab with edge selection is not yet supported. Use a "
             "Normal slab or set edge_selection = FALSE.");
     }
+    if (sampler_type == "gibbs" && edge_selection && std::abs(s_shape - 1.0) > 1e-12) {
+        Rcpp::stop(
+            "update_method = \"gibbs\" with edge selection needs the Gamma "
+            "scale prior shape = 1; a shape != 1 with edge selection is not yet "
+            "supported. Set the scale prior shape to 1 or edge_selection = FALSE.");
+    }
 
     // Set up missing data imputation (same pattern as OMRF)
     if (na_impute && missing_index_nullable.isNotNull()) {

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -88,16 +88,16 @@ Rcpp::List sample_ggm(
     // both gradient paths and all four MH ratios in GGMModel.
     model.set_determinant_tilt(delta);
 
-    // The row-block Gibbs sampler is exact only in the conjugate prior scope
-    // (Normal slab, Gamma(shape = 1) on the precision diagonal, delta = 0).
-    // Fail fast with a clear message rather than let update_row_block_gibbs
-    // cast a mismatched prior.
+    // The row-block Gibbs sampler covers a Normal or Cauchy slab on the
+    // off-diagonals and a Gamma prior on the precision diagonal. Fail fast
+    // with a clear message rather than let update_row_block_gibbs cast a
+    // mismatched prior.
     if (sampler_type == "gibbs" && !model.row_block_gibbs_eligible()) {
         Rcpp::stop(
-            "update_method = \"gibbs\" needs a Normal interaction (slab) prior, "
-            "a Gamma(shape = 1) scale prior on the precision diagonal, and "
-            "delta = 0. The current priors do not meet this; use another "
-            "update method or adjust the priors.");
+            "update_method = \"gibbs\" needs a Normal or Cauchy interaction "
+            "(slab) prior and a Gamma scale prior on the precision diagonal. "
+            "The current priors do not meet this; use another update method "
+            "or adjust the priors.");
     }
 
     // Set up missing data imputation (same pattern as OMRF)

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -100,16 +100,6 @@ Rcpp::List sample_ggm(
             "or adjust the priors.");
     }
 
-    // Edge selection with the Gibbs sampler keeps the Roverato between-step,
-    // which reads the slab density directly. A Cauchy slab there would be
-    // inconsistent with the scale-mixture the within-step uses, so that
-    // combination is not yet supported.
-    if (sampler_type == "gibbs" && edge_selection && ipt_str == "cauchy") {
-        Rcpp::stop(
-            "update_method = \"gibbs\" with edge selection needs a Normal slab; "
-            "a Cauchy slab with edge selection is not yet supported. Use a "
-            "Normal slab or set edge_selection = FALSE.");
-    }
 
     // Set up missing data imputation (same pattern as OMRF)
     if (na_impute && missing_index_nullable.isNotNull()) {

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -100,6 +100,17 @@ Rcpp::List sample_ggm(
             "or adjust the priors.");
     }
 
+    // Edge selection with the Gibbs sampler keeps the Roverato between-step,
+    // which reads the slab density directly. A Cauchy slab there would be
+    // inconsistent with the scale-mixture the within-step uses, so that
+    // combination is not yet supported.
+    if (sampler_type == "gibbs" && edge_selection && ipt_str == "cauchy") {
+        Rcpp::stop(
+            "update_method = \"gibbs\" with edge selection needs a Normal slab; "
+            "a Cauchy slab with edge selection is not yet supported. Use a "
+            "Normal slab or set edge_selection = FALSE.");
+    }
+
     // Set up missing data imputation (same pattern as OMRF)
     if (na_impute && missing_index_nullable.isNotNull()) {
         arma::imat missing_index = Rcpp::as<arma::imat>(

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -69,19 +69,21 @@ Rcpp::List sample_ggm(
         edge_selection, std::move(interaction_prior),
         std::move(diagonal_prior), na_impute);
 
-    // Forward target_accept to the model's MH proposal-SD tuner.
+    // Forward target_accept to the model's between-model MH proposal-SD tuner.
+    // Only adaptive-metropolis and nuts run the componentwise RW edge move that
+    // consumes it; the gibbs within-step and its full-conditional edge move are
+    // exact and tune nothing, so the gibbs path must not set an MH target.
     //   - Under "adaptive-metropolis": user's target_accept goes through
     //     directly (default 0.44 = componentwise RW MH optimum).
     //   - Under "nuts": user's target_accept (default 0.80) is the
     //     HMC step-size dual-averaging target and should NOT govern the
     //     between-model MH proposal SDs, which are still 1-D componentwise
-    //     RW MH. Hardcode 0.44 there to keep stage-3b RM on the right
-    //     fixed point.
-    //   - Under "gibbs": the within-step draw is exact (no MH tuning); the
-    //     target is inert, so use the same 0.44 fixed point.
-    const double mh_target =
-        (sampler_type == "adaptive-metropolis") ? target_acceptance : 0.44;
-    model.set_metropolis_target_accept(mh_target);
+    //     RW MH. Use 0.44 there to keep stage-3b RM on the right fixed point.
+    if (sampler_type != "gibbs") {
+        const double mh_target =
+            (sampler_type == "adaptive-metropolis") ? target_acceptance : 0.44;
+        model.set_metropolis_target_accept(mh_target);
+    }
 
     // Determinant-tilt prior on |K|: shifts both NUTS and MH targets by
     // delta * log|K|. delta = 0 is the default (untilted). Consumed by

--- a/tests/testthat/test-bgmCompare.R
+++ b/tests/testthat/test-bgmCompare.R
@@ -41,6 +41,20 @@ test_that("bgmCompare is reproducible with seed (x, y interface)", {
 })
 
 
+test_that("bgmCompare accepts its default update_method", {
+  data("Wenchuan", package = "bgms")
+  x = Wenchuan[1:20, 1:3]
+  y = Wenchuan[21:40, 1:3]
+  expect_error(
+    bgmCompare(
+      x = x, y = y, iter = 20, warmup = 20, chains = 1, cores = 1,
+      seed = 1, display_progress = "none", verbose = FALSE
+    ),
+    NA
+  )
+})
+
+
 # ------------------------------------------------------------------------------
 # Output Structure Tests (using saved fit)
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-ggm-gibbs.R
+++ b/tests/testthat/test-ggm-gibbs.R
@@ -1,0 +1,176 @@
+# --------------------------------------------------------------------------- #
+# Row-block Gibbs within-step for the Gaussian graphical model
+# (update_method = "gibbs", fixed graph).
+#
+# Two kinds of checks:
+#   1. Closed-form anchors. The C++ entry ggm_test_gibbs_sweep drives the row
+#      sweep directly. On an empty graph at n = 0 every row collapses to its
+#      diagonal, whose marginal is a known Gamma, so the draw is checked against
+#      that Gamma. This also exercises the Gamma(shape != 1) independent-MH,
+#      whose target is Gamma(shape, rate/2).
+#   2. Agreement with adaptive-Metropolis. On a fixed complete graph both
+#      samplers target the same K | graph posterior, so their posterior means
+#      must agree within MCMC error. This catches a wrong target that a
+#      "runs without error" check would miss.
+# --------------------------------------------------------------------------- #
+
+
+# ---- Closed-form anchors ---------------------------------------------------- #
+
+test_that("row sweep draws K_ii from Gamma(1, rate/2) on an empty graph at n = 0", {
+  p = 4L
+  edges = matrix(0L, p, p)
+  S = matrix(0, p, p) # n = 0: sufficient statistics are irrelevant
+  beta0 = 2.0
+  n_sweeps = 5000L
+
+  out = ggm_test_gibbs_sweep(
+    suf_stat = S, n = 0L, edge_indicators = edges,
+    pairwise_scale = 1.0, gamma_shape = 1.0, gamma_rate = beta0,
+    n_sweeps = n_sweeps, seed = 42L
+  )
+
+  burn = 201:n_sweeps # forget the identity init
+  K_ii = sapply(seq_len(p), function(i) out$K_samples[i, i, burn])
+
+  # Gamma(shape = 1, rate = beta0 / 2): mean 2/beta0, var 4/beta0^2.
+  theory_mean = 2.0 / beta0
+  tol_mean = 4 * sqrt((4.0 / beta0^2) / length(burn))
+  expect_true(all(abs(colMeans(K_ii) - theory_mean) < tol_mean))
+
+  ks_p = vapply(seq_len(p), function(i) {
+    suppressWarnings(
+      stats::ks.test(K_ii[, i], "pgamma", shape = 1, rate = beta0 / 2)$p.value
+    )
+  }, numeric(1L))
+  expect_gt(min(ks_p), 0.01 / p)
+})
+
+
+test_that("Gamma shape != 1 targets Gamma(shape, rate/2) via the independent-MH", {
+  # The shape != 1 path is an independent-MH chain, so its draws are
+  # autocorrelated (rejections repeat values). A KS test would be invalid;
+  # check the first two moments instead, pooled across rows.
+  p = 4L
+  edges = matrix(0L, p, p)
+  S = matrix(0, p, p)
+  alpha = 2.0
+  beta0 = 2.0
+  n_sweeps = 8000L
+
+  out = ggm_test_gibbs_sweep(
+    suf_stat = S, n = 0L, edge_indicators = edges,
+    pairwise_scale = 1.0, gamma_shape = alpha, gamma_rate = beta0,
+    n_sweeps = n_sweeps, seed = 7L
+  )
+
+  burn = 1001:n_sweeps
+  K_ii = as.vector(sapply(seq_len(p), function(i) out$K_samples[i, i, burn]))
+
+  # Gamma(shape = alpha, rate = beta0 / 2): mean 2 alpha / beta0, var 4 alpha / beta0^2.
+  theory_mean = 2.0 * alpha / beta0
+  theory_var = 4.0 * alpha / beta0^2
+  expect_lt(abs(mean(K_ii) - theory_mean) / theory_mean, 0.05)
+  expect_lt(abs(var(K_ii) - theory_var) / theory_var, 0.15)
+})
+
+
+# ---- Gibbs-vs-AM agreement helpers ------------------------------------------ #
+
+# Posterior means of K (diagonal + off-diagonal) from a fixed-graph bgm() fit.
+ggm_K_means = function(Y, update_method, interaction_prior, alpha, delta,
+                       iter, warmup, seed = 1L) {
+  fit = bgm(
+    Y,
+    variable_type = "continuous",
+    interaction_prior = interaction_prior,
+    precision_scale_prior = gamma_prior(shape = alpha, rate = 1),
+    delta = delta,
+    edge_selection = FALSE,
+    iter = iter, warmup = warmup,
+    update_method = update_method,
+    chains = 1L, cores = 1L, seed = seed,
+    display_progress = "none", verbose = FALSE
+  )
+  raw = S7::prop(fit, "raw_samples")
+  list(
+    diag = colMeans(raw$main[[1L]]),
+    off  = colMeans(raw$pairwise[[1L]])
+  )
+}
+
+# A small dense GGM, centered as bgm() expects.
+ggm_agreement_data = function(seed = 7L, p = 6L, n = 200L) {
+  set.seed(seed)
+  K_true = diag(p) + 0.3 * (abs(row(diag(p)) - col(diag(p))) == 1)
+  Y = MASS::mvrnorm(n, mu = rep(0, p), Sigma = solve(K_true))
+  Y = scale(Y, center = TRUE, scale = FALSE)
+  colnames(Y) = paste0("V", seq_len(p))
+  Y
+}
+
+expect_K_agreement = function(gibbs, am, tol_abs, tol_rel) {
+  d_diag = abs(gibbs$diag - am$diag)
+  d_off = abs(gibbs$off - am$off)
+  expect_lt(max(d_diag, d_off), tol_abs)
+  expect_lt(mean(c(d_diag, d_off)) / mean(abs(c(am$diag, am$off))), tol_rel)
+}
+
+
+# ---- Agreement with adaptive-Metropolis ------------------------------------- #
+
+test_that("gibbs routes through bgm() and agrees with AM (Normal, alpha=1, delta=0)", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  Y = ggm_agreement_data()
+  args = list(
+    Y = Y, interaction_prior = normal_prior(scale = 1),
+    alpha = 1, delta = 0, iter = 2500L, warmup = 600L
+  )
+  am = do.call(ggm_K_means, c(args, update_method = "adaptive-metropolis"))
+  gibb = do.call(ggm_K_means, c(args, update_method = "gibbs"))
+  expect_K_agreement(gibb, am, tol_abs = 0.06, tol_rel = 0.025)
+})
+
+
+test_that("gibbs agrees with AM at delta = 0.5 (xi shape shift)", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  Y = ggm_agreement_data()
+  args = list(
+    Y = Y, interaction_prior = normal_prior(scale = 1),
+    alpha = 1, delta = 0.5, iter = 2500L, warmup = 600L
+  )
+  am = do.call(ggm_K_means, c(args, update_method = "adaptive-metropolis"))
+  gibb = do.call(ggm_K_means, c(args, update_method = "gibbs"))
+  expect_K_agreement(gibb, am, tol_abs = 0.06, tol_rel = 0.025)
+})
+
+
+test_that("gibbs agrees with AM at alpha = 2 (independent-MH on the diagonal)", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  Y = ggm_agreement_data()
+  args = list(
+    Y = Y, interaction_prior = normal_prior(scale = 1),
+    alpha = 2, delta = 0, iter = 2500L, warmup = 600L
+  )
+  am = do.call(ggm_K_means, c(args, update_method = "adaptive-metropolis"))
+  gibb = do.call(ggm_K_means, c(args, update_method = "gibbs"))
+  expect_K_agreement(gibb, am, tol_abs = 0.07, tol_rel = 0.035)
+})
+
+
+test_that("gibbs agrees with AM under a Cauchy slab (scale mixture of normals)", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  Y = ggm_agreement_data()
+  # Cauchy mixing is slower than Normal: longer chain, looser tolerance.
+  args = list(
+    Y = Y, interaction_prior = cauchy_prior(scale = 1),
+    alpha = 1, delta = 0, iter = 4000L, warmup = 1000L
+  )
+  am = do.call(ggm_K_means, c(args, update_method = "adaptive-metropolis"))
+  gibb = do.call(ggm_K_means, c(args, update_method = "gibbs"))
+  expect_K_agreement(gibb, am, tol_abs = 0.10, tol_rel = 0.05)
+})

--- a/tests/testthat/test-ggm-gibbs.R
+++ b/tests/testthat/test-ggm-gibbs.R
@@ -174,3 +174,42 @@ test_that("gibbs agrees with AM under a Cauchy slab (scale mixture of normals)",
   gibb = do.call(ggm_K_means, c(args, update_method = "gibbs"))
   expect_K_agreement(gibb, am, tol_abs = 0.10, tol_rel = 0.05)
 })
+
+
+# ---- Edge selection: between-model agreement with NUTS ---------------------- #
+
+# Posterior inclusion probabilities from an edge-selection fit.
+ggm_pips = function(Y, update_method, iter, warmup, seed = 7L) {
+  fit = bgm(
+    Y,
+    variable_type = "continuous",
+    interaction_prior = normal_prior(scale = 1),
+    edge_selection = TRUE,
+    iter = iter, warmup = warmup,
+    update_method = update_method,
+    chains = 1L, cores = 1L, seed = seed,
+    display_progress = "none", verbose = FALSE
+  )
+  colMeans(S7::prop(fit, "raw_samples")$indicator[[1L]])
+}
+
+test_that("gibbs edge selection recovers the same inclusion probabilities as NUTS", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  set.seed(11)
+  p = 8L
+  n = 250L
+  # Sparse truth: a chain graph.
+  K = diag(p)
+  for(i in seq_len(p - 1L)) K[i, i + 1L] = K[i + 1L, i] = -0.35
+  diag(K) = 2
+  Y = MASS::mvrnorm(n, mu = rep(0, p), Sigma = solve(K))
+  Y = scale(Y, center = TRUE, scale = FALSE)
+  colnames(Y) = paste0("V", seq_len(p))
+
+  pip_gibbs = ggm_pips(Y, "gibbs", iter = 4000L, warmup = 1500L)
+  pip_nuts = ggm_pips(Y, "nuts", iter = 4000L, warmup = 1500L)
+
+  expect_lt(max(abs(pip_gibbs - pip_nuts)), 0.10)
+  expect_lt(mean(abs(pip_gibbs - pip_nuts)), 0.03)
+})

--- a/tests/testthat/test-ggm-gibbs.R
+++ b/tests/testthat/test-ggm-gibbs.R
@@ -179,11 +179,12 @@ test_that("gibbs agrees with AM under a Cauchy slab (scale mixture of normals)",
 # ---- Edge selection: between-model agreement with NUTS ---------------------- #
 
 # Posterior inclusion probabilities from an edge-selection fit.
-ggm_pips = function(Y, update_method, iter, warmup, shape = 1, seed = 7L) {
+ggm_pips = function(Y, update_method, iter, warmup, shape = 1,
+                    interaction_prior = normal_prior(scale = 1), seed = 7L) {
   fit = bgm(
     Y,
     variable_type = "continuous",
-    interaction_prior = normal_prior(scale = 1),
+    interaction_prior = interaction_prior,
     precision_scale_prior = gamma_prior(shape = shape, rate = 1),
     edge_selection = TRUE,
     iter = iter, warmup = warmup,
@@ -230,6 +231,27 @@ test_that("gibbs edge selection agrees with NUTS at Gamma shape = 2", {
 
   pip_gibbs = ggm_pips(Y, "gibbs", iter = 4000L, warmup = 1500L, shape = 2)
   pip_nuts = ggm_pips(Y, "nuts", iter = 4000L, warmup = 1500L, shape = 2)
+
+  expect_lt(max(abs(pip_gibbs - pip_nuts)), 0.10)
+  expect_lt(mean(abs(pip_gibbs - pip_nuts)), 0.03)
+})
+
+test_that("gibbs edge selection agrees with NUTS under a Cauchy slab", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  set.seed(11)
+  p = 8L
+  n = 250L
+  K = diag(p)
+  for(i in seq_len(p - 1L)) K[i, i + 1L] = K[i + 1L, i] = -0.35
+  diag(K) = 2
+  Y = MASS::mvrnorm(n, mu = rep(0, p), Sigma = solve(K))
+  Y = scale(Y, center = TRUE, scale = FALSE)
+  colnames(Y) = paste0("V", seq_len(p))
+
+  cp = cauchy_prior(scale = 1)
+  pip_gibbs = ggm_pips(Y, "gibbs", iter = 5000L, warmup = 2000L, interaction_prior = cp)
+  pip_nuts = ggm_pips(Y, "nuts", iter = 5000L, warmup = 2000L, interaction_prior = cp)
 
   expect_lt(max(abs(pip_gibbs - pip_nuts)), 0.10)
   expect_lt(mean(abs(pip_gibbs - pip_nuts)), 0.03)

--- a/tests/testthat/test-ggm-gibbs.R
+++ b/tests/testthat/test-ggm-gibbs.R
@@ -179,11 +179,12 @@ test_that("gibbs agrees with AM under a Cauchy slab (scale mixture of normals)",
 # ---- Edge selection: between-model agreement with NUTS ---------------------- #
 
 # Posterior inclusion probabilities from an edge-selection fit.
-ggm_pips = function(Y, update_method, iter, warmup, seed = 7L) {
+ggm_pips = function(Y, update_method, iter, warmup, shape = 1, seed = 7L) {
   fit = bgm(
     Y,
     variable_type = "continuous",
     interaction_prior = normal_prior(scale = 1),
+    precision_scale_prior = gamma_prior(shape = shape, rate = 1),
     edge_selection = TRUE,
     iter = iter, warmup = warmup,
     update_method = update_method,
@@ -209,6 +210,26 @@ test_that("gibbs edge selection recovers the same inclusion probabilities as NUT
 
   pip_gibbs = ggm_pips(Y, "gibbs", iter = 4000L, warmup = 1500L)
   pip_nuts = ggm_pips(Y, "nuts", iter = 4000L, warmup = 1500L)
+
+  expect_lt(max(abs(pip_gibbs - pip_nuts)), 0.10)
+  expect_lt(mean(abs(pip_gibbs - pip_nuts)), 0.03)
+})
+
+test_that("gibbs edge selection agrees with NUTS at Gamma shape = 2", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  set.seed(11)
+  p = 8L
+  n = 250L
+  K = diag(p)
+  for(i in seq_len(p - 1L)) K[i, i + 1L] = K[i + 1L, i] = -0.35
+  diag(K) = 2
+  Y = MASS::mvrnorm(n, mu = rep(0, p), Sigma = solve(K))
+  Y = scale(Y, center = TRUE, scale = FALSE)
+  colnames(Y) = paste0("V", seq_len(p))
+
+  pip_gibbs = ggm_pips(Y, "gibbs", iter = 4000L, warmup = 1500L, shape = 2)
+  pip_nuts = ggm_pips(Y, "nuts", iter = 4000L, warmup = 1500L, shape = 2)
 
   expect_lt(max(abs(pip_gibbs - pip_nuts)), 0.10)
   expect_lt(mean(abs(pip_gibbs - pip_nuts)), 0.03)

--- a/tests/testthat/test-validate-sampler.R
+++ b/tests/testthat/test-validate-sampler.R
@@ -6,7 +6,7 @@
 # Helper: minimal valid call with sensible defaults
 vs = function(...) {
   defaults = list(
-    update_method     = c("nuts", "adaptive-metropolis"),
+    update_method     = c("nuts", "adaptive-metropolis", "gibbs"),
     target_accept     = NULL,
     iter              = 1000L,
     warmup            = 250L,
@@ -65,6 +65,18 @@ test_that("GGM + explicit 'adaptive-metropolis' OK", {
 test_that("GGM + explicit 'nuts' OK", {
   res = vs(is_continuous = TRUE, update_method = "nuts")
   expect_equal(res$update_method, "nuts")
+})
+
+test_that("GGM + explicit 'gibbs' OK", {
+  res = vs(is_continuous = TRUE, update_method = "gibbs")
+  expect_equal(res$update_method, "gibbs")
+})
+
+test_that("gibbs is rejected for non-continuous data", {
+  expect_error(
+    vs(is_continuous = FALSE, update_method = "gibbs"),
+    "available only for the Gaussian"
+  )
 })
 
 


### PR DESCRIPTION
## Description

Adds a Gibbs sampler for the Gaussian graphical model, available through
`update_method = "gibbs"` in `bgm()`. It sits next to the existing NUTS and
adaptive-Metropolis samplers and is used only for continuous data. The sampler
updates one row of the precision matrix at a time, and can add or remove edges
when edge selection is on.

### Problem / Motivation

For continuous data, `bgm()` offered NUTS and adaptive-Metropolis. Both tune a
step size or proposal width during warmup. The Gaussian graphical model has a
direct row-by-row update that draws each row of the precision matrix from its
exact conditional distribution, so no tuning is needed. This adds that update
as a third option.

### Proposed Changes / New Functionality

- A new `GibbsSampler` class, wired into the sampler dispatch alongside NUTS and
  adaptive-Metropolis.
- The row-by-row precision update in the GGM model. It supports a Normal or a
  Cauchy prior on the edges, and any Gamma shape on the diagonal.
- Edge selection: an edge is added or removed by proposing the affected entry
  from its exact conditional.
- R side: `update_method = "gibbs"` is accepted and documented for `bgm()`,
  restricted to continuous data, with a clear error otherwise.
- Tests in `tests/testthat/test-ggm-gibbs.R`.

No default behaviour changes: existing fits are unaffected unless the user asks
for `"gibbs"`.

## Type of Change

- [x] New feature

## Documentation and Release Notes

- [x] Updated function documentation for `update_method`
- [x] Regenerated `man/*.Rd`
- [x] `NEWS.md` entry

## Testing and Validation

- New unit tests check the row update against known closed-form distributions,
  and check that the Gibbs sampler agrees with adaptive-Metropolis and NUTS on
  the same data.
- Simulation-based calibration for the new sampler, both on a fixed graph and
  with edge selection, for three cases: a Normal prior, a Normal prior with a
  non-default Gamma shape, and a Cauchy prior. All three calibrate, and the
  results line up with NUTS.
- [x] Added tests in `tests/testthat/`
- [x] Ran the project styler
- [x] Ran `lintr::lint_package()`
- [x] Ran `roxygen2::roxygenise()`

## Additional Notes

The Gibbs sampler is the first step of the standardized spike-and-slab prior
work; the follow-up steps (naming on the standardized scale, and reframing the
NUTS and Metropolis paths) will land on this branch as separate commits.
