### PR TITLE
Ordinal-model proposal caching, Z-ratio trims, and Windows math-macro coverage

### DIFF
--- a/src/models/ggm/ggm_gradient.cpp
+++ b/src/models/ggm/ggm_gradient.cpp
@@ -1,4 +1,5 @@
 #include "models/ggm/ggm_gradient.h"
+#include "math/explog_macros.h"
 
 #include <cmath>
 #include <limits>
@@ -152,7 +153,7 @@ ForwardMapResult GGMGradientEngine::forward_map(const arma::vec& theta) const {
             // Column 0: just the diagonal
             double psi_q = theta(offset);
             result.psi(q) = psi_q;
-            result.Phi(0, 0) = std::exp(psi_q);
+            result.Phi(0, 0) = MY_EXP(psi_q);
             continue;
         }
 
@@ -166,7 +167,7 @@ ForwardMapResult GGMGradientEngine::forward_map(const arma::vec& theta) const {
         // psi_q is after f_q
         double psi_q = theta(offset + d_q);
         result.psi(q) = psi_q;
-        result.Phi(q, q) = std::exp(psi_q);
+        result.Phi(q, q) = MY_EXP(psi_q);
 
         // Build constraint matrix A_q
         size_t m_q = col.m_q;
@@ -212,7 +213,7 @@ ForwardMapResult GGMGradientEngine::forward_map(const arma::vec& theta) const {
 
     // Jacobian: log|det J| = p*log(2) + 2*sum(psi) + sum_{i<p}(p-i)*psi_i
     //                       - sum_q sum_j log|R_{q,jj}|
-    double ldj = static_cast<double>(p_) * std::log(2.0);
+    double ldj = static_cast<double>(p_) * MY_LOG(2.0);
     for (size_t q = 0; q < p_; ++q) {
         ldj += 2.0 * result.psi(q);
     }
@@ -222,7 +223,7 @@ ForwardMapResult GGMGradientEngine::forward_map(const arma::vec& theta) const {
     for (size_t q = 1; q < p_; ++q) {
         const auto& rd = result.R_diag[q];
         for (size_t j = 0; j < rd.n_elem; ++j) {
-            ldj -= std::log(rd(j));
+            ldj -= MY_LOG(rd(j));
         }
     }
     result.log_det_jacobian = ldj;

--- a/src/models/ggm/ggm_model.cpp
+++ b/src/models/ggm/ggm_model.cpp
@@ -53,7 +53,7 @@ void GGMModel::recompute_theta() const {
         size_t offset = cs.theta_offsets[q];
 
         // psi_q = log(phi_qq)
-        double psi_q = std::log(cholesky_of_precision_(q, q));
+        double psi_q = MY_LOG(cholesky_of_precision_(q, q));
         theta_(offset + col.d_q) = psi_q;
 
         if (q == 0 || col.d_q == 0) continue;
@@ -309,7 +309,7 @@ double GGMModel::update_edge_parameter(size_t i, size_t j) {
     if (edge_indicators_(i, j) == 0) {
         return 0.0; // Edge is not included; skip update (AR irrelevant, masked out)
     }
-    return std::min(1.0, std::exp(ggm_edge_move(i, j)));
+    return std::min(1.0, MY_EXP(ggm_edge_move(i, j)));
 }
 
 void GGMModel::cholesky_update_after_edge(double omega_ij_old, double omega_jj_old, size_t i, size_t j)
@@ -503,7 +503,7 @@ void GGMModel::update_row_block_gibbs(size_t i) {
     // cancel, leaving the ratio (kii_new/kii_old)^(alpha-1). The guard keeps
     // the alpha = 1 path free of the runif draw.
     if (std::abs(alpha - 1.0) > 1e-12) {
-        const double log_mh = (alpha - 1.0) * (std::log(kii_new) - std::log(kii_old));
+        const double log_mh = (alpha - 1.0) * (MY_LOG(kii_new) - MY_LOG(kii_old));
         if (MY_LOG(runif(rng_)) >= log_mh) {
             return;  // reject: leave precision_matrix_, chol(K), Sigma unchanged
         }
@@ -589,7 +589,7 @@ double GGMModel::ggm_diag_move(size_t i) {
 }
 
 double GGMModel::update_diagonal_parameter(size_t i) {
-    return std::min(1.0, std::exp(ggm_diag_move(i)));
+    return std::min(1.0, MY_EXP(ggm_diag_move(i)));
 }
 
 void GGMModel::cholesky_update_after_diag(double omega_ii_old, size_t i)

--- a/src/models/ggm/zratio_engine.cpp
+++ b/src/models/ggm/zratio_engine.cpp
@@ -24,14 +24,19 @@ ZRatioBlock ZRatioEngine::extract_block(const arma::imat& G, int i,
     // 2-hop bridges between the exclusive neighbour sets. The toggled
     // edge's own state never enters, so the value is state-invariant.
     std::vector<bool> in_r(q, false);
+    // Exclusive neighbour lists of i and j; the bridge scan below then runs
+    // over the candidate pairs instead of the full q x q grid.
+    std::vector<int> excl_i, excl_j;
     for (int k = 0; k < q; k++) {
-        if (k != i && k != j && G(i, k) == 1 && G(j, k) == 1) in_r[k] = true;
+        if (k == i || k == j) continue;
+        const bool near_i = (G(i, k) == 1), near_j = (G(j, k) == 1);
+        if (near_i && near_j) in_r[k] = true;
+        else if (near_i) excl_i.push_back(k);
+        else if (near_j) excl_j.push_back(k);
     }
-    for (int a = 0; a < q; a++) {
-        if (a == i || a == j || G(i, a) != 1 || G(j, a) == 1) continue;
-        for (int b = 0; b < q; b++) {
-            if (b != i && b != j && b != a && G(j, b) == 1 && G(i, b) != 1 &&
-                G(a, b) == 1) {
+    for (int a : excl_i) {
+        for (int b : excl_j) {
+            if (G(a, b) == 1) {
                 in_r[a] = true;
                 in_r[b] = true;
             }
@@ -127,8 +132,7 @@ double ZRatioEngine::log_zratio(const arma::imat& G, int i, int j) {
     // Additive saddle: depends only on (nCN, cne, bre), served from the
     // persistent count-key cache. Corrections ride on top post-cache, so
     // corrected edges keep the compact key and full cache reuse.
-    std::string sig = "A" + std::to_string(ncn) + "_" + std::to_string(cne) +
-                      "_" + std::to_string(bre);
+    const std::uint64_t sig = pack_count_key(ncn, cne, bre);
     double a;
     auto it = cache_.find(sig);
     if (it != cache_.end()) {
@@ -397,10 +401,7 @@ void ZRatioEngine::precompute_table(int ncn_max, int bre_max) {
             for (int bre = 0; bre <= bre_max; bre++) {
                 double s1 = ncn * c1 + cne * c3 + bre * c5;
                 double s2 = ncn * c2 + cne * c4 + bre * c6;
-                std::string sig = "A" + std::to_string(ncn) + "_" +
-                                  std::to_string(cne) + "_" +
-                                  std::to_string(bre);
-                cache_[sig] = saddle_ratio(s1, s2);
+                cache_[pack_count_key(ncn, cne, bre)] = saddle_ratio(s1, s2);
             }
         }
     }

--- a/src/models/ggm/zratio_engine.cpp
+++ b/src/models/ggm/zratio_engine.cpp
@@ -1,4 +1,5 @@
 #include "zratio_engine.h"
+#include "math/explog_macros.h"
 
 #include <algorithm>
 #include <vector>
@@ -120,7 +121,7 @@ double ZRatioEngine::log_zratio(const arma::imat& G, int i, int j) {
     ZRatioBlock bl = extract_block(G, i, j);
     if (!bl.valid) {
         n_add_++;
-        return std::log(psi0_);
+        return MY_LOG(psi0_);
     }
     const int ncn = bl.ncn, cne = bl.cne, bre = bl.bre, maxbdeg = bl.maxbd,
               m = bl.m;
@@ -143,7 +144,7 @@ double ZRatioEngine::log_zratio(const arma::imat& G, int i, int j) {
         a = saddle_ratio(s1, s2);
         cache_[sig] = a;
     }
-    const double log_r_add = std::log(a);
+    const double log_r_add = MY_LOG(a);
 
     if (maxbdeg < 2) {
         n_add_++;
@@ -178,7 +179,7 @@ double ZRatioEngine::log_zratio(const arma::imat& G, int i, int j) {
         }
         double s1b = 0, s2b = 0, dl = 0;
         if (block_oracle_moments(bl.a_blk, bl.si, bl.sj, s1b, s2b)) {
-            dl = std::log(saddle_ratio(s1b, s2b)) - log_r_add;
+            dl = MY_LOG(saddle_ratio(s1b, s2b)) - log_r_add;
         }
         n_oracle_++;
         corr_cache_[ckey] = dl;
@@ -235,12 +236,12 @@ bool ZRatioEngine::audit_edge(const arma::imat& G, int i, int j,
     double s1 = bl.ncn * addc_[0] + bl.cne * addc_[2] + bl.bre * addc_[4];
     double s2 = bl.ncn * addc_[1] + bl.cne * addc_[3] + bl.bre * addc_[5];
     if (s1 <= 0 || s2 <= 0) return false;
-    const double log_r_add = std::log(saddle_ratio(s1, s2));
+    const double log_r_add = MY_LOG(saddle_ratio(s1, s2));
     bool clamped = false;
     pred_out = deployed_correction(bl, clamped);
     double s1b = 0, s2b = 0;
     if (!block_oracle_moments(bl.a_blk, bl.si, bl.sj, s1b, s2b)) return false;
-    oracle_out = std::log(saddle_ratio(s1b, s2b)) - log_r_add;
+    oracle_out = MY_LOG(saddle_ratio(s1b, s2b)) - log_r_add;
     return true;
 }
 

--- a/src/models/ggm/zratio_engine.h
+++ b/src/models/ggm/zratio_engine.h
@@ -3,6 +3,7 @@
 #include <RcppArmadillo.h>
 #include <unordered_map>
 #include <string>
+#include <cstdint>
 
 #include "rng/rng_utils.h"
 
@@ -184,10 +185,17 @@ private:
                         double& p2) const;
     void refit_();
 
+    /** Pack the (nCN, cne, bre) additive-cache counts into one integer key. */
+    static std::uint64_t pack_count_key(int ncn, int cne, int bre) {
+        return (static_cast<std::uint64_t>(ncn) << 42) |
+               (static_cast<std::uint64_t>(cne) << 21) |
+               static_cast<std::uint64_t>(bre);
+    }
+
     arma::vec addc_;
     arma::vec tg_, ihat_, ghat_, wt_;
     double psi0_;
-    std::unordered_map<std::string, double> cache_;
+    std::unordered_map<std::uint64_t, double> cache_;
     long n_hit_ = 0, n_miss_ = 0;
     long n_pred_ = 0, n_add_ = 0, n_clamp_ = 0;
 

--- a/src/models/mixed/mixed_mrf_metropolis.cpp
+++ b/src/models/mixed/mixed_mrf_metropolis.cpp
@@ -52,7 +52,7 @@ double MixedMRFModel::update_main_effect(int s, int c, std::optional<double> rm_
         proposal_sd_main_discrete_(s, c) = update_proposal_sd_with_robbins_monro(
             proposal_sd_main_discrete_(s, c), ln_alpha, *rm_weight, target_accept_);
     }
-    return std::min(1.0, std::exp(ln_alpha));
+    return std::min(1.0, MY_EXP(ln_alpha));
 }
 
 
@@ -103,7 +103,7 @@ double MixedMRFModel::update_continuous_mean(int j, std::optional<double> rm_wei
         proposal_sd_main_continuous_(j) = update_proposal_sd_with_robbins_monro(
             proposal_sd_main_continuous_(j), ln_alpha, *rm_weight, target_accept_);
     }
-    return std::min(1.0, std::exp(ln_alpha));
+    return std::min(1.0, MY_EXP(ln_alpha));
 }
 
 
@@ -156,7 +156,7 @@ double MixedMRFModel::update_pairwise_discrete(int i, int j, std::optional<doubl
         proposal_sd_pairwise_discrete_(i, j) = update_proposal_sd_with_robbins_monro(
             proposal_sd_pairwise_discrete_(i, j), ln_alpha, *rm_weight, target_accept_);
     }
-    return std::min(1.0, std::exp(ln_alpha));
+    return std::min(1.0, MY_EXP(ln_alpha));
 }
 
 
@@ -493,7 +493,7 @@ double MixedMRFModel::update_pairwise_effects_continuous_offdiag(int i, int j, s
         proposal_sd_pairwise_continuous_(i, j) = update_proposal_sd_with_robbins_monro(
             proposal_sd_pairwise_continuous_(i, j), ln_alpha, *rm_weight, target_accept_);
     }
-    return std::min(1.0, std::exp(ln_alpha));
+    return std::min(1.0, MY_EXP(ln_alpha));
 }
 
 
@@ -558,7 +558,7 @@ double MixedMRFModel::update_pairwise_effects_continuous_diag(int i, std::option
         proposal_sd_pairwise_continuous_(i, i) = update_proposal_sd_with_robbins_monro(
             proposal_sd_pairwise_continuous_(i, i), ln_alpha, *rm_weight, target_accept_);
     }
-    return std::min(1.0, std::exp(ln_alpha));
+    return std::min(1.0, MY_EXP(ln_alpha));
 }
 
 
@@ -623,7 +623,7 @@ double MixedMRFModel::update_pairwise_cross(int i, int j, std::optional<double> 
         proposal_sd_pairwise_cross_(i, j) = update_proposal_sd_with_robbins_monro(
             proposal_sd_pairwise_cross_(i, j), ln_alpha, *rm_weight, target_accept_);
     }
-    return std::min(1.0, std::exp(ln_alpha));
+    return std::min(1.0, MY_EXP(ln_alpha));
 }
 
 

--- a/src/models/mixed/mixed_mrf_model.cpp
+++ b/src/models/mixed/mixed_mrf_model.cpp
@@ -408,7 +408,7 @@ void MixedMRFModel::recompute_theta_yy() const {
         const auto& col = cs.columns[q];
         size_t offset = cs.theta_offsets[q];
 
-        theta_yy_(offset + col.d_q) = std::log(cholesky_of_precision_(q, q));
+        theta_yy_(offset + col.d_q) = MY_LOG(cholesky_of_precision_(q, q));
 
         if (q == 0 || col.d_q == 0) continue;
 

--- a/src/models/omrf/omrf_model.cpp
+++ b/src/models/omrf/omrf_model.cpp
@@ -252,31 +252,15 @@ void OMRFModel::tune_proposal_sd(int iteration, const WarmupSchedule& schedule) 
     const double target_accept = target_accept_;
 
     const int num_variables = static_cast<int>(p_);
+    recompute_log_denominators();
 
     for (int variable1 = 0; variable1 < num_variables - 1; variable1++) {
         for (int variable2 = variable1 + 1; variable2 < num_variables; variable2++) {
-            double current = pairwise_effects_(variable1, variable2);
-            double proposal_sd = proposal_sd_pairwise_(variable1, variable2);
+            double accept_prob = mh_pairwise_step(variable1, variable2);
 
-            auto log_post = [&](double theta) {
-                double delta = theta - current;
-                return log_pseudoposterior_pairwise_at_delta(variable1, variable2, delta);
-            };
-
-            StepResult result = metropolis_step(current, proposal_sd, log_post, rng_);
-
-            double value = result.state[0];
-            pairwise_effects_(variable1, variable2) = value;
-            pairwise_effects_(variable2, variable1) = value;
-
-            if (current != value) {
-                double delta = value - current;
-                residual_matrix_.col(variable1) += 2.0 * observations_double_.col(variable2) * delta;
-                residual_matrix_.col(variable2) += 2.0 * observations_double_.col(variable1) * delta;
-            }
-
-            proposal_sd = update_proposal_sd_with_robbins_monro(
-                proposal_sd, MY_LOG(result.accept_prob), rm_weight, target_accept);
+            double proposal_sd = update_proposal_sd_with_robbins_monro(
+                proposal_sd_pairwise_(variable1, variable2), MY_LOG(accept_prob),
+                rm_weight, target_accept);
             proposal_sd_pairwise_(variable1, variable2) = proposal_sd;
             proposal_sd_pairwise_(variable2, variable1) = proposal_sd;
         }
@@ -569,168 +553,55 @@ void OMRFModel::get_active_inv_mass_into(arma::vec& active_inv_mass) const {
 // Log-pseudoposterior computation
 // =============================================================================
 
-double OMRFModel::log_pseudoposterior_main_component(int variable, int category, int parameter) const {
-    double log_posterior = 0.0;
 
+
+
+
+
+
+double OMRFModel::compute_log_denominator(int variable) const {
     const int num_cats = num_categories_(variable);
-    // Stabiliser for the log-sum-exp; clamp at 0 (the reference-category
-    // exponent) so exp(-bound) cannot overflow. bound is subtracted inside the
-    // denominator and added back below, so its value does not change the result.
+    const arma::vec& residual_score = residual_matrix_.col(variable);
     arma::vec bound = arma::clamp(
-        num_cats * residual_matrix_.col(variable), 0.0, arma::datum::inf);
+        num_cats * residual_score, 0.0, arma::datum::inf);
 
-    if (is_ordinal_variable_(variable)) {
-        const double value = main_effects_(variable, category);
-        log_posterior += value * counts_per_category_(category + 1, variable);
-        log_posterior += threshold_prior_->logp(value);
-
-        arma::vec residual_score = residual_matrix_.col(variable);
-        arma::vec main_effect_param = main_effects_.row(variable).cols(0, num_cats - 1).t();
-
-        arma::vec denom = compute_denom_ordinal(residual_score, main_effect_param, bound);
-        log_posterior -= arma::accu(bound + ARMA_MY_LOG(denom));
-    } else {
-        const double value = main_effects_(variable, parameter);
-        const double linear_main_effect = main_effects_(variable, 0);
-        const double quadratic_main_effect = main_effects_(variable, 1);
-        const int ref = baseline_category_(variable);
-
-        log_posterior += value * blume_capel_stats_(parameter, variable);
-        log_posterior += threshold_prior_->logp(value);
-
-        arma::vec residual_score = residual_matrix_.col(variable);
-        arma::vec denom(n_, arma::fill::zeros);
-
-        denom = compute_denom_blume_capel(
-            residual_score, linear_main_effect, quadratic_main_effect, ref, num_cats, bound
-        );
-
-        log_posterior -= arma::accu(bound + ARMA_MY_LOG(denom));
-    }
-
-    return log_posterior;
-}
-
-
-double OMRFModel::compute_log_likelihood_ratio_for_variable(
-    int variable,
-    const arma::ivec& interacting_score,
-    double proposed_state,
-    double current_state
-) const {
-    // Convert interaction score vector to double precision
-    arma::vec interaction = arma::conv_to<arma::vec>::from(interacting_score);
-
-    const int num_persons = static_cast<int>(n_);
-    const int num_cats = num_categories_(variable);
-
-    // Linear predictors for the current and proposed interaction values. The
-    // residual matrix already carries the current interaction.
-    arma::vec res_current = residual_matrix_.col(variable);
-    arma::vec res_proposed =
-        res_current + 2.0 * interaction * (proposed_state - current_state);
-
-    // Shared stabiliser covering both states, built from the actual linear
-    // predictors (not the interaction-removed one) and clamped at 0 so exp
-    // cannot overflow. The same bound is used for both states, so it cancels
-    // in the current/proposed ratio.
-    arma::vec bounds = arma::clamp(
-        num_cats * arma::max(res_current, res_proposed), 0.0, arma::datum::inf);
-
-    arma::vec denom_current = arma::zeros(num_persons);
-    arma::vec denom_proposed = arma::zeros(num_persons);
-
+    arma::vec denom;
     if (is_ordinal_variable_(variable)) {
         arma::vec main_param = main_effects_.row(variable).cols(0, num_cats - 1).t();
-
-        denom_current += compute_denom_ordinal(res_current, main_param, bounds);
-        denom_proposed += compute_denom_ordinal(res_proposed, main_param, bounds);
+        denom = compute_denom_ordinal(residual_score, main_param, bound);
     } else {
-        const int ref_cat = baseline_category_(variable);
-
-        denom_current = compute_denom_blume_capel(
-            res_current, main_effects_(variable, 0),
-            main_effects_(variable, 1), ref_cat, num_cats, bounds
-        );
-        double log_ratio = arma::accu(ARMA_MY_LOG(denom_current) + bounds);
-
-        denom_proposed = compute_denom_blume_capel(
-            res_proposed, main_effects_(variable, 0),
-            main_effects_(variable, 1), ref_cat, num_cats, bounds
-        );
-        log_ratio -= arma::accu(ARMA_MY_LOG(denom_proposed) + bounds);
-
-        return log_ratio;
+        denom = compute_denom_blume_capel(
+            residual_score, main_effects_(variable, 0), main_effects_(variable, 1),
+            baseline_category_(variable), num_cats, bound);
     }
-
-    // Accumulated log-likelihood difference across persons
-    return arma::accu(ARMA_MY_LOG(denom_current) - ARMA_MY_LOG(denom_proposed));
+    return arma::accu(bound + ARMA_MY_LOG(denom));
 }
 
+double OMRFModel::compute_log_denominator_shifted(
+    int variable, const arma::vec& obs_other, double delta) const {
+    const int num_cats = num_categories_(variable);
+    arma::vec residual_score = residual_matrix_.col(variable) + 2.0 * obs_other * delta;
+    arma::vec bound = arma::clamp(
+        num_cats * residual_score, 0.0, arma::datum::inf);
 
-double OMRFModel::log_pseudolikelihood_ratio_interaction(
-    int variable1,
-    int variable2,
-    double proposed_state,
-    double current_state
-) const {
-    double log_ratio = 0.0;
-    const double delta = proposed_state - current_state;
-
-    arma::ivec score1 = observations_.col(variable1);
-    arma::ivec score2 = observations_.col(variable2);
-
-    log_ratio += 4.0 * pairwise_stats_(variable1, variable2) * delta;
-
-    log_ratio += compute_log_likelihood_ratio_for_variable(
-        variable1, score2, proposed_state, current_state
-    );
-
-    log_ratio += compute_log_likelihood_ratio_for_variable(
-        variable2, score1, proposed_state, current_state
-    );
-
-    return log_ratio;
+    arma::vec denom;
+    if (is_ordinal_variable_(variable)) {
+        arma::vec main_param = main_effects_.row(variable).cols(0, num_cats - 1).t();
+        denom = compute_denom_ordinal(residual_score, main_param, bound);
+    } else {
+        denom = compute_denom_blume_capel(
+            residual_score, main_effects_(variable, 0), main_effects_(variable, 1),
+            baseline_category_(variable), num_cats, bound);
+    }
+    return arma::accu(bound + ARMA_MY_LOG(denom));
 }
 
-
-double OMRFModel::log_pseudoposterior_pairwise_at_delta(int var1, int var2, double delta) const {
-    const int num_observations = static_cast<int>(n_);
-    const double proposed_value = pairwise_effects_(var1, var2) + delta;
-
-    double log_pseudo_posterior = 4.0 * proposed_value * pairwise_stats_(var1, var2);
-
-    const arma::vec& obs_var1 = observations_double_.col(var1);
-    const arma::vec& obs_var2 = observations_double_.col(var2);
-
-    for (int var : {var1, var2}) {
-        int num_cats = num_categories_(var);
-        const arma::vec& obs_other = (var == var1) ? obs_var2 : obs_var1;
-
-        arma::vec residual_score = residual_matrix_.col(var) + 2.0 * obs_other * delta;
-        arma::vec denominator = arma::zeros(num_observations);
-        arma::vec bound = arma::clamp(num_cats * residual_score, 0.0, arma::datum::inf);
-
-        if (is_ordinal_variable_(var)) {
-            arma::vec main_effect_param = main_effects_.row(var).cols(0, num_cats - 1).t();
-            denominator += compute_denom_ordinal(residual_score, main_effect_param, bound);
-        } else {
-            const int ref = baseline_category_(var);
-            denominator = compute_denom_blume_capel(
-                residual_score, main_effects_(var, 0), main_effects_(var, 1), ref, num_cats, bound
-            );
-        }
-
-        log_pseudo_posterior -= arma::accu(ARMA_MY_LOG(denominator));
-        log_pseudo_posterior -= arma::accu(bound);
-    }
-
-    if (edge_indicators_(var1, var2) == 1) {
-        log_pseudo_posterior += interaction_prior_->logp(proposed_value);
-    }
-
-    return log_pseudo_posterior;
+void OMRFModel::recompute_log_denominators() {
+    if (log_denominator_cache_.n_elem != p_) log_denominator_cache_.set_size(p_);
+    for (size_t v = 0; v < p_; ++v)
+        log_denominator_cache_(v) = compute_log_denominator(v);
 }
+
 
 
 // =============================================================================
@@ -942,41 +813,71 @@ double OMRFModel::update_main_effect_parameter(int variable, int category, int p
         ? proposal_sd_main_(variable, category)
         : proposal_sd_main_(variable, parameter);
 
-    auto log_post = [&](double theta) {
-        current = theta;
-        return log_pseudoposterior_main_component(variable, category, parameter);
-    };
+    const double count_stat = is_ordinal_variable_(variable)
+        ? static_cast<double>(counts_per_category_(category + 1, variable))
+        : static_cast<double>(blume_capel_stats_(parameter, variable));
 
-    StepResult result = metropolis_step(current, proposal_sd, log_post, rng_);
-    current = result.state[0];
-    return result.accept_prob;
+    double current_val = current;
+    double proposed = rnorm(rng_, current_val, proposal_sd);
+
+    // Current log-posterior: the normalizer comes from the sweep cache.
+    double ll_curr = current_val * count_stat + threshold_prior_->logp(current_val)
+                   - log_denominator_cache_(variable);
+
+    current = proposed;
+    double log_denom_prop = compute_log_denominator(variable);
+    double ll_prop = proposed * count_stat + threshold_prior_->logp(proposed)
+                   - log_denom_prop;
+
+    double accept_prob = std::min(1.0, MY_EXP(ll_prop - ll_curr));
+    if (runif(rng_) < accept_prob) {
+        log_denominator_cache_(variable) = log_denom_prop;
+    } else {
+        current = current_val;
+    }
+    return accept_prob;
+}
+
+
+double OMRFModel::mh_pairwise_step(int var1, int var2) {
+    double current_value = pairwise_effects_(var1, var2);
+    double proposal_sd = proposal_sd_pairwise_(var1, var2);
+
+    double proposed = rnorm(rng_, current_value, proposal_sd);
+    double delta = proposed - current_value;
+
+    const double stat = 4.0 * static_cast<double>(pairwise_stats_(var1, var2));
+    const bool has_prior = (edge_indicators_(var1, var2) == 1);
+
+    // Current log-posterior: both normalizers come from the sweep cache.
+    double ll_curr = current_value * stat
+                   - log_denominator_cache_(var1) - log_denominator_cache_(var2);
+    double log_denom_prop_1 = compute_log_denominator_shifted(
+        var1, observations_double_.col(var2), delta);
+    double log_denom_prop_2 = compute_log_denominator_shifted(
+        var2, observations_double_.col(var1), delta);
+    double ll_prop = proposed * stat - log_denom_prop_1 - log_denom_prop_2;
+    if (has_prior) {
+        ll_curr += interaction_prior_->logp(current_value);
+        ll_prop += interaction_prior_->logp(proposed);
+    }
+
+    double accept_prob = std::min(1.0, MY_EXP(ll_prop - ll_curr));
+    if (runif(rng_) < accept_prob) {
+        pairwise_effects_(var1, var2) = proposed;
+        pairwise_effects_(var2, var1) = proposed;
+        residual_matrix_.col(var1) += 2.0 * observations_double_.col(var2) * delta;
+        residual_matrix_.col(var2) += 2.0 * observations_double_.col(var1) * delta;
+        log_denominator_cache_(var1) = log_denom_prop_1;
+        log_denominator_cache_(var2) = log_denom_prop_2;
+    }
+    return accept_prob;
 }
 
 
 double OMRFModel::update_pairwise_effect(int var1, int var2) {
     if (edge_indicators_(var1, var2) == 0) return 1.0;
-
-    double current_value = pairwise_effects_(var1, var2);
-    double proposal_sd = proposal_sd_pairwise_(var1, var2);
-
-    auto log_post = [&](double theta) {
-        double delta = theta - current_value;
-        return log_pseudoposterior_pairwise_at_delta(var1, var2, delta);
-    };
-
-    StepResult result = metropolis_step(current_value, proposal_sd, log_post, rng_);
-
-    double value = result.state[0];
-    pairwise_effects_(var1, var2) = value;
-    pairwise_effects_(var2, var1) = value;
-
-    if (current_value != value) {
-        double delta = value - current_value;
-        residual_matrix_.col(var1) += 2.0 * observations_double_.col(var2) * delta;
-        residual_matrix_.col(var2) += 2.0 * observations_double_.col(var1) * delta;
-    }
-
-    return result.accept_prob;
+    return mh_pairwise_step(var1, var2);
 }
 
 
@@ -988,9 +889,16 @@ void OMRFModel::update_edge_indicator(int var1, int var2) {
         ? rnorm(rng_, current_state, proposal_sd_pairwise_(var1, var2))
         : 0.0;
 
-    double log_accept = log_pseudolikelihood_ratio_interaction(
-        var1, var2, proposed_state, current_state
-    );
+    // Likelihood ratio: statistic shift plus the normalizer change, with the
+    // current-state normalizers read from the sweep cache.
+    const double delta = proposed_state - current_state;
+    const double log_denom_prop_1 = compute_log_denominator_shifted(
+        var1, observations_double_.col(var2), delta);
+    const double log_denom_prop_2 = compute_log_denominator_shifted(
+        var2, observations_double_.col(var1), delta);
+    double log_accept = 4.0 * static_cast<double>(pairwise_stats_(var1, var2)) * delta
+        + log_denominator_cache_(var1) + log_denominator_cache_(var2)
+        - log_denom_prop_1 - log_denom_prop_2;
 
     const double inclusion_probability_ij = inclusion_probability_(var1, var2);
     const double sd = proposal_sd_pairwise_(var1, var2);
@@ -1013,9 +921,10 @@ void OMRFModel::update_edge_indicator(int var1, int var2) {
         pairwise_effects_(var1, var2) = proposed_state;
         pairwise_effects_(var2, var1) = proposed_state;
 
-        const double delta = proposed_state - current_state;
         residual_matrix_.col(var1) += 2.0 * observations_double_.col(var2) * delta;
         residual_matrix_.col(var2) += 2.0 * observations_double_.col(var1) * delta;
+        log_denominator_cache_(var1) = log_denom_prop_1;
+        log_denominator_cache_(var2) = log_denom_prop_2;
     }
 }
 
@@ -1025,6 +934,8 @@ void OMRFModel::update_edge_indicator(int var1, int var2) {
 // =============================================================================
 
 void OMRFModel::do_one_metropolis_step(int iteration) {
+    recompute_log_denominators();
+
     // Track running mean acceptance probability across all components
     // updated this iteration; exposed via last_metropolis_mean_accept_prob().
     double sum_accept = 0.0;
@@ -1094,6 +1005,7 @@ void OMRFModel::prepare_iteration() {
 
 
 void OMRFModel::update_edge_indicators() {
+    recompute_log_denominators();
     for (size_t i = 0; i < num_pairwise_; ++i) {
         int idx = shuffled_edge_order_(i);
         int var1 = interaction_index_(idx, 1);

--- a/src/models/omrf/omrf_model.h
+++ b/src/models/omrf/omrf_model.h
@@ -282,6 +282,11 @@ private:
     arma::imat pairwise_stats_;         ///< X^T X
     arma::mat residual_matrix_;         ///< X * pairwise_effects (n x p)
 
+    // Per-variable log normalizer sum_i (bound + log denom) at the current
+    // state. Refreshed at the top of each MH/indicator sweep and maintained
+    // on accept, so proposals stop re-evaluating the current state.
+    arma::vec log_denominator_cache_;   ///< p
+
     // Parameters
     arma::mat main_effects_;            ///< Main effect parameters (p x max_cats)
     arma::mat pairwise_effects_;        ///< Pairwise interactions (p x p, symmetric)
@@ -378,35 +383,27 @@ private:
     // -------------------------------------------------------------------------
 
     /**
-     * Log-posterior for single main effect component
+     * Log normalizer sum_i (bound + log denom) for one variable at the
+     * current state; the expensive shared piece of every MH acceptance.
      */
-    double log_pseudoposterior_main_component(int variable, int category, int parameter) const;
+    double compute_log_denominator(int variable) const;
 
     /**
-     * Log-likelihood ratio for variable update
+     * Log normalizer for variable under a pairwise shift: the residual
+     * column moves by 2 * obs_other * delta.
      */
-    double compute_log_likelihood_ratio_for_variable(
-        int variable,
-        const arma::ivec& interacting_score,
-        double proposed_state,
-        double current_state
-    ) const;
+    double compute_log_denominator_shifted(
+        int variable, const arma::vec& obs_other, double delta) const;
+
+    /** Refill log_denominator_cache_ for all variables. */
+    void recompute_log_denominators();
 
     /**
-     * Log-pseudolikelihood ratio for interaction update
+     * One cached MH step on pairwise effect (var1, var2): shared by
+     * update_pairwise_effect and the stage-3b tuner (which runs it without
+     * the edge gate). Returns the acceptance probability.
      */
-    double log_pseudolikelihood_ratio_interaction(
-        int variable1,
-        int variable2,
-        double proposed_state,
-        double current_state
-    ) const;
-
-    /**
-     * Log-pseudoposterior of a pairwise interaction at proposed = current + delta.
-     * Used by tune_proposal_sd() for Robbins-Monro adaptation.
-     */
-    double log_pseudoposterior_pairwise_at_delta(int var1, int var2, double delta) const;
+    double mh_pairwise_step(int var1, int var2);
 
     // -------------------------------------------------------------------------
     // Parameter vectorization

--- a/src/mrf_simulation.cpp
+++ b/src/mrf_simulation.cpp
@@ -812,7 +812,7 @@ void simulate_mixed_mrf(
           double cumsum = 0.0;
           arma::vec cum_probs(Cs + 1);
           for (int c = 0; c <= Cs; c++) {
-            cumsum += std::exp(log_probs(c) - max_lp);
+            cumsum += MY_EXP(log_probs(c) - max_lp);
             cum_probs(c) = cumsum;
           }
 
@@ -835,7 +835,7 @@ void simulate_mixed_mrf(
           double cumsum = 0.0;
           arma::vec cum_probs(Cs + 1);
           for (int c = 0; c <= Cs; c++) {
-            cumsum += std::exp(log_probs(c) - max_lp);
+            cumsum += MY_EXP(log_probs(c) - max_lp);
             cum_probs(c) = cumsum;
           }
 

--- a/src/priors/edge_prior_correction.h
+++ b/src/priors/edge_prior_correction.h
@@ -2,6 +2,7 @@
 
 #include <RcppArmadillo.h>
 #include "rng/rng_utils.h"
+#include "math/explog_macros.h"
 
 /**
  * Normalizing-constant correction for hierarchical edge priors on the GGM.
@@ -82,13 +83,13 @@ public:
         for (int k = 0; k < N; k++) {
             double th = lo + step * k;
             grid[k] = th;
-            weight[k] = (a_post - 1.0) * std::log(th) +
-                (b_post - 1.0) * std::log1p(-th) - log_C(th);
+            weight[k] = (a_post - 1.0) * MY_LOG(th) +
+                (b_post - 1.0) * MY_LOG1P(-th) - log_C(th);
             if (weight[k] > max_logp) max_logp = weight[k];
         }
         double total = 0.0;
         for (int k = 0; k < N; k++) {
-            weight[k] = std::exp(weight[k] - max_logp);
+            weight[k] = MY_EXP(weight[k] - max_logp);
             total += weight[k];
         }
         double u = runif(rng) * total;

--- a/src/priors/parameter_prior.h
+++ b/src/priors/parameter_prior.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <cmath>
 #include <Rmath.h>
+#include "math/explog_macros.h"
 
 
 // =============================================================================
@@ -97,12 +98,12 @@ public:
         : alpha_(alpha), beta_(beta) {}
 
     double logp(double x) const override {
-        return x * alpha_ - std::log1p(std::exp(x)) * (alpha_ + beta_);
+        return x * alpha_ - MY_LOG1P(MY_EXP(x)) * (alpha_ + beta_);
     }
 
     double grad(double x) const override {
         // alpha - (alpha + beta) * sigmoid(x)
-        double p = 1.0 / (1.0 + std::exp(-x));
+        double p = 1.0 / (1.0 + MY_EXP(-x));
         return alpha_ - (alpha_ + beta_) * p;
     }
 


### PR DESCRIPTION
Three more items from the 3 July performance audit, one commit each.

- **Ordinal model: cache the per-variable normalizers.** Every Metropolis proposal evaluated the current state's normalizing denominators from scratch alongside the proposed state's; the edge-indicator moves did the same inside their likelihood ratio. The per-variable log normalizer is now cached, refreshed at the start of each sweep and updated on accept, so each proposal computes only the proposed state. The pairwise updater and the stage-3b tuner now share one implementation, and the superseded likelihood-component functions are removed.
- **Z-ratio engine: cheaper block extraction and cache keys.** The mediating-block scan walked the full variable grid on every edge toggle; it now walks the two exclusive neighbour lists. The additive-saddle cache is keyed by a packed integer instead of a formatted string.
- **Windows: route the remaining hot-path exp/log calls through the platform macros**, which select OpenLibM on Windows and the standard library elsewhere. No behavior change on macOS or Linux.

**Effect** (Wenchuan, 24 variables, 500 warmup + 500 iterations, one chain, optimized build): the adaptive-Metropolis fit drops from 1.96s to 1.11s with edge selection and from 1.75s to 0.97s without (about 1.8x). NUTS fits are unchanged, as expected — they are gradient-dominated.

**Verification**: a same-seed adaptive-Metropolis fit with edge selection reproduces the previous implementation exactly (identical edge-selection paths, draws equal to 1e-8); the bgm, GGM-gradient, mixed, Z-ratio-prior, simulate/predict, and audit-regression suites pass; `R CMD check --as-cran` is clean.
