### PR TITLE
Reliable user interrupts: main-thread progress polling and an interrupt-safe warmup diagnostic

### DIFF
--- a/R/diagnostics_nuts.R
+++ b/R/diagnostics_nuts.R
@@ -45,15 +45,35 @@ check_warmup_complete = function(energy_mat) {
     ))
   }
 
-  mid = floor(n / 2)
+  # Per-chain NA result for chains with too little usable energy to assess.
+  na_result = list(
+    warmup_incomplete = FALSE,
+    energy_slope = NA_real_,
+    slope_significant = FALSE,
+    ebfmi_first_half = NA_real_,
+    ebfmi_second_half = NA_real_,
+    var_ratio = NA_real_
+  )
 
   results = lapply(seq_len(nchains), function(chain) {
+    # An interrupted or degenerate run leaves the energy trace partly or
+    # fully NA; assess the finite draws only.
     energy = energy_mat[chain, ]
+    energy = energy[is.finite(energy)]
+    n_chain = length(energy)
+
+    # Too few usable values to split and regress: return NA diagnostics
+    # rather than fitting lm/var on empty data.
+    if(n_chain < 20) {
+      return(na_result)
+    }
+
+    mid = floor(n_chain / 2)
     first_half = energy[1:mid]
-    second_half = energy[(mid + 1):n]
+    second_half = energy[(mid + 1):n_chain]
 
     # Linear trend in energy
-    time_idx = seq_len(n)
+    time_idx = seq_len(n_chain)
     trend_lm = stats::lm(energy ~ time_idx)
     slope = stats::coef(trend_lm)[2]
     slope_se = summary(trend_lm)$coefficients[2, 2]

--- a/src/utils/progress_manager.cpp
+++ b/src/utils/progress_manager.cpp
@@ -58,16 +58,18 @@ ProgressManager::ProgressManager(int nChains_, int nIter_, int nWarmup_, int pri
 }
 
 void ProgressManager::update(size_t chainId) {
-  const size_t count = progress[chainId].fetch_add(1, std::memory_order_relaxed) + 1;
+  progress[chainId].fetch_add(1, std::memory_order_relaxed);
 
-  // Every chain counts (atomically), but only chain 0 drives the display, and
-  // only when it runs on the R main thread. The R API (interrupt check,
-  // printing, callback) is not safe off the main thread; when the scheduler
-  // happens to run chain 0 on a worker thread the display is skipped that
-  // iteration rather than corrupting the interpreter.
-  if (chainId != 0) return;
+  // Every chain counts (atomically). The display is driven by whichever
+  // chain(s) the R main thread executes: the main thread always participates
+  // in the parallel_for, so progress advances no matter which chain the
+  // scheduler places on it -- unlike gating on chain 0, which stalls the
+  // display whenever chain 0 lands on a worker thread. The R API (interrupt
+  // check, printing, callback) is not safe off the main thread, so worker
+  // iterations only bump the counter. main_thread_updates_ is touched solely
+  // on the main thread and needs no atomicity.
   if (std::this_thread::get_id() != main_thread_id) return;
-  if (count % printEvery == 0) poll();
+  if (++main_thread_updates_ % printEvery == 0) poll();
 }
 
 void ProgressManager::poll() {

--- a/src/utils/progress_manager.h
+++ b/src/utils/progress_manager.h
@@ -47,8 +47,9 @@ inline bool checkInterrupt() {
  * per-chain counters and the exit flag are atomics, so update() and
  * shouldExit() may be called from any thread. All R API interaction (the
  * interrupt check, console output, and the R callback) happens only on the
- * construction thread: update() drives it when chain 0 runs on that thread and
- * skips it otherwise, so a worker thread never touches the R interpreter.
+ * construction thread: update() drives it from whichever chains that thread
+ * executes and skips the display on worker threads, so a worker thread never
+ * touches the R interpreter.
  *
  * Key features:
  * - Multi-chain progress tracking with atomic counters
@@ -134,6 +135,7 @@ private:
     bool useUnicode = true;            // Use Unicode vs ASCII theme
     std::vector<std::atomic<size_t>> progress; // Per-chain progress counters
     std::thread::id main_thread_id;    // Thread the manager was constructed on (the R main thread)
+    size_t main_thread_updates_ = 0;   // update() calls seen on the main thread; throttles poll() (main-thread only, no atomic)
 
     // internal config parameters/ data
     size_t no_spaces_for_total;     // Spacing for total line alignment


### PR DESCRIPTION
Two related fixes for user-interrupt (Ctrl-C) handling in `bgm()`. The second was surfaced by the first.

## 1. Progress polling driven by the main thread

The multi-chain progress bar reaches `poll()` only through `update()` for chain 0, then gates that call to the R main thread. Under RcppParallel/TBB, `parallelFor` can place chain 0 on a worker thread; since the R API (interrupt check, console output, callback) is confined to the main thread, the bar and Ctrl-C responsiveness can stay frozen for the whole run. Sampling results are unaffected.

Drive the display from whichever chains the main thread executes. The main thread always participates in `parallelFor`, so it polls regularly regardless of which chain the scheduler places where. Worker threads still only increment the atomic per-chain counter and never touch the interpreter.

## 2. Interrupt-safe warmup diagnostic

With interrupts now firing reliably, interrupting during warmup exposed a crash in post-processing. The run returns before any sampling draw is stored, so the per-chain energy trace is all-NA over the full pre-allocated width. `check_warmup_complete()` guarded only on the column count, passed that check, and called `lm(energy ~ time_idx)` on an all-NA column — `lm.fit: 0 (non-NA) cases` — aborting output assembly.

```r
f <- bgm(Wenchuan, iter = 1e4)   # interrupt during warmup
# Error in lm.fit(...): 0 (non-NA) cases
```

Assess the finite draws per chain: drop non-finite energy values, and when fewer than 20 remain return NA diagnostics for that chain instead of fitting on empty data. Complete runs are unchanged.

## Verification

- Progress: `-fsyntax-only` clean; one-core DLL build compiles and links clean.
- Diagnostic: standalone tests over complete / all-NA / partial-NA / mixed energy matrices — no errors; the all-NA case (the reported crash) returns NA diagnostics; complete runs identical. styler: file unchanged; lintr: no lints.
- Full `R CMD check` runs in CI on this PR.
