### PR TITLE
[DO NOT MERGE] Probe: serial/parallel determinism mismatch rate on Windows

### DIFF
--- a/tests/testthat/test-zz-parallel-correctness-probe.R
+++ b/tests/testthat/test-zz-parallel-correctness-probe.R
@@ -1,0 +1,62 @@
+# TEMPORARY diagnostic (not for merge).
+#
+# Question: under RcppParallel 6.0.0 (oneTBB 2022) on Windows, the second chain
+# of a parallel run diverges bit-for-bit from the serial run. Is that a
+# CORRECTNESS bug (chain samples the wrong posterior) or just NON-REPRODUCIBILITY
+# (a different but equally valid trajectory)?
+#
+# Method: compare POSTERIOR SUMMARIES, not raw draws. If serial and parallel
+# recover the same posterior means within Monte Carlo error -- even though the
+# raw draws differ -- each chain is a valid sample and the issue is purely
+# reproducibility. Reports the numbers via a deliberate diagnostic failure so
+# they surface in the CI log. Windows-only; a no-op elsewhere.
+
+test_that("serial vs parallel posterior agreement (windows correctness probe)", {
+  if (Sys.info()[["sysname"]] != "Windows") {
+    skip("windows-only correctness probe")
+  }
+
+  set.seed(11)
+  p <- 4
+  x <- matrix(sample(0:2, 120 * p, replace = TRUE), ncol = p)
+  colnames(x) <- paste0("V", seq_len(p))
+
+  it <- 4000L
+  wu <- 2000L
+  s <- bgm(x, iter = it, warmup = wu, chains = 2, cores = 1, seed = 7,
+           display_progress = "none", verbose = FALSE)
+  q <- bgm(x, iter = it, warmup = wu, chains = 2, cores = 2, seed = 7,
+           display_progress = "none", verbose = FALSE)
+
+  fmt <- function(comp) {
+    ls <- s$raw_samples[[comp]]
+    lq <- q$raw_samples[[comp]]
+    # Pooled posterior mean across both chains, and posterior SD for scale.
+    pooled_s <- colMeans(do.call(rbind, ls))
+    pooled_q <- colMeans(do.call(rbind, lq))
+    post_sd <- apply(do.call(rbind, ls), 2, stats::sd)
+    # Chain 2 is the one that differs bit-for-bit under the regression.
+    c2s <- colMeans(ls[[2]])
+    c2q <- colMeans(lq[[2]])
+    # Chain 1 vs chain 2 within the serial run: how far apart do two *valid*
+    # independently-seeded chains land? A same-target reference scale.
+    c1s <- colMeans(ls[[1]])
+    sprintf(paste0("%s: d_pooled=%.4f d_chain2(serial-vs-par)=%.4f ",
+                   "ref_chain1-vs-chain2=%.4f post_sd~%.3f rough_MCSE~%.4f"),
+            comp,
+            max(abs(pooled_s - pooled_q)),
+            max(abs(c2s - c2q)),
+            max(abs(c1s - c2s)),
+            max(post_sd),
+            max(post_sd) / sqrt(it))
+  }
+
+  bw1 <- identical(s$raw_samples$pairwise[[1]], q$raw_samples$pairwise[[1]])
+  bw2 <- identical(s$raw_samples$pairwise[[2]], q$raw_samples$pairwise[[2]])
+
+  fail(paste0(
+    "[[CORRECTNESS PROBE — deliberate diagnostic fail]] ",
+    "bitwise chain1_ident=", bw1, " chain2_ident=", bw2, " | ",
+    fmt("pairwise"), " || ", fmt("main")
+  ))
+})

--- a/tests/testthat/test-zz-parallel-determinism-stress.R
+++ b/tests/testthat/test-zz-parallel-determinism-stress.R
@@ -1,0 +1,59 @@
+# TEMPORARY investigation probe (not for merge).
+#
+# Intermittent Windows CI failures of
+# 'test-regressions-2.R:355' ("serial and parallel dispatch produce identical
+# draws") reproduced on immediate retry. This probe repeats the exact
+# comparison many times in one job to measure the mismatch rate and localise
+# the first divergence, so we can tell a rare flake from a near-deterministic
+# regression. Windows-only; a no-op elsewhere.
+
+test_that("serial/parallel draw-identity mismatch rate (windows probe)", {
+  if (Sys.info()[["sysname"]] != "Windows") {
+    skip("windows-only determinism stress probe")
+  }
+
+  reps = 25L
+  mism = 0L
+  first_detail = ""
+
+  for (r in seq_len(reps)) {
+    set.seed(11)
+    p = 4
+    x = matrix(sample(0:2, 120 * p, replace = TRUE), ncol = p)
+    colnames(x) = paste0("V", seq_len(p))
+
+    serial = bgm(
+      x, iter = 100, warmup = 100, chains = 2, cores = 1, seed = 7,
+      display_progress = "none", verbose = FALSE
+    )
+    parallel = bgm(
+      x, iter = 100, warmup = 100, chains = 2, cores = 2, seed = 7,
+      display_progress = "none", verbose = FALSE
+    )
+
+    same_pw = identical(serial$raw_samples$pairwise, parallel$raw_samples$pairwise)
+    same_main = identical(serial$raw_samples$main, parallel$raw_samples$main)
+    if (!same_pw || !same_main) {
+      mism = mism + 1L
+      if (!nzchar(first_detail)) {
+        which_chain = NA_integer_
+        for (c in seq_along(serial$raw_samples$pairwise)) {
+          if (!identical(serial$raw_samples$pairwise[[c]],
+                         parallel$raw_samples$pairwise[[c]])) {
+            which_chain = c
+            break
+          }
+        }
+        first_detail = sprintf(
+          "first at rep %d (pairwise_ok=%s main_ok=%s, chain %s)",
+          r, same_pw, same_main, which_chain
+        )
+      }
+    }
+  }
+
+  expect_equal(
+    mism, 0L,
+    info = sprintf("[[PROBE]] mismatches %d/%d; %s", mism, reps, first_detail)
+  )
+})


### PR DESCRIPTION
Investigation only — not for merge.

Adds a Windows-gated stress test that repeats the `test-regressions-2.R:355` serial-vs-parallel draw-identity comparison 25 times per job, to measure the mismatch rate (rare flake vs near-deterministic) and localise the first divergence.

Context: the assertion failed twice in a row on the same commit on Windows CI (2026-07-24), while develop was green on 2026-07-23 with identical sampler code. The probe result plus a re-run of develop's own CI will tell us whether this is environmental (a dependency bump on the CI Windows image) or code.

The probe skips on non-Windows. Delete this branch once the question is answered.