### PR TITLE
Performance fixes from the 3 July audit

### DIFF
--- a/R/mcmc_summary_sbm.R
+++ b/R/mcmc_summary_sbm.R
@@ -87,34 +87,45 @@ find_representative_clustering = function(cluster_matrix) {
   n_iter = nrow(cluster_matrix)
   p = ncol(cluster_matrix)
 
-  # Build co-clustering (membership) matrices for all iterations
-
-  Ms = lapply(seq_len(n_iter), function(t) {
+  # Posterior similarity (co-clustering) matrix, streamed one iteration at a
+  # time; the per-iteration membership matrices are never stored.
+  psm = matrix(0, p, p)
+  for(t in seq_len(n_iter)) {
     z = cluster_matrix[t, ]
-    (outer(z, z, FUN = "==")) * 1L
-  })
+    psm = psm + (outer(z, z, FUN = "==") * 1L)
+  }
+  psm = psm / n_iter
 
-  # Average (posterior similarity / co-clustering) matrix
-  psm = Reduce(`+`, Ms) / n_iter
-
-  # MEAN representative (Dahl's method)
-  sqerr = vapply(Ms, function(M) sum((M - psm)^2), numeric(1))
+  # MEAN representative (Dahl's method): ||M_t - psm||^2 expands to
+  # n_pairs_t - 2 * sum(psm over co-clustered pairs) + sum(psm^2), where the
+  # co-clustered pairs decompose block-by-block, so M_t is never materialized.
+  sum_psm2 = sum(psm^2)
+  sqerr = vapply(seq_len(n_iter), function(t) {
+    z = cluster_matrix[t, ]
+    s = 0
+    n_pairs = 0
+    for(lab in unique(z)) {
+      idx = which(z == lab)
+      s = s + sum(psm[idx, idx])
+      n_pairs = n_pairs + length(idx)^2
+    }
+    n_pairs - 2 * s + sum_psm2
+  }, numeric(1))
   idx_dahl = which.min(sqerr)
   alloc_dahl = cluster_matrix[idx_dahl, , drop = TRUE]
 
-  #  MODE representative
-  hash_mat = function(M) paste(as.integer(t(M)), collapse = ",")
-  keys = vapply(Ms, hash_mat, character(1))
+  # MODE representative: two allocation vectors induce the same partition
+  # exactly when their first-occurrence canonical relabelings match, so an
+  # O(p) canonical label vector replaces the p x p membership matrix as the
+  # hash key.
+  keys = vapply(seq_len(n_iter), function(t) {
+    z = cluster_matrix[t, ]
+    paste(match(z, unique(z)), collapse = ",")
+  }, character(1))
   tab = table(keys)
   key_mode = names(tab)[which.max(tab)]
   idx_mode = match(key_mode, keys)
   alloc_mode = cluster_matrix[idx_mode, , drop = TRUE]
-  indicator_mode = matrix(
-    as.integer(strsplit(key_mode, ",", fixed = TRUE)[[1]]),
-    nrow = p, byrow = TRUE
-  )
-  p_dist = as.numeric(tab) / sum(tab)
-  posterior_variance = (1 - sum(p_dist^2)) / (1 - 1 / length(p_dist))
 
   list(
     mean = alloc_dahl,
@@ -145,29 +156,21 @@ compute_p_k_given_t = function(
   # Initialize vector for probabilities
   p_k_given_t = numeric(length(K_values))
 
-  # Normalization constant for t
-  log_vn_t = log_Vn[t]
+  # Shifted Poisson prior on the number of components (log scale)
+  log_poisson_pmf = dpois(K_values - 1, lambda, log = TRUE)
 
-  # Shifted Poisson prior on the number of components
-  poisson_pmf = dpois(K_values - 1, lambda)
+  # Falling factorial K!/(K-t)! and rising factorial
+  # prod(alpha*K + 0:(n-1)) = gamma(alpha*K + n)/gamma(alpha*K), both on the
+  # log scale so large K/t cannot overflow to Inf.
+  valid = K_values >= t
+  K = K_values[valid]
+  log_falling_factorial = lgamma(K + 1) - lgamma(K - t + 1)
+  log_rising_factorial = lgamma(dirichlet_alpha * K + num_variables) -
+    lgamma(dirichlet_alpha * K)
+  log_p_k = log_falling_factorial - log_rising_factorial +
+    log_poisson_pmf[valid] - log_Vn[t]
+  p_k_given_t[valid] = exp(log_p_k)
 
-  # Loop through each value of K
-  for(i in seq_along(K_values)) {
-    K = K_values[i]
-    if(K >= t) {
-      # Falling factorial
-      falling_factorial = prod(K:(K - t + 1))
-      # Rising factorial
-      rising_factorial = prod((dirichlet_alpha * K) + 0:(num_variables - 1))
-      # Compute log probability
-      log_p_k = log(falling_factorial) - log(rising_factorial) +
-        log(poisson_pmf[i]) - log_vn_t
-      # Convert log probability to probability
-      p_k_given_t[i] = exp(log_p_k)
-    } else {
-      p_k_given_t[i] = 0
-    }
-  }
   # Normalize probabilities
   p_k_given_t = p_k_given_t / sum(p_k_given_t)
 
@@ -195,18 +198,15 @@ posterior_summary_SBM = function(
   # cardinality  of the partition z
   clusters = apply(cluster_allocations, 1, function(row) length(unique(row)))
 
-  # Compute the conditional probabilities of the number of clusters for each
-  # row in clusters
-  p_k_given_t = matrix(NA, nrow = length(clusters), ncol = num_variables)
-
-  for(i in seq_along(clusters)) {
-    p_k_given_t[i, ] = compute_p_k_given_t(
-      clusters[i], log_Vn, dirichlet_alpha, num_variables, lambda
-    )
-  }
-
-  # Average across all iterations
-  p_k_given_t = colMeans(p_k_given_t)
+  # Compute the conditional probabilities of the number of clusters once per
+  # unique cardinality, then average with the observed frequencies (the
+  # per-iteration values only depend on the cardinality t).
+  unique_t = sort(unique(clusters))
+  p_k_by_t = vapply(unique_t, function(t) {
+    compute_p_k_given_t(t, log_Vn, dirichlet_alpha, num_variables, lambda)
+  }, numeric(num_variables))
+  t_freq = tabulate(match(clusters, unique_t), nbins = length(unique_t))
+  p_k_given_t = as.numeric(p_k_by_t %*% (t_freq / length(clusters)))
 
   # Format the output
   # num_blocks = 1:num_variables

--- a/src/math/cholesky_helpers.h
+++ b/src/math/cholesky_helpers.h
@@ -24,7 +24,7 @@ namespace cholesky_helpers {
  * @return   log|Ω| = 2 Σ log(R_ii).
  */
 inline double get_log_det(const arma::mat& R) {
-    return 2.0 * arma::accu(arma::log(R.diag()));
+    return 2.0 * arma::accu(ARMA_MY_LOG(arma::vec(R.diag())));
 }
 
 /**
@@ -97,16 +97,15 @@ inline double log_det_ratio_diag_kernel(
  * and MixedMRFModel::get_precision_constants, which differ only in where the
  * current precision entries come from (K vs −½K), passed in as scalars.
  *
- * @param cholesky      Upper-triangular Cholesky factor of K.
+ * @param logdet        log|K| (cached by the caller).
  * @param covariance    Σ = K⁻¹.
  * @param i, j          Off-diagonal/diagonal indices (i < j).
  * @param precision_ij, precision_jj  Current K entries K(i,j), K(j,j).
  * @return  {Phi_q1q, Phi_q1q1, c2, Phi_q1q1, c4, c5}.
  */
 inline std::array<double, 6> precision_proposal_constants(
-        const arma::mat& cholesky, const arma::mat& covariance,
+        double logdet, const arma::mat& covariance,
         size_t i, size_t j, double precision_ij, double precision_jj) {
-    double logdet = get_log_det(cholesky);
 
     double log_adj_ii = logdet + MY_LOG(std::abs(covariance(i, i)));
     double log_adj_ij = logdet + MY_LOG(std::abs(covariance(i, j)));
@@ -128,6 +127,14 @@ inline std::array<double, 6> precision_proposal_constants(
     c[4] = precision_jj - Phi_q1q * Phi_q1q;
     c[5] = c[4] + c[2] * c[2] / (c[3] * c[3]);
     return c;
+}
+
+/** Overload computing log|K| from the Cholesky factor (callers without a cached log-determinant). */
+inline std::array<double, 6> precision_proposal_constants(
+        const arma::mat& cholesky, const arma::mat& covariance,
+        size_t i, size_t j, double precision_ij, double precision_jj) {
+    return precision_proposal_constants(get_log_det(cholesky), covariance,
+                                        i, j, precision_ij, precision_jj);
 }
 
 } // namespace cholesky_helpers

--- a/src/mcmc/algorithms/leapfrog.cpp
+++ b/src/mcmc/algorithms/leapfrog.cpp
@@ -87,8 +87,11 @@ ConstrainedLeapfrogResult leapfrog_constrained_checked(
   );
 
   // --- Backward step (negate momentum, step forward) ---
-  // Use a separate Memoizer so the caller's cache stays at theta_new.
+  // Use a separate Memoizer so the caller's cache stays at theta_new, but
+  // seed it with the caller's cached evaluation: the forward step left memo
+  // at theta_new, which is exactly where the backward step starts.
   Memoizer back_memo(memo.joint_fn);
+  back_memo.seed_from(memo);
   arma::vec r_back = -r_new;
   auto [theta_back, r_back_out] = leapfrog_constrained(
     theta_new, r_back, eps, back_memo, inv_mass_diag,

--- a/src/mcmc/algorithms/leapfrog.h
+++ b/src/mcmc/algorithms/leapfrog.h
@@ -71,6 +71,19 @@ public:
    */
   void invalidate() { has_cache = false; }
 
+  /**
+   * Copy another Memoizer's cached entry (position, logp, gradient).
+   *
+   * Lets a secondary Memoizer start from an evaluation the primary one
+   * already holds instead of recomputing it.
+   */
+  void seed_from(const Memoizer& other) {
+    cached_theta = other.cached_theta;
+    cached_logp_val = other.cached_logp_val;
+    cached_grad_val = other.cached_grad_val;
+    has_cache = other.has_cache;
+  }
+
 private:
   void ensure_cached(const arma::vec& theta) {
     if (has_cache &&

--- a/src/mcmc/algorithms/nuts.cpp
+++ b/src/mcmc/algorithms/nuts.cpp
@@ -83,10 +83,11 @@ BuildTreeResult build_tree(
     // ---- Base case: a single leapfrog step --------------------------------
     arma::vec theta_new, r_new;
     bool non_reversible = false;
-    if (project_position && project_momentum) {
-      // Always run the checked variant so we can observe reversibility even
-      // when reverse_check is off. reverse_check controls whether we ACT
-      // on the result (terminate the tree); observation is always on.
+    if (project_position && project_momentum && reverse_check) {
+      // Checked variant: forward step plus a full backward integration to
+      // verify reversibility. Only run when the check is enforced (sampling
+      // phase); warmup observations are never stored, so the backward
+      // integration would be pure overhead there (mirrors hmc_step).
       auto checked = leapfrog_constrained_checked(
         theta, r, v * step_size, memo, inv_mass_diag,
         *project_position, *project_momentum,
@@ -95,6 +96,11 @@ BuildTreeResult build_tree(
       theta_new = std::move(checked.theta);
       r_new = std::move(checked.r);
       non_reversible = !checked.reversible;
+    } else if (project_position && project_momentum) {
+      std::tie(theta_new, r_new) = leapfrog_constrained(
+        theta, r, v * step_size, memo, inv_mass_diag,
+        *project_position, *project_momentum
+      );
     } else {
       std::tie(theta_new, r_new) = leapfrog_memo(
         theta, r, v * step_size, memo, inv_mass_diag
@@ -117,6 +123,7 @@ BuildTreeResult build_tree(
       result.p_end = r_new;
       result.r_prime = std::move(r_new);
       result.theta_prime = std::move(theta_new);
+      result.logp_prime = neg_inf;  // never selected: s_prime = 0
       result.p_sharp_beg = p_sharp;
       result.p_sharp_end = std::move(p_sharp);
       result.log_sum_weight = neg_inf;
@@ -151,6 +158,7 @@ BuildTreeResult build_tree(
     result.p_end = r_new;
     result.r_prime = std::move(r_new);
     result.theta_prime = std::move(theta_new);
+    result.logp_prime = logp;
     result.p_sharp_beg = p_sharp;
     result.p_sharp_end = std::move(p_sharp);
     result.alpha = alpha;
@@ -192,6 +200,7 @@ BuildTreeResult build_tree(
   arma::vec r_plus = std::move(init_result.r_plus);
   arma::vec theta_prime = std::move(init_result.theta_prime);
   arma::vec r_prime = std::move(init_result.r_prime);
+  double logp_prime = init_result.logp_prime;
   arma::vec rho_init = std::move(init_result.rho);
   arma::vec p_sharp_init_beg = std::move(init_result.p_sharp_beg);
   arma::vec p_sharp_init_end = std::move(init_result.p_sharp_end);
@@ -240,6 +249,7 @@ BuildTreeResult build_tree(
     result.r_plus = std::move(r_plus);
     result.theta_prime = std::move(theta_prime);
     result.r_prime = std::move(r_prime);
+    result.logp_prime = logp_prime;
     rho_init += final_result.rho;
     result.rho = std::move(rho_init);
     result.p_sharp_beg = std::move(p_sharp_init_beg);
@@ -273,10 +283,12 @@ BuildTreeResult build_tree(
   if (log_sum_weight_final > log_sum_weight_subtree) {
     theta_prime = std::move(final_result.theta_prime);
     r_prime = std::move(final_result.r_prime);
+    logp_prime = final_result.logp_prime;
   } else if (MY_LOG(runif(rng)) <
              log_sum_weight_final - log_sum_weight_subtree) {
     theta_prime = std::move(final_result.theta_prime);
     r_prime = std::move(final_result.r_prime);
+    logp_prime = final_result.logp_prime;
   }
 
   arma::vec rho_subtree = rho_init + rho_final;
@@ -298,6 +310,7 @@ BuildTreeResult build_tree(
   result.r_plus = std::move(r_plus);
   result.theta_prime = std::move(theta_prime);
   result.r_prime = std::move(r_prime);
+  result.logp_prime = logp_prime;
   result.rho = std::move(rho_subtree);
   result.p_sharp_beg = std::move(p_sharp_init_beg);
   result.p_sharp_end = std::move(p_sharp_final_end);
@@ -340,6 +353,8 @@ StepResult nuts_step(
   double logp0 = memo.cached_log_post(init_theta);
   double kin0 = kinetic_energy(r0, inv_mass_diag);
   double H0 = -logp0 + kin0;
+  // Log-posterior of the currently selected sample, kept in sync with theta.
+  double logp_selected = logp0;
 
   arma::vec theta_min = init_theta, r_min = r0;
   arma::vec theta_plus = init_theta, r_plus = r0;
@@ -431,6 +446,7 @@ StepResult nuts_step(
             result.log_sum_weight - log_sum_weight_traj) {
         theta = std::move(result.theta_prime);
         r = std::move(result.r_prime);
+        logp_selected = result.logp_prime;
       }
     }
     log_sum_weight_traj =
@@ -453,9 +469,8 @@ StepResult nuts_step(
   }
 
   double accept_prob = sum_metro_prob / static_cast<double>(n_leapfrog_total);
-  auto logp_final = memo.cached_log_post(theta);
   double kin_final = kinetic_energy(r, inv_mass_diag);
-  double energy = -logp_final + kin_final;
+  double energy = -logp_selected + kin_final;
 
   auto diag = std::make_shared<NUTSDiagnostics>();
   diag->tree_depth = j;

--- a/src/mcmc/algorithms/nuts.h
+++ b/src/mcmc/algorithms/nuts.h
@@ -21,6 +21,7 @@ struct BuildTreeResult {
   arma::vec r_plus;        ///< Corresponding momentum at theta_plus
   arma::vec theta_prime;   ///< Current proposed sample (to possibly accept)
   arma::vec r_prime;       ///< Momentum at theta_prime (for energy diagnostics)
+  double logp_prime;       ///< Log-posterior at theta_prime (avoids a re-eval in nuts_step)
   arma::vec rho;           ///< Sum of momenta along the subtree (for U-turn criterion)
   arma::vec p_sharp_beg;   ///< Sharp momentum (M^{-1} p) at subtree beginning
   arma::vec p_sharp_end;   ///< Sharp momentum (M^{-1} p) at subtree end

--- a/src/models/bgmCompare/bgmCompare_logp_and_grad.cpp
+++ b/src/models/bgmCompare/bgmCompare_logp_and_grad.cpp
@@ -142,8 +142,8 @@ arma::vec gradient_observed_active(
   // -------------------------------
   for (int g = 0; g < num_groups; g++) {
     // list access
-    arma::imat counts_per_category = counts_per_category_group[g];
-    arma::imat blume_capel_stats = blume_capel_stats_group[g];
+    const arma::imat& counts_per_category = counts_per_category_group[g];
+    const arma::imat& blume_capel_stats = blume_capel_stats_group[g];
     const arma::vec proj_g = projection.row(g).t(); // length = num_groups-1
 
     // Main effects
@@ -191,7 +191,7 @@ arma::vec gradient_observed_active(
     }
 
     // Pairwise (observed)
-    arma::mat pairwise_stats = pairwise_stats_group[g];
+    const arma::mat& pairwise_stats = pairwise_stats_group[g];
     for (int v1 = 0; v1 < num_variables - 1; v1++) {
       for (int v2 = v1 + 1; v2 < num_variables; v2++) {
         const int row = pairwise_effect_indices(v1, v2);
@@ -542,8 +542,8 @@ std::pair<double, arma::vec> logp_and_gradient(
     const int r0 = group_indices(g, 0);
     const int r1 = group_indices(g, 1);
 
-    const arma::imat counts_per_category = counts_per_category_group[g];
-    const arma::imat blume_capel_stats = blume_capel_stats_group[g];
+    const arma::imat& counts_per_category = counts_per_category_group[g];
+    const arma::imat& blume_capel_stats = blume_capel_stats_group[g];
     const arma::vec proj_g = projection.row(g).t();
 
     main_group.zeros();
@@ -581,7 +581,7 @@ std::pair<double, arma::vec> logp_and_gradient(
     // ---- data contribution pseudolikelihood (quadratic terms) ----
     const arma::mat obs = observations_double.rows(r0, r1);
     const arma::mat obs_t = obs.t();  // Pre-transpose for BLAS vectorization
-    const arma::mat pairwise_stats = pairwise_stats_group[g];
+    const arma::mat& pairwise_stats = pairwise_stats_group[g];
 
     log_pp += arma::accu(pairwise_group % pairwise_stats);
 

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -134,6 +134,7 @@ void GGMModel::set_vectorized_parameters(const arma::vec& parameters) {
         refresh_cholesky();
     } else {
         covariance_matrix_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
+        log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
     }
 
     // Cache theta
@@ -185,7 +186,7 @@ arma::vec GGMModel::get_active_inv_mass() const {
 void GGMModel::get_constants(size_t i, size_t j) {
     // GGM stores K directly, so the precision entries are precision_matrix_.
     constants_ = cholesky_helpers::precision_proposal_constants(
-        cholesky_of_precision_, covariance_matrix_, i, j,
+        log_det_precision_, covariance_matrix_, i, j,
         precision_matrix_(i, j), precision_matrix_(j, j));
 }
 
@@ -256,8 +257,10 @@ double GGMModel::ggm_edge_move(size_t i, size_t j) {
     double omega_prop_q1q = constants_[2] + constants_[3] * phi_prop;
     double omega_prop_qq  = constrained_diagonal(omega_prop_q1q);
 
-    // form full proposal matrix for Omega
-    precision_proposal_ = precision_matrix_;
+    // Only the (i,j), (j,i), (j,j) entries of the proposal are read on the
+    // data path; the full-matrix copy is needed only for the prior-only PD
+    // check below.
+    if (n_ == 0) precision_proposal_ = precision_matrix_;
     precision_proposal_(i, j) = omega_prop_q1q;
     precision_proposal_(j, i) = omega_prop_q1q;
     precision_proposal_(j, j) = omega_prop_qq;
@@ -350,6 +353,7 @@ void GGMModel::apply_rank2_chol_smw_update_()
         refresh_cholesky();
     } else {
         covariance_matrix_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
+        log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
     }
 }
 
@@ -541,7 +545,7 @@ void GGMModel::do_one_gibbs_step(int /*iteration*/) {
 }
 
 double GGMModel::ggm_diag_move(size_t i) {
-    double logdet_omega = cholesky_helpers::get_log_det(cholesky_of_precision_);
+    double logdet_omega = log_det_precision_;
     double logdet_omega_sub_ii = logdet_omega + MY_LOG(covariance_matrix_(i, i));
 
     size_t e = i * (i + 3) / 2; // parameter index in vectorized form (column-major upper triangle, i==j)
@@ -550,7 +554,9 @@ double GGMModel::ggm_diag_move(size_t i) {
     double theta_curr = (logdet_omega - logdet_omega_sub_ii) / 2;
     double theta_prop = rnorm(rng_, theta_curr, proposal_sd);
 
-    precision_proposal_ = precision_matrix_;
+    // Only the (i,i) entry of the proposal is read on the data path; the
+    // full-matrix copy is needed only for the prior-only PD check below.
+    if (n_ == 0) precision_proposal_ = precision_matrix_;
     precision_proposal_(i, i) = precision_matrix_(i, i) - MY_EXP(theta_curr) * MY_EXP(theta_curr) + MY_EXP(theta_prop) * MY_EXP(theta_prop);
 
     // Prior-only chains have no likelihood anchor vetoing non-PD proposals;
@@ -608,6 +614,7 @@ void GGMModel::cholesky_update_after_diag(double omega_ii_old, size_t i)
         refresh_cholesky();
     } else {
         covariance_matrix_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
+        log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
     }
 
     // reset for next iteration
@@ -621,8 +628,8 @@ void GGMModel::update_edge_indicator_parameter_pair(size_t i, size_t j) {
     double proposal_sd = proposal_sds_(e);
 
     if (edge_indicators_(i, j) == 1) {
-        // Propose to turn OFF the edge
-        precision_proposal_ = precision_matrix_;
+        // Propose to turn OFF the edge. Only the (i,j), (j,i), (j,j)
+        // entries of the proposal are read below.
         precision_proposal_(i, j) = 0.0;
         precision_proposal_(j, i) = 0.0;
 
@@ -687,7 +694,7 @@ void GGMModel::update_edge_indicator_parameter_pair(size_t i, size_t j) {
         double omega_prop_ij = constants_[3] * epsilon;
         double omega_prop_jj = constrained_diagonal(omega_prop_ij);
 
-        precision_proposal_ = precision_matrix_;
+        // Only the (i,j), (j,i), (j,j) entries of the proposal are read below.
         precision_proposal_(i, j) = omega_prop_ij;
         precision_proposal_(j, i) = omega_prop_ij;
         precision_proposal_(j, j) = omega_prop_jj;
@@ -790,19 +797,8 @@ void GGMModel::prepare_iteration() {
 void GGMModel::update_edge_indicators() {
     for (size_t idx = 0; idx < num_pairwise_; ++idx) {
         size_t flat = shuffled_edge_order_(idx);
-        // Convert flat index to (i, j) upper-triangle pair.
-        // flat = 0..(num_pairwise_-1), row-major: (0,1),(0,2),...,(0,p-1),(1,2),...
-        size_t i = 0, j = 0;
-        size_t acc = 0;
-        for (size_t row = 0; row < p_ - 1; ++row) {
-            size_t cols_in_row = p_ - 1 - row;
-            if (flat < acc + cols_in_row) {
-                i = row;
-                j = row + 1 + (flat - acc);
-                break;
-            }
-            acc += cols_in_row;
-        }
+        size_t i = edge_pairs_(flat, 0);
+        size_t j = edge_pairs_(flat, 1);
         if (use_conjugate_edge_proposal_) {
             update_edge_indicator_conjugate(i, j);
         } else {
@@ -955,6 +951,7 @@ void GGMModel::refresh_cholesky() {
     arma::solve(inv_cholesky_of_precision_, arma::trimatu(cholesky_of_precision_),
                 arma::eye(p_, p_), arma::solve_opts::fast);
     covariance_matrix_ = inv_cholesky_of_precision_ * inv_cholesky_of_precision_.t();
+    log_det_precision_ = cholesky_helpers::get_log_det(cholesky_of_precision_);
 }
 
 

--- a/src/models/ggm/ggm_model.h
+++ b/src/models/ggm/ggm_model.h
@@ -111,6 +111,14 @@ public:
         int num_edges = arma::accu(edge_indicators_) / 2;
         int max_edges = static_cast<int>(p_ * (p_ - 1) / 2);
         has_sparse_graph_ = !edge_selection_ && (num_edges < max_edges);
+        edge_pairs_.set_size(num_pairwise_, 2);
+        size_t flat = 0;
+        for (size_t i = 0; i + 1 < p_; ++i) {
+            for (size_t j = i + 1; j < p_; ++j, ++flat) {
+                edge_pairs_(flat, 0) = i;
+                edge_pairs_(flat, 1) = j;
+            }
+        }
         initialize_precision_from_mle();
     }
 
@@ -132,12 +140,14 @@ public:
           cholesky_of_precision_(other.cholesky_of_precision_),
           inv_cholesky_of_precision_(other.inv_cholesky_of_precision_),
           covariance_matrix_(other.covariance_matrix_),
+          log_det_precision_(other.log_det_precision_),
           omega_(other.omega_),
           edge_indicators_(other.edge_indicators_),
           vectorized_parameters_(other.vectorized_parameters_),
           vectorized_indicator_parameters_(other.vectorized_indicator_parameters_),
           proposal_sds_(other.proposal_sds_),
           shuffled_edge_order_(other.shuffled_edge_order_),
+          edge_pairs_(other.edge_pairs_),
           num_pairwise_(other.num_pairwise_),
           rng_(other.rng_),
           observations_(other.observations_),
@@ -501,6 +511,7 @@ private:
     /// Precision matrix Omega, its Cholesky factor R (Omega = R'R),
     /// inverse Cholesky factor, and covariance matrix.
     arma::mat precision_matrix_, cholesky_of_precision_, inv_cholesky_of_precision_, covariance_matrix_;
+    double log_det_precision_ = 0.0;    ///< Cached log|K|, refreshed with the Cholesky caches
     /// Per-edge scale-mixture weight for the Cauchy slab: K_yy_ij | omega_ij ~
     /// N(0, sigma^2 omega_ij), omega_ij ~ InvGamma(1/2, 1/2). Fixed at 1 for a
     /// Normal slab (the mixture collapses to the plain Normal). Used only by
@@ -520,6 +531,7 @@ private:
 
     /// Shuffled edge visit order for random-scan edge selection.
     arma::uvec shuffled_edge_order_;
+    arma::umat edge_pairs_;             ///< num_pairwise x 2 flat-index -> (i, j) table (row-major upper triangle)
     /// Number of unique off-diagonal pairs: p(p-1)/2.
     size_t num_pairwise_ = 0;
     /// Random number generator.

--- a/src/models/mixed/mixed_mrf_gradient.cpp
+++ b/src/models/mixed/mixed_mrf_gradient.cpp
@@ -227,8 +227,8 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
 
     // --- Derived quantities ---
     // Conditional mean: M_i = μ_y' + 2 x_i' A_xy Σ_yy  (n x q)
-    arma::mat temp_cond_mean = arma::repmat(temp_main_continuous.t(), n_, 1)
-                             + 2.0 * discrete_observations_dbl_ * temp_pairwise_cross * temp_covariance;
+    arma::mat temp_cond_mean = 2.0 * discrete_observations_dbl_ * temp_pairwise_cross * temp_covariance;
+    temp_cond_mean.each_row() += temp_main_continuous.t();
 
     // Residual: D = Y - M  (n x q)
     arma::mat D = continuous_observations_ - temp_cond_mean;
@@ -238,6 +238,11 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
     // (see recompute_marginal_interactions in mixed_mrf_model.cpp).
     arma::mat temp_marginal;
     temp_marginal = temp_pairwise_discrete + 2.0 * temp_pairwise_cross * temp_covariance * temp_pairwise_cross.t();
+
+    // Rest-score ingredients shared by every variable: one n x p GEMM instead
+    // of p per-variable GEMVs, and the p cross-bias scalars in one GEMV.
+    arma::mat X_marginal = discrete_observations_dbl_ * temp_marginal;
+    arma::vec cross_bias = 2.0 * (temp_pairwise_cross * temp_main_continuous);
 
     // Start gradient from observed-statistics cache
     arma::vec grad = grad_obs_cache_;
@@ -262,9 +267,9 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
         arma::vec rest;
         // Marginal: Θ-based rest + A_xy μ_y bias
         double precision_ss = temp_marginal(s, s);
-        rest = 2.0 * (discrete_observations_dbl_ * temp_marginal.col(s)
+        rest = 2.0 * (X_marginal.col(s)
                     - discrete_observations_dbl_.col(s) * precision_ss)
-             + 2.0 * arma::dot(temp_pairwise_cross.row(s), temp_main_continuous);
+             + cross_bias(s);
 
         if(is_ordinal_variable_(s)) {
             arma::vec main_param = temp_main_discrete.row(s).cols(0, C_s - 1).t();
@@ -465,9 +470,9 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient(
         int C_s = num_categories_(s);
         arma::vec rest;
         double precision_ss = temp_marginal(s, s);
-        rest = 2.0 * (discrete_observations_dbl_ * temp_marginal.col(s)
+        rest = 2.0 * (X_marginal.col(s)
                     - discrete_observations_dbl_.col(s) * precision_ss)
-             + 2.0 * arma::dot(temp_pairwise_cross.row(s), temp_main_continuous);
+             + cross_bias(s);
         // Marginal self-interaction quadratic contribution
         logp += precision_ss * arma::dot(
             discrete_observations_dbl_.col(s),
@@ -811,12 +816,17 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
     double temp_log_det = 2.0 * arma::sum(arma::log(temp_cholesky.diag()));
 
     // --- Derived quantities ---
-    arma::mat temp_cond_mean = arma::repmat(temp_main_continuous.t(), n_, 1)
-                             + 2.0 * discrete_observations_dbl_ * temp_pairwise_cross * temp_covariance;
+    arma::mat temp_cond_mean = 2.0 * discrete_observations_dbl_ * temp_pairwise_cross * temp_covariance;
+    temp_cond_mean.each_row() += temp_main_continuous.t();
     arma::mat D = continuous_observations_ - temp_cond_mean;
 
     arma::mat temp_marginal;
     temp_marginal = temp_pairwise_discrete + 2.0 * temp_pairwise_cross * temp_covariance * temp_pairwise_cross.t();
+
+    // Rest-score ingredients shared by every variable: one n x p GEMM instead
+    // of p per-variable GEMVs, and the p cross-bias scalars in one GEMV.
+    arma::mat X_marginal = discrete_observations_dbl_ * temp_marginal;
+    arma::vec cross_bias = 2.0 * (temp_pairwise_cross * temp_main_continuous);
 
     // Initialize gradient (full dimension)
     arma::vec grad(full_dim, arma::fill::zeros);
@@ -883,9 +893,9 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
         // Rest score
         arma::vec rest;
         double precision_ss = temp_marginal(s, s);
-        rest = 2.0 * (discrete_observations_dbl_ * temp_marginal.col(s)
+        rest = 2.0 * (X_marginal.col(s)
                     - discrete_observations_dbl_.col(s) * precision_ss)
-             + 2.0 * arma::dot(temp_pairwise_cross.row(s), temp_main_continuous);
+             + cross_bias(s);
 
         if(is_ordinal_variable_(s)) {
             arma::vec main_param = temp_main_discrete.row(s).cols(0, C_s - 1).t();
@@ -1038,9 +1048,9 @@ std::pair<double, arma::vec> MixedMRFModel::logp_and_gradient_full(
         int C_s = num_categories_(s);
         arma::vec rest;
         double precision_ss = temp_marginal(s, s);
-        rest = 2.0 * (discrete_observations_dbl_ * temp_marginal.col(s)
+        rest = 2.0 * (X_marginal.col(s)
                     - discrete_observations_dbl_.col(s) * precision_ss)
-             + 2.0 * arma::dot(temp_pairwise_cross.row(s), temp_main_continuous);
+             + cross_bias(s);
         logp += precision_ss * arma::dot(
             discrete_observations_dbl_.col(s),
             discrete_observations_dbl_.col(s));

--- a/src/models/mixed/mixed_mrf_metropolis.cpp
+++ b/src/models/mixed/mixed_mrf_metropolis.cpp
@@ -20,26 +20,31 @@ namespace {
 // indicator) temporarily set pairwise_effects_continuous_, covariance_continuous_,
 // and marginal_interactions_ to proposed values, sum the OMRF marginals, then
 // must restore the accepted state regardless of the accept/reject outcome. This
-// snapshots those three fields on construction and restores them on scope exit,
+// snapshots those fields (plus the cross_term_ cache) on construction and
+// restores them on scope exit,
 // replacing the open-coded save / mutate / recompute / restore dance.
 struct ProposedContinuousState {
     arma::mat& pairwise;
     arma::mat& covariance;
     arma::mat& marginal;
+    arma::mat& cross_term;
     arma::mat pairwise_saved;
     arma::mat covariance_saved;
     arma::mat marginal_saved;
+    arma::mat cross_term_saved;
 
     ProposedContinuousState(arma::mat& pairwise_ref, arma::mat& covariance_ref,
-                            arma::mat& marginal_ref)
+                            arma::mat& marginal_ref, arma::mat& cross_term_ref)
         : pairwise(pairwise_ref), covariance(covariance_ref), marginal(marginal_ref),
+          cross_term(cross_term_ref),
           pairwise_saved(pairwise_ref), covariance_saved(covariance_ref),
-          marginal_saved(marginal_ref) {}
+          marginal_saved(marginal_ref), cross_term_saved(cross_term_ref) {}
 
     ~ProposedContinuousState() {
         pairwise = std::move(pairwise_saved);
         covariance = std::move(covariance_saved);
         marginal = std::move(marginal_saved);
+        cross_term = std::move(cross_term_saved);
     }
 
     ProposedContinuousState(const ProposedContinuousState&) = delete;
@@ -149,7 +154,7 @@ double MixedMRFModel::update_pairwise_discrete(int i, int j, std::optional<doubl
 
     pairwise_effects_discrete_(i, j) = proposed;
     pairwise_effects_discrete_(j, i) = proposed;
-    recompute_marginal_interactions();
+    refresh_marginal_interactions_entry(i, j);
 
     double ll_prop = log_marginal_omrf(i) + log_marginal_omrf(j)
                    + interaction_prior_->logp(proposed);
@@ -159,7 +164,7 @@ double MixedMRFModel::update_pairwise_discrete(int i, int j, std::optional<doubl
     if(MY_LOG(runif(rng_)) >= ln_alpha) {
         pairwise_effects_discrete_(i, j) = current_val;  // reject
         pairwise_effects_discrete_(j, i) = current_val;
-        recompute_marginal_interactions();
+        refresh_marginal_interactions_entry(i, j);
     }
 
     if (rm_weight) {
@@ -187,7 +192,7 @@ void MixedMRFModel::get_precision_constants(int i, int j) {
     size_t ui = static_cast<size_t>(i);
     size_t uj = static_cast<size_t>(j);
     cont_constants_ = cholesky_helpers::precision_proposal_constants(
-        cholesky_of_precision_, covariance_continuous_, ui, uj,
+        log_det_precision_, covariance_continuous_, ui, uj,
         -2.0 * pairwise_effects_continuous_(ui, uj),
         -2.0 * pairwise_effects_continuous_(uj, uj));
 }
@@ -279,8 +284,8 @@ double MixedMRFModel::log_ggm_ratio_edge(int i, int j, arma::mat& cov_prop_out) 
 
     // --- Proposed conditional mean ---
     // M' = μ_y' + 2 X A_xy Σ'
-    arma::mat cond_mean_prop = arma::repmat(main_effects_continuous_.t(), n_, 1) +
-                               2.0 * discrete_observations_dbl_ * pairwise_effects_cross_ * cov_prop;
+    arma::mat cond_mean_prop = 2.0 * discrete_observations_dbl_ * pairwise_effects_cross_ * cov_prop;
+    cond_mean_prop.each_row() += main_effects_continuous_.t();
 
     // --- Quadratic form difference ---
     arma::mat D_curr = continuous_observations_ - conditional_mean_;
@@ -323,8 +328,8 @@ double MixedMRFModel::log_ggm_ratio_diag(int i, arma::mat& cov_prop_out) const {
     arma::mat cov_prop = covariance_continuous_ + (2.0 * Uj / denom) * s * s.t();
 
     // --- Proposed conditional mean ---
-    arma::mat cond_mean_prop = arma::repmat(main_effects_continuous_.t(), n_, 1) +
-                               2.0 * discrete_observations_dbl_ * pairwise_effects_cross_ * cov_prop;
+    arma::mat cond_mean_prop = 2.0 * discrete_observations_dbl_ * pairwise_effects_cross_ * cov_prop;
+    cond_mean_prop.each_row() += main_effects_continuous_.t();
 
     // --- Quadratic form difference ---
     arma::mat D_curr = continuous_observations_ - conditional_mean_;
@@ -477,7 +482,8 @@ double MixedMRFModel::update_pairwise_effects_continuous_offdiag(int i, int j, s
         // Evaluate the proposed-state OMRF marginals under (Kyy', Σ'); the guard
         // restores the continuous fields when the block exits.
         ProposedContinuousState proposed_state(
-            pairwise_effects_continuous_, covariance_continuous_, marginal_interactions_);
+            pairwise_effects_continuous_, covariance_continuous_, marginal_interactions_,
+            cross_term_);
         pairwise_effects_continuous_(i, j) = -0.5 * theta_prop_ij;
         pairwise_effects_continuous_(j, i) = -0.5 * theta_prop_ij;
         pairwise_effects_continuous_(j, j) = -0.5 * theta_prop_jj;
@@ -533,7 +539,7 @@ double MixedMRFModel::update_pairwise_effects_continuous_offdiag(int i, int j, s
 // =============================================================================
 
 double MixedMRFModel::update_pairwise_effects_continuous_diag(int i, std::optional<double> rm_weight) {
-    double logdet = cholesky_helpers::get_log_det(cholesky_of_precision_);
+    double logdet = log_det_precision_;
     double logdet_sub_ii = logdet + MY_LOG(covariance_continuous_(i, i));
 
     double theta_curr = (logdet - logdet_sub_ii) / 2.0;
@@ -566,7 +572,8 @@ double MixedMRFModel::update_pairwise_effects_continuous_diag(int i, std::option
         // Evaluate the proposed-state OMRF marginals under (Kyy', Σ'); the guard
         // restores the continuous fields when the block exits.
         ProposedContinuousState proposed_state(
-            pairwise_effects_continuous_, covariance_continuous_, marginal_interactions_);
+            pairwise_effects_continuous_, covariance_continuous_, marginal_interactions_,
+            cross_term_);
         pairwise_effects_continuous_(i, i) = -0.5 * theta_ii_prop;
         covariance_continuous_ = cov_prop;
         recompute_marginal_interactions();
@@ -622,6 +629,7 @@ double MixedMRFModel::update_pairwise_cross(int i, int j, std::optional<double> 
     // Set proposed value and refresh caches
     arma::mat cond_mean_saved = conditional_mean_;
     arma::mat marginal_saved = marginal_interactions_;
+    arma::mat cross_term_saved = cross_term_;
     pairwise_effects_cross_(i, j) = proposed;
     recompute_conditional_mean();
     recompute_marginal_interactions();
@@ -637,6 +645,7 @@ double MixedMRFModel::update_pairwise_cross(int i, int j, std::optional<double> 
         pairwise_effects_cross_(i, j) = current_val;  // reject
         conditional_mean_ = std::move(cond_mean_saved);
         marginal_interactions_ = std::move(marginal_saved);
+        cross_term_ = std::move(cross_term_saved);
     }
 
     if (rm_weight) {
@@ -674,14 +683,14 @@ void MixedMRFModel::update_edge_indicator_discrete(int i, int j) {
 
     pairwise_effects_discrete_(i, j) = k_prop;
     pairwise_effects_discrete_(j, i) = k_prop;
-    recompute_marginal_interactions();
+    refresh_marginal_interactions_entry(i, j);
 
     double ll_prop = log_marginal_omrf(i) + log_marginal_omrf(j);
 
     // Restore
     pairwise_effects_discrete_(i, j) = k_curr;
     pairwise_effects_discrete_(j, i) = k_curr;
-    recompute_marginal_interactions();
+    refresh_marginal_interactions_entry(i, j);
 
     double ln_alpha = ll_prop - ll_curr;
 
@@ -706,7 +715,7 @@ void MixedMRFModel::update_edge_indicator_discrete(int i, int j) {
         pairwise_effects_discrete_(j, i) = k_prop;
         set_gxx(i, j, g_prop);
         constraint_dirty_ = true;
-        recompute_marginal_interactions();
+        refresh_marginal_interactions_entry(i, j);
     }
 }
 
@@ -764,7 +773,8 @@ void MixedMRFModel::update_edge_indicator_continuous(int i, int j) {
         // Evaluate the proposed-state OMRF marginals under (Kyy', Σ'); the guard
         // restores the continuous fields when the block exits.
         ProposedContinuousState proposed_state(
-            pairwise_effects_continuous_, covariance_continuous_, marginal_interactions_);
+            pairwise_effects_continuous_, covariance_continuous_, marginal_interactions_,
+            cross_term_);
         pairwise_effects_continuous_(i, j) = -0.5 * theta_prop_ij;
         pairwise_effects_continuous_(j, i) = -0.5 * theta_prop_ij;
         pairwise_effects_continuous_(j, j) = -0.5 * theta_prop_jj;
@@ -865,6 +875,7 @@ void MixedMRFModel::update_edge_indicator_cross(int i, int j) {
 
     arma::mat cond_mean_saved = conditional_mean_;
     arma::mat marginal_saved = marginal_interactions_;
+    arma::mat cross_term_saved = cross_term_;
     pairwise_effects_cross_(i, j) = k_prop;
     recompute_conditional_mean();
     recompute_marginal_interactions();
@@ -877,6 +888,7 @@ void MixedMRFModel::update_edge_indicator_cross(int i, int j) {
     pairwise_effects_cross_(i, j) = k_curr;
     conditional_mean_ = std::move(cond_mean_saved);
     marginal_interactions_ = std::move(marginal_saved);
+    cross_term_ = std::move(cross_term_saved);
 
     double ln_alpha = ll_prop - ll_curr;
 

--- a/src/models/mixed/mixed_mrf_model.cpp
+++ b/src/models/mixed/mixed_mrf_model.cpp
@@ -107,6 +107,7 @@ MixedMRFModel::MixedMRFModel(
     // Initialize marginal interactions: disc_int + 2 * cross_int * Sigma_yy * cross_int'
     //   With cross_int = 0, this is zero.
     marginal_interactions_ = arma::zeros<arma::mat>(p_, p_);
+    cross_term_ = arma::zeros<arma::mat>(p_, p_);
 
     // Initialize edge-order permutation vectors. The counts are size_t, so a
     // zero count (one continuous or one discrete variable) must not reach
@@ -117,6 +118,22 @@ MixedMRFModel::MixedMRFModel(
         ? arma::regspace<arma::uvec>(0, num_pairwise_yy_ - 1) : arma::uvec();
     edge_order_xy_ = num_cross_
         ? arma::regspace<arma::uvec>(0, num_cross_ - 1) : arma::uvec();
+
+    // Flat-index -> (i, j) lookup tables for the upper-triangle edge loops
+    // (row-major: (0,1),(0,2),...,(1,2),...).
+    auto build_edge_pairs = [](size_t dim, size_t count) {
+        arma::umat pairs(count, 2);
+        size_t flat = 0;
+        for (size_t i = 0; i + 1 < dim; ++i) {
+            for (size_t j = i + 1; j < dim; ++j, ++flat) {
+                pairs(flat, 0) = i;
+                pairs(flat, 1) = j;
+            }
+        }
+        return pairs;
+    };
+    edge_pairs_xx_ = build_edge_pairs(p_, num_pairwise_xx_);
+    edge_pairs_yy_ = build_edge_pairs(q_, num_pairwise_yy_);
 
     // Detect sparse initial graph (constraints without edge selection)
     if(!edge_selection_) {
@@ -181,6 +198,7 @@ MixedMRFModel::MixedMRFModel(const MixedMRFModel& other)
       covariance_continuous_(other.covariance_continuous_),
       log_det_precision_(other.log_det_precision_),
       marginal_interactions_(other.marginal_interactions_),
+      cross_term_(other.cross_term_),
       conditional_mean_(other.conditional_mean_),
       cont_constants_(other.cont_constants_),
       precision_proposal_(other.precision_proposal_),
@@ -202,7 +220,9 @@ MixedMRFModel::MixedMRFModel(const MixedMRFModel& other)
       rng_(other.rng_),
       edge_order_xx_(other.edge_order_xx_),
       edge_order_yy_(other.edge_order_yy_),
-      edge_order_xy_(other.edge_order_xy_)
+      edge_order_xy_(other.edge_order_xy_),
+      edge_pairs_xx_(other.edge_pairs_xx_),
+      edge_pairs_yy_(other.edge_pairs_yy_)
 {
     // Deep-copy the Z-ratio engine (per-chain caches never cross threads)
     // and rebind its RNG to this clone's stream.
@@ -285,8 +305,8 @@ size_t MixedMRFModel::count_num_main_effects() const {
 
 void MixedMRFModel::recompute_conditional_mean() {
     // M = μ_y' + 2 X A_xy Σ_yy
-    conditional_mean_ = arma::repmat(main_effects_continuous_.t(), n_, 1) +
-                        2.0 * discrete_observations_dbl_ * pairwise_effects_cross_ * covariance_continuous_;
+    conditional_mean_ = 2.0 * discrete_observations_dbl_ * pairwise_effects_cross_ * covariance_continuous_;
+    conditional_mean_.each_row() += main_effects_continuous_.t();
 }
 
 void MixedMRFModel::recompute_pairwise_effects_continuous_decomposition() {
@@ -303,8 +323,16 @@ void MixedMRFModel::recompute_marginal_interactions() {
     //   M = A_xx + 2 A_xy Σ_yy A_xy'
     // The log-marginal has x'Mx, so the x_s-conditional rest score carries
     // a factor 2 on M.col(s) (consumed at the call site in log_marginal_omrf).
-    marginal_interactions_ = pairwise_effects_discrete_
-                           + 2.0 * pairwise_effects_cross_ * covariance_continuous_ * pairwise_effects_cross_.t();
+    cross_term_ = 2.0 * pairwise_effects_cross_ * covariance_continuous_ * pairwise_effects_cross_.t();
+    marginal_interactions_ = pairwise_effects_discrete_ + cross_term_;
+}
+
+void MixedMRFModel::refresh_marginal_interactions_entry(int i, int j) {
+    // A_xx-only change: the cross term is untouched, so only the (i,j)/(j,i)
+    // entries of M move.
+    double value = pairwise_effects_discrete_(i, j) + cross_term_(i, j);
+    marginal_interactions_(i, j) = value;
+    marginal_interactions_(j, i) = value;
 }
 
 
@@ -1386,34 +1414,13 @@ void MixedMRFModel::update_edge_indicators() {
     // Discrete-discrete edges (shuffled order)
     for(size_t e = 0; e < num_pairwise_xx_; ++e) {
         size_t idx = edge_order_xx_(e);
-        // Decode upper-triangle index to (i, j)
-        size_t i = 0, j = 1;
-        size_t count = 0;
-        for(i = 0; i < p_ - 1; ++i) {
-            size_t row_len = p_ - 1 - i;
-            if(count + row_len > idx) {
-                j = i + 1 + (idx - count);
-                break;
-            }
-            count += row_len;
-        }
-        update_edge_indicator_discrete(i, j);
+        update_edge_indicator_discrete(edge_pairs_xx_(idx, 0), edge_pairs_xx_(idx, 1));
     }
 
     // Continuous-continuous edges (shuffled order)
     for(size_t e = 0; e < num_pairwise_yy_; ++e) {
         size_t idx = edge_order_yy_(e);
-        size_t i = 0, j = 1;
-        size_t count = 0;
-        for(i = 0; i < q_ - 1; ++i) {
-            size_t row_len = q_ - 1 - i;
-            if(count + row_len > idx) {
-                j = i + 1 + (idx - count);
-                break;
-            }
-            count += row_len;
-        }
-        update_edge_indicator_continuous(i, j);
+        update_edge_indicator_continuous(edge_pairs_yy_(idx, 0), edge_pairs_yy_(idx, 1));
     }
 
     // Cross edges (shuffled order)

--- a/src/models/mixed/mixed_mrf_model.h
+++ b/src/models/mixed/mixed_mrf_model.h
@@ -439,6 +439,7 @@ private:
     arma::mat covariance_continuous_;       ///< q x q Σ = Precision^{-1}
     double log_det_precision_;              ///< log|Precision|
     arma::mat marginal_interactions_;                       ///< p x p marginal PL interaction matrix
+    arma::mat cross_term_;                  ///< p x p cached 2 A_xy Σ A_xy' (marginal PL cross term)
     arma::mat conditional_mean_;            ///< n x q conditional mean
 
     // Rank-1 Cholesky update workspace
@@ -497,6 +498,8 @@ private:
     arma::uvec edge_order_xx_;          ///< Shuffled xx-edge pair indices
     arma::uvec edge_order_yy_;          ///< Shuffled yy-edge pair indices
     arma::uvec edge_order_xy_;          ///< Shuffled xy-edge pair indices
+    arma::umat edge_pairs_xx_;          ///< num_pairwise_xx x 2 flat-index -> (i, j) table
+    arma::umat edge_pairs_yy_;          ///< num_pairwise_yy x 2 flat-index -> (i, j) table
 
     // =========================================================================
     // Private helpers
@@ -514,8 +517,11 @@ private:
     /** Recompute cholesky_of_precision_, inv_cholesky_of_precision_, covariance_continuous_, log_det_precision_ from pairwise_effects_continuous_. */
     void recompute_pairwise_effects_continuous_decomposition();
 
-    /** Recompute marginal_interactions_ from pairwise_effects_discrete_, pairwise_effects_cross_, covariance_continuous_ (marginal PL only). */
+    /** Recompute marginal_interactions_ from pairwise_effects_discrete_, pairwise_effects_cross_, covariance_continuous_ (marginal PL only). Refreshes cross_term_. */
     void recompute_marginal_interactions();
+
+    /** Refresh marginal_interactions_(i,j)/(j,i) from pairwise_effects_discrete_ and the cached cross_term_. Valid only while pairwise_effects_cross_ and covariance_continuous_ are unchanged since the last cross_term_ refresh. */
+    void refresh_marginal_interactions_entry(int i, int j);
 
     /** Rebuild Cholesky constraint structure and excluded-edge index lists. */
     void ensure_constraint_structure();

--- a/src/priors/sbm_edge_prior.cpp
+++ b/src/priors/sbm_edge_prior.cpp
@@ -251,7 +251,7 @@ arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
                                              no_variables);
 
             log_weights(c) =
-              std::log(dirichlet_alpha + static_cast<double>(cluster_size_node(c))) +
+              MY_LOG(dirichlet_alpha + static_cast<double>(cluster_size_node(c))) +
               loglike;
           }
           else{ // if old group, the weight is zero (log-weight -inf)
@@ -266,7 +266,7 @@ arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
                                          beta_bernoulli_alpha_between,
                                          beta_bernoulli_beta_between);
 
-          log_weights(c) = std::log(dirichlet_alpha) + logmarg +
+          log_weights(c) = MY_LOG(dirichlet_alpha) + logmarg +
             (log_Vn(no_clusters - 1) - log_Vn(no_clusters - 2));
         }
       }
@@ -306,7 +306,7 @@ arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
                                            no_variables);
 
           log_weights(c) =
-            std::log(dirichlet_alpha + static_cast<double>(cluster_size_node(c))) +
+            MY_LOG(dirichlet_alpha + static_cast<double>(cluster_size_node(c))) +
             loglike;
         } else {
           logmarg = log_marginal_mfm_sbm(cluster_assign_tmp,
@@ -316,7 +316,7 @@ arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
                                          beta_bernoulli_alpha_between,
                                          beta_bernoulli_beta_between);
 
-          log_weights(c) = std::log(dirichlet_alpha) + logmarg +
+          log_weights(c) = MY_LOG(dirichlet_alpha) + logmarg +
             (log_Vn(no_clusters) - log_Vn(no_clusters-1));
         }
       }
@@ -442,7 +442,7 @@ arma::mat compute_ce_sbm(const arma::uvec& cluster_assign,
         double c = correction.fprime_at(dmin);
         ce(i, j) = c; ce(j, i) = c;
         double th = TH(i, j);
-        double ec = std::exp(c);
+        double ec = MY_EXP(c);
         double e = th * ec / (1.0 - th + th * ec);
         max_diff = std::max(max_diff, std::abs(e - ep(i, j)));
         ep(i, j) = e; ep(j, i) = e;
@@ -474,7 +474,7 @@ arma::vec degrees_ld_sbm(const arma::uvec& cluster_assign,
     for(arma::uword j = 0; j < q; j++) {
       if(j == i || !correction.node_continuous(j)) continue;
       double th = block_probs(cluster_assign(i), cluster_assign(j));
-      double ec = std::exp(ce(i, j));
+      double ec = MY_EXP(ce(i, j));
       s += th * ec / (1.0 - th + th * ec);
     }
     deg(i) = s / static_cast<double>(q_cc - 1);
@@ -521,7 +521,7 @@ double miniti_node_sbm(arma::uword node,
       for(arma::uword j : js) {
         double th = (1 - t) * th_old[j] + t * th_new[j];
         double dmin = std::min(degk, deg_base(j));
-        double ec = std::exp(correction.fprime_at(dmin));
+        double ec = MY_EXP(correction.fprime_at(dmin));
         s += th * ec / (1.0 - th + th * ec);
       }
       double ndeg = s / static_cast<double>(q_cc - 1);
@@ -533,7 +533,7 @@ double miniti_node_sbm(arma::uword node,
       double th = (1 - t) * th_old[j] + t * th_new[j];
       double dth = th_new[j] - th_old[j];
       double dmin = std::min(degk, deg_base(j));
-      double ec = std::exp(correction.fprime_at(dmin));
+      double ec = MY_EXP(correction.fprime_at(dmin));
       sc += dth * (ec - 1.0) / (1.0 - th + th * ec);
     }
     if(ti > 0) dlogC += 0.5 * (prev + sc) * (1.0 / T);
@@ -580,7 +580,7 @@ double miniti_removal_sbm(arma::uword node,
       for(arma::uword j : js) {
         double th = (1 - t) * th_old[j];
         double dmin = std::min(degk, deg_base(j));
-        double ec = std::exp(correction.fprime_at(dmin));
+        double ec = MY_EXP(correction.fprime_at(dmin));
         s += th * ec / (1.0 - th + th * ec);
       }
       double ndeg = s / static_cast<double>(q_cc - 1);
@@ -592,7 +592,7 @@ double miniti_removal_sbm(arma::uword node,
       double th = (1 - t) * th_old[j];
       double dth = 0.0 - th_old[j];
       double dmin = std::min(degk, deg_base(j));
-      double ec = std::exp(correction.fprime_at(dmin));
+      double ec = MY_EXP(correction.fprime_at(dmin));
       sc += dth * (ec - 1.0) / (1.0 - th + th * ec);
     }
     if(ti > 0) dlogC += 0.5 * (prev + sc) * (1.0 / T);
@@ -628,6 +628,12 @@ double corrected_log_marginal_mfm_sbm(const arma::uvec& cluster_assign,
 
   double out = 0;
   std::vector<double> lp(Nq);
+  // log(th)/log1p(-th) are cluster-invariant; precompute the grids once.
+  std::vector<double> log_thq(Nq), log1p_neg_thq(Nq);
+  for(arma::uword k = 0; k < Nq; k++) {
+    log_thq[k] = MY_LOG(thq(k));
+    log1p_neg_thq[k] = MY_LOG1P(-thq(k));
+  }
   for(arma::uword r = 0; r < no_clusters; r++) {
     int nr = 0, mr = 0, nr_cc = 0;
     for(arma::uword j = 0; j < no_variables; j++) {
@@ -646,15 +652,14 @@ double corrected_log_marginal_mfm_sbm(const arma::uvec& cluster_assign,
     }
     double mx = -std::numeric_limits<double>::infinity();
     for(arma::uword k = 0; k < Nq; k++) {
-      double th = thq(k);
-      lp[k] = (beta_bernoulli_alpha_between - 1.0 + mr) * std::log(th) +
-        (beta_bernoulli_beta_between - 1.0 + nr - mr) * std::log1p(-th) -
+      lp[k] = (beta_bernoulli_alpha_between - 1.0 + mr) * log_thq[k] +
+        (beta_bernoulli_beta_between - 1.0 + nr - mr) * log1p_neg_thq[k] -
         static_cast<double>(tilt_n) * fq(k);
       if(lp[k] > mx) mx = lp[k];
     }
     double s = 0;
-    for(arma::uword k = 0; k < Nq; k++) s += std::exp(lp[k] - mx);
-    out += (std::log(s) + mx + std::log(dth)) - lbab;
+    for(arma::uword k = 0; k < Nq; k++) s += MY_EXP(lp[k] - mx);
+    out += (MY_LOG(s) + mx + MY_LOG(dth)) - lbab;
   }
   return out;
 }
@@ -732,7 +737,7 @@ arma::uvec block_allocations_mfm_sbm_corrected(arma::uvec cluster_assign,
         deg_base, correction);
       double size_excl = static_cast<double>(cluster_size(c)) -
         ((c == old) ? 1.0 : 0.0);
-      log_weights(c) = std::log(dir_alpha + size_excl) + loglike - corr;
+      log_weights(c) = MY_LOG(dir_alpha + size_excl) + loglike - corr;
     }
 
     double logmarg = corrected_log_marginal_mfm_sbm(
@@ -745,7 +750,7 @@ arma::uvec block_allocations_mfm_sbm_corrected(arma::uvec cluster_assign,
       ? (log_Vn(no_clusters - 1) - log_Vn(no_clusters - 2))
       : (log_Vn(no_clusters) - log_Vn(no_clusters - 1));
     log_weights(no_clusters) =
-      std::log(dir_alpha) + logmarg + vn_ratio - removal;
+      MY_LOG(dir_alpha) + logmarg + vn_ratio - removal;
 
     arma::uword cluster = sample_cluster_log(log_weights, rng);
 
@@ -792,20 +797,25 @@ static double draw_theta_local_density(int m, int n_pairs, double a, double b,
   double hi = std::min(1.0 - 1e-7, theta_current + half_width);
   double grid[N], weight[N];
   double step = (hi - lo) / (N - 1);
+  // exp(c_e) is grid-invariant; hoist it out of the N-point loop.
+  std::vector<double> exp_ce(ce_edges.size());
+  for(size_t e = 0; e < ce_edges.size(); e++) {
+    exp_ce[e] = MY_EXP(ce_edges[e]);
+  }
   double mx = -std::numeric_limits<double>::infinity();
   for(int k = 0; k < N; k++) {
     double th = lo + step * k;
     grid[k] = th;
     double lc = 0;
-    for(size_t e = 0; e < ce_edges.size(); e++) {
-      lc += std::log(1.0 - th + th * std::exp(ce_edges[e]));
+    for(size_t e = 0; e < exp_ce.size(); e++) {
+      lc += MY_LOG(1.0 - th + th * exp_ce[e]);
     }
-    weight[k] = (a + m - 1.0) * std::log(th) +
-      (b + n_pairs - m - 1.0) * std::log1p(-th) - lc;
+    weight[k] = (a + m - 1.0) * MY_LOG(th) +
+      (b + n_pairs - m - 1.0) * MY_LOG1P(-th) - lc;
     if(weight[k] > mx) mx = weight[k];
   }
   double s = 0;
-  for(int k = 0; k < N; k++) { weight[k] = std::exp(weight[k] - mx); s += weight[k]; }
+  for(int k = 0; k < N; k++) { weight[k] = MY_EXP(weight[k] - mx); s += weight[k]; }
   double u = runif(rng) * s;
   double cum = 0;
   int k = 0;


### PR DESCRIPTION
This lands the remaining efficiency improvements from the 3 July performance audit (`dev/audit/2026-07-03-performance-audit.md`). Each commit is one self-contained fix:

- **Mixed model**: the matrix coupling the discrete and continuous variables is cached and updated entry by entry when a proposal changes one edge, instead of being rebuilt in full. The gradient computes its rest scores through one shared matrix product.
- **NUTS reverse check**: the backward integration step used to run on every leapfrog step; it now runs only while sampling (during warmup its result was never used), and cached evaluations are reused where possible.
- **GGM proposals**: edge proposals write only the precision entries they change instead of copying the whole matrix, and the log-determinant is cached alongside the Cholesky factors.
- **bgmCompare**: the per-group sufficient statistics are bound by reference instead of being copied on every likelihood evaluation.
- **SBM prior**: terms that do not change across the quadrature grid or across clusters are computed once per call.
- **SBM summaries**: co-clustering summaries are accumulated one iteration at a time instead of storing a full membership matrix per iteration, and cluster-count probabilities are computed on the log scale.

No sampler output changes; results are numerically equivalent up to floating-point reordering.

**Benchmark** (n = 400, 8 ordinal + 8 continuous variables, 500 warmup + 500 iterations, one chain, optimized build): a mixed-model NUTS fit with edge selection went from 44.0s to 19.9s. The other fixes give smaller but consistent gains on their respective paths.

**Verification**: full fast test suites pass (2,750+ assertions, 0 failures); `R CMD check --as-cran` clean.
