### PR TITLE
refactor(warmup): retire dead Stage-3d calibration scaffolding (audit #44)

### DIFF
--- a/src/mcmc/execution/chain_runner.cpp
+++ b/src/mcmc/execution/chain_runner.cpp
@@ -86,11 +86,6 @@ void run_mcmc_chain(
             model.impute_missing();
         }
 
-        // Warmup/sampling boundary hook (models with warmup-dependent state)
-        if (iter == schedule.total_warmup) {
-            model.on_warmup_end();
-        }
-
         // Edge selection
         if (schedule.selection_enabled(iter) && model.has_edge_selection()) {
             if (iter == schedule.stage3c_start) {

--- a/src/mcmc/execution/warmup_schedule.h
+++ b/src/mcmc/execution/warmup_schedule.h
@@ -39,9 +39,8 @@ struct WarmupSchedule {
   std::vector<int> window_ends;   ///< Stage-2 windows (last index of each)
   int stage3a_start;              ///< First iter in Stage-3a
   int stage3b_start;              ///< First iter in Stage-3b (== stage3c_start if skipped)
-  int stage3c_start;              ///< First iter in Stage-3c (== stage3d_start if skipped)
-  int stage3d_start;              ///< First iter in Stage-3d (== total_warmup if no window)
-  int total_warmup;               ///< User warmup plus the Stage-3d calibration window
+  int stage3c_start;              ///< First iter in Stage-3c (== total_warmup if skipped)
+  int total_warmup;               ///< User-specified warmup (== first retained iteration)
   bool learn_proposal_sd;         ///< Whether to run the proposal-SD tuner
   bool enable_selection;          ///< Allow edge-indicator moves
   int warning_type;               ///< Warning code (see above)
@@ -50,16 +49,13 @@ struct WarmupSchedule {
   WarmupSchedule(int warmup,
                  bool enable_sel,
                  bool learn_sd,
-                 bool select_during_warmup = false,
-                 int calibration_window = 0)
+                 bool select_during_warmup = false)
     : stage1_end(0)
     , window_ends()
     , stage3a_start(0)
     , stage3b_start(0)
     , stage3c_start(0)
-    , stage3d_start(warmup)       // Appended Stage-3d calibration window:
-                                  // adaptation stages keep the user's warmup
-    , total_warmup(warmup + std::max(0, calibration_window))
+    , total_warmup(warmup)
     , learn_proposal_sd(learn_sd)
     , enable_selection(enable_sel)
     , warning_type(0)
@@ -164,7 +160,6 @@ struct WarmupSchedule {
     stage3c_start = (selection_warmup_start >= 0)
       ? selection_warmup_start              // Gibbs: settle, then selection
       : warmup_core + stage3b_budget;
-    // total_warmup = stage3d_start (user warmup) + calibration window
   }
 
   /// Stage query helpers
@@ -172,11 +167,7 @@ struct WarmupSchedule {
   bool in_stage2 (int i) const { return i >= stage1_end && i < stage3a_start; }
   bool in_stage3a(int i) const { return i >= stage3a_start && i < stage3b_start; }
   bool in_stage3b(int i) const { return !stage3b_skipped && i >= stage3b_start && i < stage3c_start; }
-  bool in_stage3c(int i) const { return enable_selection && !stage3b_skipped && i >= stage3c_start && i < stage3d_start; }
-  /// Stage-3d: the appended calibration window (selection active on every
-  /// host, so the Z-ratio calibrator sees a selection-warm stream; on the
-  /// adaptive-Metropolis host this is also its only selection-warm window).
-  bool in_stage3d(int i) const { return enable_selection && i >= stage3d_start && i < total_warmup; }
+  bool in_stage3c(int i) const { return enable_selection && !stage3b_skipped && i >= stage3c_start && i < total_warmup; }
   bool sampling (int i) const { return i >= total_warmup; }
 
   bool has_warning() const { return warning_type > 0; }
@@ -187,7 +178,7 @@ struct WarmupSchedule {
 
   /// Whether indicator moves are enabled (Stage 3c and sampling)
   bool selection_enabled(int i) const {
-    return enable_selection && (in_stage3c(i) || in_stage3d(i) || sampling(i));
+    return enable_selection && (in_stage3c(i) || sampling(i));
   }
 
   /// Whether to adapt proposal_sd (Stage-3b only, if not skipped)

--- a/src/models/base_model.h
+++ b/src/models/base_model.h
@@ -157,13 +157,6 @@ public:
     virtual void prepare_iteration() {}
 
     /**
-     * Called once at the warmup/sampling boundary (before the first
-     * retained iteration). Default no-op; models with warm-up-calibrated
-     * state (e.g. the GGM Z-ratio engine) freeze it here.
-     */
-    virtual void on_warmup_end() {}
-
-    /**
      * Called once at the end of the chain run. Default no-op; models with
      * run-level diagnostic state (e.g. the GGM Z-ratio engine's counters,
      * frozen constants, and calibration anchors) copy it into the chain


### PR DESCRIPTION
Retires the OLS/warmup-calibration scaffolding that the Option-B z-ratio surfaces replaced (backlog audit item #44).

## Changes

- `WarmupSchedule`: remove the `calibration_window` ctor parameter, the `stage3d_start` member, and `in_stage3d()`. No caller ever passed `calibration_window`, so Stage-3d was always the empty range `[warmup, warmup)` (`stage3d_start == total_warmup == warmup`, `in_stage3d()` never true). `in_stage3c()` now runs to `total_warmup`, and `selection_enabled()` no longer consults `in_stage3d()`.
- `BaseModel::on_warmup_end()`: remove the virtual hook (zero overrides across `src/`) and its call site in `chain_runner.cpp`.

`total_warmup` is retained — it is the warmup→sampling boundary used by both the GGM/OMRF and bgmCompare loops — and simplifies to `= warmup`.

## Why behavior-neutral

Stage-3d only ever existed as an appended calibration window driven by `calibration_window`, which no code path set to a non-zero value. `on_warmup_end()` had no overrides, so the call was a no-op.

Item 34 lever 1 (parked) is pre-chain calibration built at spec-build time; it does not use this appended post-warmup window, so the removal does not affect that design.

## Verification

- `devtools::load_all()` compiles clean.
- `test-warmup-schedule.R`: 13/13 pass (the single skip is the unrelated on-CRAN gate).
- No SBC/parameter-recovery re-run required (behavior-neutral).