### PR TITLE
Correct and gate the suppressed-NA note in summary print output

### DIFF
--- a/R/methods_bgmcompare.R
+++ b/R/methods_bgmcompare.R
@@ -157,6 +157,8 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
       ind[["n_eff_mixt"]][few] = NA
     }
 
+    ind_has_na = anyNA(ind)
+
     # round only numeric columns
     ind[] = lapply(ind, function(col) {
       if(is.numeric(col)) {
@@ -175,15 +177,19 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
     if(nrow(x$indicator) > 6) {
       cat("... (use `summary(fit)$indicator` to see full output)\n")
     }
-    cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
-    cat("was constant or had fewer than 5 transitions, so n_eff_mixt is unreliable;\n")
-    cat("`summary(fit)$indicator` still contains all computed values.\n\n")
+    if(ind_has_na) {
+      cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
+      cat("was constant or had fewer than 5 transitions, so n_eff_mixt is unreliable;\n")
+      cat("`summary(fit)$indicator` still contains all computed values.\n")
+    }
+    cat("\n")
   }
 
   if(!is.null(x$main_diff)) {
     cat("Group differences (main effects):\n")
 
     maind = head(x$main_diff, 6)
+    maind_has_na = anyNA(maind)
 
     # Only round numeric columns
     is_num = vapply(maind, is.numeric, logical(1))
@@ -198,9 +204,9 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
       cat("... (use `summary(fit)$main_diff` to see full output)\n")
     }
 
-    if(!is.null(x$indicator)) {
-      cat("Note: NA values are suppressed in the print table. They occur here when an\n")
-      cat("indicator was zero across all iterations, so mcse/n_eff/n_eff_mixt/Rhat are undefined;\n")
+    if(!is.null(x$indicator) && maind_has_na) {
+      cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
+      cat("is constant across iterations, so mcse/n_eff_mixt are undefined;\n")
       cat("`summary(fit)$main_diff` still contains the NA values.\n")
     }
     cat("\n")
@@ -210,6 +216,7 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
     cat("Group differences (pairwise effects):\n")
 
     pairwised = head(x$pairwise_diff, 6)
+    pairwised_has_na = anyNA(pairwised)
 
     # Only round numeric columns
     is_num = vapply(pairwised, is.numeric, logical(1))
@@ -224,9 +231,9 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
       cat("... (use `summary(fit)$pairwise_diff` to see full output)\n")
     }
 
-    if(!is.null(x$indicator)) {
-      cat("Note: NA values are suppressed in the print table. They occur here when an\n")
-      cat("indicator was zero across all iterations, so mcse/n_eff/n_eff_mixt/Rhat are undefined;\n")
+    if(!is.null(x$indicator) && pairwised_has_na) {
+      cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
+      cat("is constant across iterations, so mcse/n_eff_mixt are undefined;\n")
       cat("`summary(fit)$pairwise_diff` still contains the NA values.\n")
     }
     cat("\n")

--- a/R/methods_bgms.R
+++ b/R/methods_bgms.R
@@ -165,12 +165,13 @@ print.summary.bgms = function(x, digits = 3, ...) {
   if(!is.null(x$pairwise)) {
     cat("Pairwise interactions:\n")
     pair = head(x$pairwise, .summary_preview_rows)
+    pair_has_na = anyNA(pair)
     pair[] = lapply(pair, function(col) ifelse(is.na(col), "", round(col, digits)))
     print(pair)
     if(nrow(x$pairwise) > .summary_preview_rows) cat("... (use `summary(fit)$pairwise` to see full output)\n")
-    if(!is.null(x$indicator)) {
-      cat("Note: NA values are suppressed in the print table. They occur here when an \n")
-      cat("indicator was zero across all iterations, so mcse/n_eff/n_eff_mixt/Rhat are undefined;\n")
+    if(!is.null(x$indicator) && pair_has_na) {
+      cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
+      cat("is constant across iterations, so mcse/n_eff_mixt are undefined;\n")
       cat("`summary(fit)$pairwise` still contains the NA values.\n")
     }
     cat("\n")
@@ -185,12 +186,16 @@ print.summary.bgms = function(x, digits = 3, ...) {
       few[is.na(few)] = TRUE
       ind[["n_eff_mixt"]][few] = NA
     }
+    ind_has_na = anyNA(ind)
     ind[] = lapply(ind, function(col) ifelse(is.na(col), "", round(col, digits)))
     print(ind)
     if(nrow(x$indicator) > .summary_preview_rows) cat("... (use `summary(fit)$indicator` to see full output)\n")
-    cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
-    cat("was constant or had fewer than 5 transitions, so n_eff_mixt is unreliable;\n")
-    cat("`summary(fit)$indicator` still contains all computed values.\n\n")
+    if(ind_has_na) {
+      cat("Note: NA values are suppressed in the print table. They occur when an indicator\n")
+      cat("was constant or had fewer than 5 transitions, so n_eff_mixt is unreliable;\n")
+      cat("`summary(fit)$indicator` still contains all computed values.\n")
+    }
+    cat("\n")
   }
 
   if(!is.null(x$allocations)) {


### PR DESCRIPTION
The `summary()` print methods blank out NA diagnostics in the preview tables and add a note explaining them. This corrects and narrows that note.

## The note described the wrong condition

The note said the NAs occur when an indicator "was zero across all iterations." That covers a never-included edge, but the same blanks appear for an always-included edge: with every draw in the slab, there are no spike draws, so the mixture effective sample size (`n_eff_mixt`) is undefined. In practice an always-included edge shows a blank `n_eff_mixt`, and a never-included edge shows blank `mcse`/`sd`/`n_eff_mixt`.

The unifying condition is that the indicator is constant across iterations (at 0 or 1), which the note now states.

## The note is only shown when there is something to explain

Each preview note is now printed only when the previewed rows actually contain a suppressed value. A summary whose preview has no such rows no longer prints the note.

The indicator-table note ("was constant or had fewer than 5 transitions, so `n_eff_mixt` is unreliable") keeps its wording; it is now also gated on the preview containing a suppressed value.

## Scope

`R/methods_bgms.R` (pairwise and inclusion-probability tables) and `R/methods_bgmcompare.R` (inclusion-probability, main-effect difference, and pairwise difference tables). No change to `summary(fit)$...`, which still contains every computed value including the NAs.

Verified by printing summaries with and without constant-indicator edges: the note appears only when the preview shows a blank, and reads "is constant across iterations." `test-methods.R` passes (1910). No test pins the note text.
