### PR TITLE
chore(zratio): dedupe surface wiring (#43) and relocate the oracle entry (#41)

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -157,16 +157,16 @@ test_warmup_schedule <- function(warmup, edge_selection, learn_sd, select_during
     .Call(`_bgms_test_warmup_schedule`, warmup, edge_selection, learn_sd, select_during_warmup, probe_iterations)
 }
 
+zratio_block_oracle_moments <- function(a_blk, si, sj, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_sweep, burn, seed, slab_cauchy = FALSE, alpha = 1.0) {
+    .Call(`_bgms_zratio_block_oracle_moments`, a_blk, si, sj, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_sweep, burn, seed, slab_cauchy, alpha)
+}
+
 zratio_test_eval <- function(G, edges, addc, tg, ihat, ghat, wt, psi0) {
     .Call(`_bgms_zratio_test_eval`, G, edges, addc, tg, ihat, ghat, wt, psi0)
 }
 
 zratio_test_reference <- function(G, i, j, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_draws, burn, seed, slab_cauchy = FALSE, alpha = 1.0) {
     .Call(`_bgms_zratio_test_reference`, G, i, j, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_draws, burn, seed, slab_cauchy, alpha)
-}
-
-zratio_block_oracle_moments <- function(a_blk, si, sj, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_sweep, burn, seed, slab_cauchy = FALSE, alpha = 1.0) {
-    .Call(`_bgms_zratio_block_oracle_moments`, a_blk, si, sj, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_sweep, burn, seed, slab_cauchy, alpha)
 }
 
 zratio_test_saddle <- function(s1, s2, addc, tg, ihat, ghat, wt, psi0) {

--- a/R/run_sampler.R
+++ b/R/run_sampler.R
@@ -94,31 +94,11 @@ run_sampler_ggm = function(spec) {
     # parameter, not a switch. Built for the Normal and Cauchy slabs (both
     # alpha = 1); a non-unit Gamma diagonal shape returns NULL and keeps the
     # additive path (open problem).
-    surf = zratio_build_surfaces(
-      zc,
-      max_size = min(d$num_variables, 44L),
-      cores = zratio_surface_build_cores(s$cores)
+    zratio = zratio_attach_surface(
+      zratio, zc, d$num_variables,
+      cores = zratio_surface_build_cores(s$cores),
+      verbose = isTRUE(s$verbose)
     )
-    if(!is.null(surf)) {
-      zratio$surface = surf
-    } else if(isTRUE(s$verbose)) {
-      if(abs(zc$alpha - 1) > 1e-12) {
-        # Non-exponential precision diagonal (Gamma shape != 1): the surface is
-        # not yet validated for this cell, so the engine keeps the additive path.
-        message(
-          "z-ratio: precision shape alpha = ", format(zc$alpha),
-          " -> additive path (absolute-moment surface validated only for the ",
-          "exponential alpha = 1 diagonal; Gamma shapes are pending)."
-        )
-      } else {
-        # A failed build at alpha = 1 must not downgrade the fit silently.
-        message(
-          "z-ratio: the absolute-moment surface build failed -> additive ",
-          "path (coarser correction; enable the trust gauge with ",
-          "options(bgms.zratio_gauge_sweeps = 2L) to quantify the impact)."
-        )
-      }
-    }
   } else {
     correction = ggm_edge_prior_correction(p, s, d$num_variables)
   }
@@ -263,29 +243,11 @@ run_sampler_mixed_mrf = function(spec) {
     )
     # Option-B surface on the continuous subgraph (same as the GGM path); sized
     # on the number of continuous variables.
-    surf = zratio_build_surfaces(
-      zc,
-      max_size = min(d$num_continuous, 44L),
-      cores = zratio_surface_build_cores(s$cores)
+    zratio = zratio_attach_surface(
+      zratio, zc, d$num_continuous,
+      cores = zratio_surface_build_cores(s$cores),
+      verbose = isTRUE(s$verbose)
     )
-    if(!is.null(surf)) {
-      zratio$surface = surf
-    } else if(isTRUE(s$verbose)) {
-      if(abs(zc$alpha - 1) > 1e-12) {
-        message(
-          "z-ratio: precision shape alpha = ", format(zc$alpha),
-          " -> additive path (absolute-moment surface validated only for the ",
-          "exponential alpha = 1 diagonal; Gamma shapes are pending)."
-        )
-      } else {
-        # A failed build at alpha = 1 must not downgrade the fit silently.
-        message(
-          "z-ratio: the absolute-moment surface build failed -> additive ",
-          "path (coarser correction; enable the trust gauge with ",
-          "options(bgms.zratio_gauge_sweeps = 2L) to quantify the impact)."
-        )
-      }
-    }
   } else {
     correction = ggm_edge_prior_correction(
       p, s, d$num_variables, d$num_continuous

--- a/R/sample_ggm_prior.R
+++ b/R/sample_ggm_prior.R
@@ -332,11 +332,12 @@ sample_ggm_prior = function(
       gauge_sweeps = if(isTRUE(zratio_diagnostics)) 2L else 0L
     )
     # Deploy the same Option-B surface the posterior chain uses, so the prior
-    # chain (SBC reference) carries an identical per-edge correction.
-    surf = zratio_build_surfaces(
-      zc, max_size = min(p, 44L), cores = zratio_surface_build_cores()
+    # chain (SBC reference) carries an identical per-edge correction. Silent on
+    # a fallback: the SBC reference must not add console noise to the loop.
+    zratio = zratio_attach_surface(
+      zratio, zc, p,
+      cores = zratio_surface_build_cores()
     )
-    if(!is.null(surf)) zratio$surface = surf
   } else if(!identical(ep$edge_prior, "Bernoulli") && apply_correction) {
     table = ggm_correction_table(
       p = p, delta = delta,

--- a/R/zratio_surfaces.R
+++ b/R/zratio_surfaces.R
@@ -167,8 +167,14 @@ zratio_surface_cache_key = function(zc, max_size, seed0) {
   )
 }
 
-zratio_build_surfaces = function(zc, max_size = 44L, cores = 1L,
-                                seed0 = 700000L) {
+# Trained size-hull cap for the anchor build: components larger than this clamp
+# to the hull edge at deploy, so it must stay >= the anchor grid's largest size
+# (42). The build default and every sampler call site size through this one
+# value, so the cap cannot drift between them.
+.zratio_surface_size_cap = 44L
+
+zratio_build_surfaces = function(zc, max_size = .zratio_surface_size_cap,
+                                 cores = 1L, seed0 = 700000L) {
   if(abs(zc$alpha - 1) > 1e-12) return(NULL)
   cap = as.integer(max_size)
 
@@ -330,6 +336,45 @@ zratio_surface_build_cores = function(fit_cores = 1L) {
   ))
   if(length(cores) != 1L || is.na(cores) || cores < 1L) cores = 1L
   cores
+}
+
+# Message the fallback to the additive path when no surface is attached: a
+# non-unit Gamma diagonal shape (surface pending validation) or a failed
+# alpha = 1 build (which must not downgrade the fit silently). Shared by every
+# sampler call site so the two messages stay identical.
+zratio_surface_fence_message = function(zc) {
+  if(abs(zc$alpha - 1) > 1e-12) {
+    message(
+      "z-ratio: precision shape alpha = ", format(zc$alpha),
+      " -> additive path (absolute-moment surface validated only for the ",
+      "exponential alpha = 1 diagonal; Gamma shapes are pending)."
+    )
+  } else {
+    message(
+      "z-ratio: the absolute-moment surface build failed -> additive ",
+      "path (coarser correction; enable the trust gauge with ",
+      "options(bgms.zratio_gauge_sweeps = 2L) to quantify the impact)."
+    )
+  }
+}
+
+# Build the Option-B surface for cell `zc`, sized on `size` variables, and, on a
+# successful build, attach it to the `zratio` spec; otherwise keep the additive
+# path (messaging the reason when `verbose`). Centralizes the size cap, cores
+# policy, and fence message the GGM, mixed, and prior sampler paths share.
+# Returns the (possibly surface-carrying) `zratio` list.
+zratio_attach_surface = function(zratio, zc, size, cores, verbose = FALSE) {
+  surf = zratio_build_surfaces(
+    zc,
+    max_size = min(size, .zratio_surface_size_cap),
+    cores = cores
+  )
+  if(!is.null(surf)) {
+    zratio$surface = surf
+  } else if(isTRUE(verbose)) {
+    zratio_surface_fence_message(zc)
+  }
+  zratio
 }
 
 # Number of in-chain trust-gauge assessment sweeps. The gauge is a post-sampling

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -757,6 +757,32 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// zratio_block_oracle_moments
+Rcpp::List zratio_block_oracle_moments(arma::imat a_blk, arma::uvec si, arma::uvec sj, arma::vec addc, arma::vec tg, arma::vec ihat, arma::vec ghat, arma::vec wt, double psi0, double delta, double eta, int n_sweep, int burn, int seed, bool slab_cauchy, double alpha);
+RcppExport SEXP _bgms_zratio_block_oracle_moments(SEXP a_blkSEXP, SEXP siSEXP, SEXP sjSEXP, SEXP addcSEXP, SEXP tgSEXP, SEXP ihatSEXP, SEXP ghatSEXP, SEXP wtSEXP, SEXP psi0SEXP, SEXP deltaSEXP, SEXP etaSEXP, SEXP n_sweepSEXP, SEXP burnSEXP, SEXP seedSEXP, SEXP slab_cauchySEXP, SEXP alphaSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::imat >::type a_blk(a_blkSEXP);
+    Rcpp::traits::input_parameter< arma::uvec >::type si(siSEXP);
+    Rcpp::traits::input_parameter< arma::uvec >::type sj(sjSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type addc(addcSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type tg(tgSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type ihat(ihatSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type ghat(ghatSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type wt(wtSEXP);
+    Rcpp::traits::input_parameter< double >::type psi0(psi0SEXP);
+    Rcpp::traits::input_parameter< double >::type delta(deltaSEXP);
+    Rcpp::traits::input_parameter< double >::type eta(etaSEXP);
+    Rcpp::traits::input_parameter< int >::type n_sweep(n_sweepSEXP);
+    Rcpp::traits::input_parameter< int >::type burn(burnSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    Rcpp::traits::input_parameter< bool >::type slab_cauchy(slab_cauchySEXP);
+    Rcpp::traits::input_parameter< double >::type alpha(alphaSEXP);
+    rcpp_result_gen = Rcpp::wrap(zratio_block_oracle_moments(a_blk, si, sj, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_sweep, burn, seed, slab_cauchy, alpha));
+    return rcpp_result_gen;
+END_RCPP
+}
 // zratio_test_eval
 Rcpp::List zratio_test_eval(arma::imat G, arma::imat edges, arma::vec addc, arma::vec tg, arma::vec ihat, arma::vec ghat, arma::vec wt, double psi0);
 RcppExport SEXP _bgms_zratio_test_eval(SEXP GSEXP, SEXP edgesSEXP, SEXP addcSEXP, SEXP tgSEXP, SEXP ihatSEXP, SEXP ghatSEXP, SEXP wtSEXP, SEXP psi0SEXP) {
@@ -798,32 +824,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type slab_cauchy(slab_cauchySEXP);
     Rcpp::traits::input_parameter< double >::type alpha(alphaSEXP);
     rcpp_result_gen = Rcpp::wrap(zratio_test_reference(G, i, j, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_draws, burn, seed, slab_cauchy, alpha));
-    return rcpp_result_gen;
-END_RCPP
-}
-// zratio_block_oracle_moments
-Rcpp::List zratio_block_oracle_moments(arma::imat a_blk, arma::uvec si, arma::uvec sj, arma::vec addc, arma::vec tg, arma::vec ihat, arma::vec ghat, arma::vec wt, double psi0, double delta, double eta, int n_sweep, int burn, int seed, bool slab_cauchy, double alpha);
-RcppExport SEXP _bgms_zratio_block_oracle_moments(SEXP a_blkSEXP, SEXP siSEXP, SEXP sjSEXP, SEXP addcSEXP, SEXP tgSEXP, SEXP ihatSEXP, SEXP ghatSEXP, SEXP wtSEXP, SEXP psi0SEXP, SEXP deltaSEXP, SEXP etaSEXP, SEXP n_sweepSEXP, SEXP burnSEXP, SEXP seedSEXP, SEXP slab_cauchySEXP, SEXP alphaSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::imat >::type a_blk(a_blkSEXP);
-    Rcpp::traits::input_parameter< arma::uvec >::type si(siSEXP);
-    Rcpp::traits::input_parameter< arma::uvec >::type sj(sjSEXP);
-    Rcpp::traits::input_parameter< arma::vec >::type addc(addcSEXP);
-    Rcpp::traits::input_parameter< arma::vec >::type tg(tgSEXP);
-    Rcpp::traits::input_parameter< arma::vec >::type ihat(ihatSEXP);
-    Rcpp::traits::input_parameter< arma::vec >::type ghat(ghatSEXP);
-    Rcpp::traits::input_parameter< arma::vec >::type wt(wtSEXP);
-    Rcpp::traits::input_parameter< double >::type psi0(psi0SEXP);
-    Rcpp::traits::input_parameter< double >::type delta(deltaSEXP);
-    Rcpp::traits::input_parameter< double >::type eta(etaSEXP);
-    Rcpp::traits::input_parameter< int >::type n_sweep(n_sweepSEXP);
-    Rcpp::traits::input_parameter< int >::type burn(burnSEXP);
-    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    Rcpp::traits::input_parameter< bool >::type slab_cauchy(slab_cauchySEXP);
-    Rcpp::traits::input_parameter< double >::type alpha(alphaSEXP);
-    rcpp_result_gen = Rcpp::wrap(zratio_block_oracle_moments(a_blk, si, sj, addc, tg, ihat, ghat, wt, psi0, delta, eta, n_sweep, burn, seed, slab_cauchy, alpha));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -994,9 +994,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_bgms_test_sbm_corrected_log_marginal", (DL_FUNC) &_bgms_test_sbm_corrected_log_marginal, 10},
     {"_bgms_compute_Vn_mfm_sbm", (DL_FUNC) &_bgms_compute_Vn_mfm_sbm, 4},
     {"_bgms_test_warmup_schedule", (DL_FUNC) &_bgms_test_warmup_schedule, 5},
+    {"_bgms_zratio_block_oracle_moments", (DL_FUNC) &_bgms_zratio_block_oracle_moments, 16},
     {"_bgms_zratio_test_eval", (DL_FUNC) &_bgms_zratio_test_eval, 8},
     {"_bgms_zratio_test_reference", (DL_FUNC) &_bgms_zratio_test_reference, 16},
-    {"_bgms_zratio_block_oracle_moments", (DL_FUNC) &_bgms_zratio_block_oracle_moments, 16},
     {"_bgms_zratio_test_saddle", (DL_FUNC) &_bgms_zratio_test_saddle, 8},
     {"_bgms_zratio_test_surface_eval", (DL_FUNC) &_bgms_zratio_test_surface_eval, 14},
     {"_bgms_zratio_test_surface_batch", (DL_FUNC) &_bgms_zratio_test_surface_batch, 13},

--- a/src/zratio_interface.cpp
+++ b/src/zratio_interface.cpp
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------------
+// zratio_interface.cpp
+//
+// Production R-facing entry for the hierarchical-spec per-edge Z-ratio engine.
+// Kept apart from the zratio_test_* entries (zratio_test_interface.cpp), which
+// drive the engine in isolation for tests: this file holds the entry the fit
+// itself calls.
+// -----------------------------------------------------------------------------
+
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
+
+#include "models/ggm/zratio_engine.h"
+
+// -----------------------------------------------------------------------------
+// zratio_block_oracle_moments:
+//   Weighted block moments (S1, S2) from the block-Gibbs oracle on a BARE
+//   mediating component, standing alone (no host graph). This is the offline
+//   anchor generator for the Option-B absolute-moment surfaces (called on every
+//   alpha = 1 hierarchical fit by R/zratio_surfaces.R): for a CN cluster every
+//   node is a common neighbour, so si = sj = all block rows; for a bipartite
+//   bridge structure si = side-A rows, sj = side-B rows (both 0-based into
+//   `a_blk`). Reuses the bgms-aligned Schur+rank-2-SMW kernel, so the anchors
+//   are drawn from the same law the sampler uses. addc/tg/ihat/ghat/wt/psi0 are
+//   unused by the moment recipe (it reads only delta, eta, sigma = 1) but the
+//   engine constructor requires them; pass the fit-time constants for the cell.
+// -----------------------------------------------------------------------------
+
+// [[Rcpp::export(name = "zratio_block_oracle_moments")]]
+Rcpp::List zratio_block_oracle_moments(
+    arma::imat a_blk,
+    arma::uvec si,
+    arma::uvec sj,
+    arma::vec addc,
+    arma::vec tg,
+    arma::vec ihat,
+    arma::vec ghat,
+    arma::vec wt,
+    double psi0,
+    double delta,
+    double eta,
+    int n_sweep,
+    int burn,
+    int seed,
+    bool slab_cauchy = false,
+    double alpha = 1.0
+) {
+    ZRatioEngine engine(addc, tg, ihat, ghat, wt, psi0);
+    SafeRNG rng(seed);
+    engine.set_oracle_params(delta, eta, &rng, n_sweep, burn, slab_cauchy,
+                             alpha);
+    double s1 = NA_REAL, s2 = NA_REAL;
+    bool ok = engine.block_oracle_moments(a_blk, si, sj, s1, s2);
+    return Rcpp::List::create(
+        Rcpp::_["ok"] = ok,
+        Rcpp::_["S1"] = s1,
+        Rcpp::_["S2"] = s2
+    );
+}

--- a/src/zratio_test_interface.cpp
+++ b/src/zratio_test_interface.cpp
@@ -98,52 +98,6 @@ Rcpp::List zratio_test_reference(
 }
 
 // -----------------------------------------------------------------------------
-// zratio_block_oracle_moments:
-//   Weighted block moments (S1, S2) from the block-Gibbs oracle on a BARE
-//   mediating component, standing alone (no host graph). This is the offline
-//   anchor generator for the Option-B absolute-moment surfaces: for a CN
-//   cluster every node is a common neighbour, so si = sj = all block rows; for
-//   a bipartite bridge structure si = side-A rows, sj = side-B rows (both
-//   0-based into `a_blk`). Reuses the bgms-aligned Schur+rank-2-SMW kernel, so
-//   the anchors are drawn from the same law the sampler uses. addc/tg/ihat/
-//   ghat/wt/psi0 are unused by the moment recipe (it reads only delta, eta,
-//   sigma = 1) but the engine constructor requires them; pass the fit-time
-//   constants for the cell.
-// -----------------------------------------------------------------------------
-
-// [[Rcpp::export(name = "zratio_block_oracle_moments")]]
-Rcpp::List zratio_block_oracle_moments(
-    arma::imat a_blk,
-    arma::uvec si,
-    arma::uvec sj,
-    arma::vec addc,
-    arma::vec tg,
-    arma::vec ihat,
-    arma::vec ghat,
-    arma::vec wt,
-    double psi0,
-    double delta,
-    double eta,
-    int n_sweep,
-    int burn,
-    int seed,
-    bool slab_cauchy = false,
-    double alpha = 1.0
-) {
-    ZRatioEngine engine(addc, tg, ihat, ghat, wt, psi0);
-    SafeRNG rng(seed);
-    engine.set_oracle_params(delta, eta, &rng, n_sweep, burn, slab_cauchy,
-                             alpha);
-    double s1 = NA_REAL, s2 = NA_REAL;
-    bool ok = engine.block_oracle_moments(a_blk, si, sj, s1, s2);
-    return Rcpp::List::create(
-        Rcpp::_["ok"] = ok,
-        Rcpp::_["S1"] = s1,
-        Rcpp::_["S2"] = s2
-    );
-}
-
-// -----------------------------------------------------------------------------
 // zratio_test_saddle:
 //   The bare two-moment saddle map at (s1, s2), for closed-form checks.
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Two self-contained refactors from the 2026-07-24 z-ratio subsystem audit
(dev/plans/backlog/future_tasks.md). One commit per audit task; no behavior
change.

**#43 — dedupe the surface build+attach wiring.** The build + attach +
fence-message block was copy-pasted at three sampler sites (`run_sampler.R`
GGM and mixed, `sample_ggm_prior.R`). Extract `zratio_attach_surface` (build,
attach on success, message the fallback when `verbose`) and
`zratio_surface_fence_message` (the two additive-path messages), and route the
size cap through one `.zratio_surface_size_cap` constant used by the build
default and all three sites, so the messages and `max_size`/cores policy can no
longer drift. Behavior-neutral: the prior (SBC reference) path stays silent on
a fallback; GGM/mixed keep identical messages; the cap stays `44L`.

**#41 — relocate the oracle entry.** `zratio_block_oracle_moments` is a
production entry point (the Option-B surface build calls it on every `alpha = 1`
hierarchical fit) but shipped from `zratio_test_interface.cpp` alongside the
test-only `zratio_test_*` exports. Move it to a new production interface file
`src/zratio_interface.cpp`, matching the `*_interface.cpp` (production) vs
`*_test_interface.cpp` (test) convention. Export name and signature unchanged;
`RcppExports` regenerated.

Verification: clean `compileAttributes` + `load_all` build; `lintr` clean on
all three R files; targeted tests pass — test-zratio-surface-build (11),
-surface (42), -engine (62), -gauge (39), -cauchy (16), -gamma-shape (40), plus
the integration paths test-bgm-hier-spec (33) and test-sample-ggm-prior (55).