### PR TITLE
ci: run checks on the develop branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 name: lint
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 name: test-coverage
 


### PR DESCRIPTION
## Description

`R-CMD-check`, `lint`, and `test-coverage` only ran on `main`. Pull requests
targeting `develop` got no checks at all, so work integrated through `develop`
was never built, linted, or covered by CI.

### Problem / Motivation

Every check workflow filters its triggers to `branches: [main]`. For a
`pull_request` event that filter matches the PR's base branch, so a PR based on
`develop` never triggers, and pushes to `develop` are skipped too. A PR into
`develop` shows "no checks reported".

### Proposed Changes

- `R-CMD-check.yaml`, `lint.yaml`, `test-coverage.yaml`: add `develop` to the
  `push` and `pull_request` branch filters (`[main]` -> `[main, develop]`).
- `pkgdown` (docs publishing) and the scheduled jobs (`nightly-validation`,
  `weekly-compliance`) are left unchanged.

## Type of Change

- [x] Other: CI configuration

## Testing and Validation

- YAML parses without error; the only change is the branch list on each trigger.
- Opening this PR against `develop` exercises the new triggers directly.
