### PR TITLE
refactor(zratio): single-source duplicated constants (audit #40 pts 2/5/7)

### DIFF
--- a/R/correction_tables.R
+++ b/R/correction_tables.R
@@ -533,6 +533,20 @@ ggm_edge_prior_correction = function(prior, sampler, num_variables,
 
 
 # ------------------------------------------------------------------
+# Shared cache-policy accessors (internal)
+# ------------------------------------------------------------------
+# Single source for the correction-cache option defaults so the
+# correction-table build and the Z-ratio surface build agree.
+# ------------------------------------------------------------------
+correction_cache_enabled = function() {
+  isTRUE(getOption("bgms.correction_table_cache", TRUE))
+}
+
+correction_cache_dir = function() {
+  getOption("bgms.correction_cache_dir", tools::R_user_dir("bgms", which = "cache"))
+}
+
+# ------------------------------------------------------------------
 # ggm_correction_table (internal)
 # ------------------------------------------------------------------
 # Cache wrapper: get-or-build the table for a model cell. Tables are
@@ -555,7 +569,7 @@ ggm_correction_table = function(
     delta = 0.5 * log(p)
   }
 
-  use_cache = isTRUE(getOption("bgms.correction_table_cache", TRUE))
+  use_cache = correction_cache_enabled()
   cache_file = NULL
   if(use_cache) {
     cell = ggm_correction_cell(
@@ -566,10 +580,7 @@ ggm_correction_table = function(
       cell$q, cell$delta, cell$eta, cell$slab_family, cell$scale_shape,
       n_grid, n_samples, n_warmup, n_seeds, update_method
     )
-    cache_dir = getOption(
-      "bgms.correction_cache_dir",
-      tools::R_user_dir("bgms", which = "cache")
-    )
+    cache_dir = correction_cache_dir()
     cache_file = file.path(cache_dir, key)
     if(!refresh && file.exists(cache_file)) {
       table = tryCatch(readRDS(cache_file), error = function(e) NULL)

--- a/R/zratio_surfaces.R
+++ b/R/zratio_surfaces.R
@@ -186,17 +186,14 @@ zratio_build_surfaces = function(zc, max_size = .zratio_surface_size_cap,
   # options(bgms.correction_table_cache) so one switch governs both.
   use_cache = isTRUE(getOption(
     "bgms.zratio_surface_cache",
-    getOption("bgms.correction_table_cache", TRUE)
+    correction_cache_enabled()
   ))
   cache_file = NULL
   if(use_cache) {
     key = zratio_surface_cache_key(zc, cap, seed0)
     hit = get0(key, envir = .zratio_surface_cache, inherits = FALSE)
     if(!is.null(hit)) return(hit)
-    cache_dir = getOption(
-      "bgms.correction_cache_dir",
-      tools::R_user_dir("bgms", which = "cache")
-    )
+    cache_dir = correction_cache_dir()
     cache_file = file.path(cache_dir, paste0(key, ".rds"))
     if(file.exists(cache_file)) {
       surf = tryCatch(readRDS(cache_file), error = function(e) NULL)

--- a/src/mcmc/execution/chain_runner.cpp
+++ b/src/mcmc/execution/chain_runner.cpp
@@ -6,6 +6,7 @@
 #include "mcmc/samplers/nuts_sampler.h"
 #include "mcmc/samplers/metropolis_sampler.h"
 #include "mcmc/samplers/gibbs_sampler.h"
+#include "models/ggm/zratio_gauge.h"  // ZRatioGauge::default_n_draws / default_cap
 
 
 namespace {
@@ -155,8 +156,8 @@ void run_mcmc_chain(
     // pair-by-pair as usual. Post-sampling, so no stored samples are touched.
     if (config.zratio_gauge_sweeps > 0 && model.gauge_available() &&
         model.has_edge_selection()) {
-        model.set_gauge_active(true, config.zratio_gauge_draws,
-                               config.zratio_gauge_cap);
+        model.set_gauge_active(true, ZRatioGauge::default_n_draws,
+                               ZRatioGauge::default_cap);
         for (int k = 0; k < config.zratio_gauge_sweeps; ++k) {
             model.gauge_begin_sweep();
             model.update_edge_indicators();
@@ -166,7 +167,8 @@ void run_mcmc_chain(
                 break;
             }
         }
-        model.set_gauge_active(false);
+        model.set_gauge_active(false, ZRatioGauge::default_n_draws,
+                               ZRatioGauge::default_cap);
     }
 
     // Run-level diagnostic state (e.g. the Z-ratio engine's counters and

--- a/src/mcmc/execution/sampler_config.h
+++ b/src/mcmc/execution/sampler_config.h
@@ -23,11 +23,10 @@ struct SamplerConfig {
     /// In-chain Z-ratio trust gauge: number of post-sampling assessment
     /// sweeps (0 = off). Each sweep is a deployed selection pass that also
     /// references non-trivial edge moves against the exact block-local
-    /// reference. Reference block-Gibbs draws per pair and the per-sweep
-    /// referenced-pair cap are fixed design parameters.
+    /// reference. The reference block-Gibbs draws per pair and the per-sweep
+    /// referenced-pair cap are fixed design parameters owned by ZRatioGauge
+    /// (default_n_draws / default_cap), applied at the activation site.
     int zratio_gauge_sweeps = 0;
-    int zratio_gauge_draws = 120;
-    int zratio_gauge_cap = 25;
 
     /// Maximum NUTS tree depth.
     int max_tree_depth = 10;

--- a/src/models/base_model.h
+++ b/src/models/base_model.h
@@ -188,8 +188,7 @@ public:
      * While active, update_edge_indicators() also references non-trivial edge
      * moves against the block-local exact reference. Default no-op.
      */
-    virtual void set_gauge_active(bool /*on*/, int /*n_draws*/ = 120,
-                                  int /*cap*/ = 25) {}
+    virtual void set_gauge_active(bool /*on*/, int /*n_draws*/, int /*cap*/) {}
 
     /** Start a new gauge assessment sweep (reset the per-sweep cap). */
     virtual void gauge_begin_sweep() {}

--- a/src/models/ggm/zratio_engine.h
+++ b/src/models/ggm/zratio_engine.h
@@ -131,6 +131,13 @@ inline SurfaceFamily surface_family_from_list(const Rcpp::List& s) {
  */
 class ZRatioEngine {
 public:
+    /// Default oracle block-Gibbs schedule (sweeps and burn-in) for the
+    /// mediating-block sampler. Single source of truth: the set_oracle_params
+    /// default arguments, the member initializers, and the sampler call sites
+    /// (sample_ggm.cpp, sample_mixed.cpp) all reference these.
+    static constexpr int default_oracle_n_sweep = 300;
+    static constexpr int default_oracle_burn = 30;
+
     ZRatioEngine(const arma::vec& addc, const arma::vec& tg,
                  const arma::vec& ihat, const arma::vec& ghat,
                  const arma::vec& wt, double psi0)
@@ -215,7 +222,8 @@ public:
      * reference, and the trust gauge.
      */
     void set_oracle_params(double delta, double eta, SafeRNG* rng,
-                           int n_sweep = 300, int burn = 30,
+                           int n_sweep = default_oracle_n_sweep,
+                           int burn = default_oracle_burn,
                            bool slab_cauchy = false, double alpha = 1.0) {
         delta_ = delta;
         sigma_ = 1.0;
@@ -403,7 +411,7 @@ private:
     bool oracle_slab_cauchy_ = false;
     double delta_ = 0.0, sigma_ = 1.0, beta_ = 0.5, alpha_ = 1.0;
     SafeRNG* rng_ = nullptr;
-    int n_sweep_ = 300, burn_ = 30;
+    int n_sweep_ = default_oracle_n_sweep, burn_ = default_oracle_burn;
 
     // Reused scratch for extract_block_. One engine serves one chain, and
     // the counts pass runs once per edge proposal, so per-call heap

--- a/src/models/ggm/zratio_gauge.h
+++ b/src/models/ggm/zratio_gauge.h
@@ -29,9 +29,15 @@
  * (n_ent) and never silently dropped.
  */
 struct ZRatioGauge {
+    /// Fixed design parameters for the trust gauge. Single source of truth:
+    /// the member initializers below and the activation site (chain_runner)
+    /// reference these. Not user-configurable (only the sweep count is).
+    static constexpr int default_cap = 25;      ///< max referenced pairs per sweep
+    static constexpr int default_n_draws = 120; ///< reference block-Gibbs draws per pair
+
     bool active = false;
-    int cap = 25;         ///< max referenced pairs per sweep
-    int n_draws = 120;    ///< reference block-Gibbs draws per pair
+    int cap = default_cap;      ///< max referenced pairs per sweep
+    int n_draws = default_n_draws; ///< reference block-Gibbs draws per pair
     double nE = 0.0;      ///< q(q-1)/2, set at activation
 
     // Per-sweep scratch (reset by begin_sweep).

--- a/src/sample_ggm.cpp
+++ b/src/sample_ggm.cpp
@@ -140,7 +140,9 @@ Rcpp::List sample_ggm(
         // The rng pointer is rebound per chain clone by GGMModel. Hand the
         // engine the standardized-cell prior params so its sibling paths (the
         // gold reference and the trust gauge) can sample.
-        engine->set_oracle_params(zr_delta, zr_eta, nullptr, 300, 30,
+        engine->set_oracle_params(zr_delta, zr_eta, nullptr,
+                                  ZRatioEngine::default_oracle_n_sweep,
+                                  ZRatioEngine::default_oracle_burn,
                                   zr_cauchy, zr_alpha);
         model.set_zratio_engine(std::move(engine));
     }

--- a/src/sample_mixed.cpp
+++ b/src/sample_mixed.cpp
@@ -169,7 +169,9 @@ Rcpp::List sample_mixed_mrf(
                                 surface_family_from_list(zsurf["bip"]));
         }
         // The rng pointer is rebound per chain clone by MixedMRFModel.
-        engine->set_oracle_params(zr_delta, zr_eta, nullptr, 300, 30,
+        engine->set_oracle_params(zr_delta, zr_eta, nullptr,
+                                  ZRatioEngine::default_oracle_n_sweep,
+                                  ZRatioEngine::default_oracle_burn,
                                   zr_cauchy, zr_alpha);
         model.set_zratio_engine(std::move(engine));
     }

--- a/src/zratio_test_interface.cpp
+++ b/src/zratio_test_interface.cpp
@@ -152,7 +152,9 @@ Rcpp::List zratio_test_surface_eval(
     double alpha = 1.0
 ) {
     ZRatioEngine engine(addc, tg, ihat, ghat, wt, psi0);
-    engine.set_oracle_params(delta, eta, nullptr, 300, 30, slab_cauchy, alpha);
+    engine.set_oracle_params(delta, eta, nullptr,
+                             ZRatioEngine::default_oracle_n_sweep,
+                             ZRatioEngine::default_oracle_burn, slab_cauchy, alpha);
     engine.set_surface(surface_family_from_list(surface["cn"]),
                        surface_family_from_list(surface["bip"]));
     double s1 = NA_REAL, s2 = NA_REAL, logr = NA_REAL;
@@ -212,7 +214,9 @@ Rcpp::List zratio_test_surface_batch(
     double alpha = 1.0
 ) {
     ZRatioEngine engine(addc, tg, ihat, ghat, wt, psi0);
-    engine.set_oracle_params(delta, eta, nullptr, 300, 30, slab_cauchy, alpha);
+    engine.set_oracle_params(delta, eta, nullptr,
+                             ZRatioEngine::default_oracle_n_sweep,
+                             ZRatioEngine::default_oracle_burn, slab_cauchy, alpha);
     engine.set_surface(surface_family_from_list(surface["cn"]),
                        surface_family_from_list(surface["bip"]));
     arma::vec out(edges.n_rows);


### PR DESCRIPTION
Collapses hand-copied literals flagged in the 2026-07-24 z-ratio subsystem audit (backlog item #40) so they can no longer silently drift out of sync. Behavior-neutral: every value is byte-identical to before.

## Point 2 — gauge `cap = 25` / `n_draws = 120`
`ZRatioGauge::default_cap` and `ZRatioGauge::default_n_draws` become the single source.
- `sampler_config.h`: drop the dead `zratio_gauge_draws` / `zratio_gauge_cap` fields — they were never written from R (only `gauge_sweeps` is configurable) and were read at exactly one site.
- `base_model.h`: drop the dead default arguments on the `set_gauge_active` interface (both model overrides and both call sites pass explicit values).
- `chain_runner.cpp`: apply the `ZRatioGauge` constants at the activation/deactivation sites.

## Point 5 — oracle `n_sweep = 300` / `burn = 30`
`ZRatioEngine::default_oracle_n_sweep` and `ZRatioEngine::default_oracle_burn` become the single source, referenced by the `set_oracle_params` default arguments, the member initializers, and every call site (`sample_ggm.cpp`, `sample_mixed.cpp`, `zratio_test_interface.cpp`).

## Point 7 — correction-cache option defaults
`correction_cache_enabled()` and `correction_cache_dir()` centralize the `bgms.correction_table_cache` / `bgms.correction_cache_dir` defaults, consumed by both the correction-table build (`correction_tables.R`) and the Z-ratio surface build (`zratio_surfaces.R`).

Point 4 of the audit item (the `44L` size cap) was already closed by #178. Points 1, 3, and 6 remain open (tracked in the backlog); point 1 in particular touches the C++ surface predictor and warrants its own change.

## Verification
- `devtools::load_all()` compiles clean.
- `test-zratio-surface.R`: 42/42.
- `test-zratio-gauge.R`: 27/27 (3 on-CRAN skips).
- R cache helpers resolve and toggle correctly under `options(bgms.correction_table_cache = ...)`.