### PR TITLE
extract_ess() indicators report the RB n_eff; standardize= goes through lifecycle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 
 * `update_method = "hamiltonian-mc"` has been removed. Use `update_method = "nuts"` instead. NUTS dynamically adapts trajectory length and is more reliable, especially with edge selection on GGM models.
 * The `hmc_num_leapfrogs` argument has been removed along with pure HMC.
-* The `standardize` argument of `bgm()` and `bgmCompare()` has been removed. Passing it now errors.
+* The `standardize` argument of `bgm()` and `bgmCompare()` has been removed: pairwise interactions are on the association scale and share one prior scale, so the per-pair adjustment by the product of the variables' maximum scores no longer applies. The argument stays a deprecated formal so the failure is informative rather than an unused-argument error: `standardize = FALSE`, the old default, warns and proceeds because it is what the sampler already does, while `standardize = TRUE` errors and points to setting the scale directly through `interaction_prior` (and `difference_scale` for `bgmCompare()`).
 
 * Pairwise interaction parameters for ordinal MRFs are now stored on association scale (half the sigma scale used in 0.1.6.3). Code that interprets raw pairwise posterior samples or sets `pairwise_scale` explicitly will need adjustment.
 * Default `pairwise_scale` changed from 2.5 to 1 to match the association-scale reparameterization.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Pairwise interaction parameters for ordinal MRFs are now stored on association scale (half the sigma scale used in 0.1.6.3). Code that interprets raw pairwise posterior samples or sets `pairwise_scale` explicitly will need adjustment.
 * Default `pairwise_scale` changed from 2.5 to 1 to match the association-scale reparameterization.
 * `extract_category_thresholds()` is deprecated in favor of `extract_main_effects()`, which covers category thresholds, continuous means, and precision diagonal entries.
+* `extract_ess()` reports the Rao-Blackwellized effective sample size for the edge (or difference) indicators, the `n_eff` column of the fit summary's inclusion table, where 0.1.6.3 returned the indicator chain's transition-based ESS. The extractor family is now coherent: the Rao-Blackwellized inclusion probability (`extract_posterior_inclusion_probabilities()`), its R-hat (`extract_rhat()`), and its ESS all describe the same estimate. The transition ESS remains in the summary table as `n_eff_mixt` and is available as `extract_ess(fit, estimator = "mixt")`; few transitions are expected on edges whose inclusion probability sits near 0 or 1, so it reads as a secondary mixing diagnostic beside the Rao-Blackwellized number.
 
 ## New features
 

--- a/R/bgm.R
+++ b/R/bgm.R
@@ -297,6 +297,15 @@
 #'   Deprecated arguments as of \strong{bgms 0.1.6.0}.
 #'   Use `interaction_prior`, `warmup`, and `threshold_prior` instead.
 #'
+#' @param standardize `r lifecycle::badge("deprecated")` Logical. Deprecated
+#'   as of \strong{bgms 0.2.0.0}. Through 0.1.6.3, \code{TRUE} adjusted each
+#'   pair's interaction prior scale by the product of the two variables'
+#'   maximum scores. Pairwise interactions are now on the association scale
+#'   and share one prior scale, so the per-pair adjustment is gone:
+#'   \code{standardize = FALSE} (the old default) warns and proceeds, while
+#'   \code{standardize = TRUE} errors and points to setting the scale directly
+#'   through \code{interaction_prior}.
+#'
 #' @return
 #' An S7 object of class \code{bgms} with posterior summaries, posterior mean
 #' matrices, and access to raw MCMC draws. Its fields are accessible with
@@ -436,7 +445,9 @@ bgm = function(
   burnin,
   save,
   threshold_alpha,
-  threshold_beta
+  threshold_beta,
+  # Deprecated arguments (v0.2.0.0)
+  standardize
 ) {
   # Set verbose option for internal functions, restore on exit
 
@@ -499,6 +510,34 @@ bgm = function(
       ma = if(hasArg(main_alpha)) main_alpha else 0.5
       mb = if(hasArg(main_beta)) main_beta else 0.5
       threshold_prior = beta_prime_prior(alpha = ma, beta = mb)
+    }
+  }
+
+  # --- Legacy deprecation: v0.2.0.0 removals ----------------------------------
+  # standardize scaled each pair's interaction prior by the product of the two
+  # variables' maximum scores. FALSE, its old default, is what the sampler does
+  # now, so it warns and proceeds; TRUE asks for an adjustment that no longer
+  # exists, so it stops with the manual alternative.
+  if(hasArg(standardize)) {
+    if(isFALSE(standardize)) {
+      lifecycle::deprecate_warn(
+        "0.2.0", "bgm(standardize =)",
+        details = paste(
+          "FALSE is what the sampler does, so the fit is unaffected; drop the",
+          "argument."
+        )
+      )
+    } else {
+      lifecycle::deprecate_stop(
+        "0.2.0", "bgm(standardize = 'no longer supports TRUE')",
+        details = paste(
+          "Pairwise interactions are on the association scale and share one",
+          "prior scale, so the per-pair adjustment by the maximum score",
+          "product (scale * m_i * m_j) has been dropped. Set the scale",
+          "directly, e.g. interaction_prior = normal_prior(scale =) or",
+          "cauchy_prior(scale =); there is no per-pair equivalent."
+        )
+      )
     }
   }
 

--- a/R/bgmCompare.R
+++ b/R/bgmCompare.R
@@ -124,6 +124,14 @@
 #'   Use `difference_scale`, `difference_prior`, `difference_probability`,
 #'   `beta_bernoulli_alpha`, `beta_bernoulli_beta`, `baseline_category`,
 #'   `interaction_prior`, `threshold_prior`, and `warmup` instead.
+#' @param standardize `r lifecycle::badge("deprecated")` Logical. Deprecated
+#'   as of \strong{bgms 0.2.0.0}. Through 0.1.6.3, \code{TRUE} adjusted each
+#'   pair's baseline and difference prior scale by the product of the two
+#'   variables' maximum scores. Pairwise interactions are now on the
+#'   association scale and share one prior scale, so the per-pair adjustment is
+#'   gone: \code{standardize = FALSE} (the old default) warns and proceeds,
+#'   while \code{standardize = TRUE} errors and points to setting the scales
+#'   directly through \code{interaction_prior} and \code{difference_scale}.
 #' @return
 #' An S7 object of class \code{bgmCompare} supporting list-style \code{$} /
 #' \code{[[} access for backward compatibility, containing posterior summaries,
@@ -224,7 +232,9 @@ bgmCompare = function(
   threshold_alpha,
   threshold_beta,
   burnin,
-  save
+  save,
+  # Deprecated arguments (v0.2.0.0)
+  standardize
 ) {
   # Set verbose option for internal functions, restore on exit
   old_verbose = getOption("bgms.verbose")
@@ -350,6 +360,35 @@ bgmCompare = function(
 
   if(hasArg(save)) {
     lifecycle::deprecate_warn("0.1.6.0", "bgmCompare(save =)")
+  }
+
+  # --- Legacy deprecation: v0.2.0.0 removals ----------------------------------
+  # standardize scaled each pair's baseline and difference prior by the product
+  # of the two variables' maximum scores. FALSE, its old default, is what the
+  # sampler does now, so it warns and proceeds; TRUE asks for an adjustment that
+  # no longer exists, so it stops with the manual alternative.
+  if(hasArg(standardize)) {
+    if(isFALSE(standardize)) {
+      lifecycle::deprecate_warn(
+        "0.2.0", "bgmCompare(standardize =)",
+        details = paste(
+          "FALSE is what the sampler does, so the fit is unaffected; drop the",
+          "argument."
+        )
+      )
+    } else {
+      lifecycle::deprecate_stop(
+        "0.2.0", "bgmCompare(standardize = 'no longer supports TRUE')",
+        details = paste(
+          "Pairwise interactions are on the association scale and share one",
+          "prior scale, so the per-pair adjustment by the maximum score",
+          "product (scale * m_i * m_j) has been dropped. Set the scales",
+          "directly, e.g. interaction_prior = cauchy_prior(scale =) for the",
+          "baseline and difference_scale for the differences; there is no",
+          "per-pair equivalent."
+        )
+      )
+    }
   }
 
   # --- Handle difference_prior: accept both string (deprecated) and object ------

--- a/R/extractor_functions.R
+++ b/R/extractor_functions.R
@@ -1299,6 +1299,12 @@ extract_pairwise_thresholds = function(bgms_object) {
 #' @return A named list with R-hat values for each parameter type present in
 #'   the model (e.g., `main`, `pairwise`, `indicator`).
 #'
+#' @details
+#' The `indicator` element is the split-R-hat of the Rao-Blackwellized
+#' inclusion draws, matching the default of [extract_ess()]; the indicator
+#' chain's transition-based effective sample size is available as
+#' `extract_ess(fit, estimator = "mixt")`.
+#'
 #' @seealso [bgm()], [bgmCompare()], [extract_ess()]
 #' @family extractors
 #' @export
@@ -1393,6 +1399,51 @@ extract_rhat.bgmCompare = function(bgms_object) {
 # extract_ess() - Effective Sample Size
 # ------------------------------------------------------------------------------
 
+# ------------------------------------------------------------------------------
+# indicator_ess_column
+# ------------------------------------------------------------------------------
+# Resolve the indicator ESS column that extract_ess() returns. The default
+# "rb" is the continuous ESS of the Rao-Blackwellized inclusion draws, the ESS
+# of the inclusion probability the fit reports; "mixt" is the indicator chain's
+# transition-based ESS. Both are read from the summary table, so the NA masking
+# summarize_rb_inclusion() applies carries over unchanged.
+#
+# Fits without Rao-Blackwellized draws (bgms < 0.2.0.0) carry no n_eff column,
+# so a default call falls back to the transition ESS while an explicit
+# estimator = "rb" errors, as in
+# extract_posterior_inclusion_probabilities().
+#
+# @param summary_indicator  The fit's posterior_summary_indicator table.
+# @param estimator          Character: "rb" or "mixt" (or the unevaluated
+#   default vector).
+# @param estimator_missing  Logical: TRUE if the caller did not supply one.
+#
+# Returns: numeric vector of ESS values, one per indicator.
+# ------------------------------------------------------------------------------
+indicator_ess_column = function(summary_indicator, estimator, estimator_missing) {
+  # names(), not $, because $ partial-matches n_eff to n_eff_mixt.
+  has_rb = "n_eff" %in% names(summary_indicator)
+  estimator = if(estimator_missing && !has_rb) {
+    "mixt"
+  } else {
+    match.arg(estimator, choices = c("rb", "mixt"))
+  }
+  if(estimator == "rb") {
+    if(!has_rb) {
+      stop(
+        "This fit carries no Rao-Blackwellized inclusion draws, so the ",
+        "Rao-Blackwellized effective sample size is unavailable. Refit with ",
+        "bgms >= 0.2.0.0, or use estimator = \"mixt\" for the indicator ",
+        "chain's transition-based effective sample size."
+      )
+    }
+    summary_indicator$n_eff
+  } else {
+    summary_indicator$n_eff_mixt
+  }
+}
+
+
 #' @title Extract Effective Sample Size
 #'
 #' @description
@@ -1401,21 +1452,51 @@ extract_rhat.bgmCompare = function(bgms_object) {
 #'
 #' @param bgms_object A fitted model object of class `bgms` (from [bgm()])
 #'   or `bgmCompare` (from [bgmCompare()]).
+#' @param estimator Character; which effective sample size to return for the
+#'   edge (or difference) indicators. `"rb"` (default) returns the ESS of the
+#'   Rao-Blackwellized inclusion draws; `"mixt"` returns the indicator chain's
+#'   transition-based ESS. Ignored for all other parameter types.
 #'
 #' @return A named list with ESS values for each parameter type present in
 #'   the model (e.g., `main`, `pairwise`, `indicator`).
 #'
-#' @seealso [bgm()], [bgmCompare()], [extract_rhat()]
+#' @details
+#' The `indicator` element reports the two effective sample sizes of the
+#' inclusion inference as a pair, and both also appear in the fit summary's
+#' inclusion table (`summary(fit)$indicator`).
+#'
+#' The default, `estimator = "rb"`, is the `n_eff` column: the continuous ESS
+#' of the Rao-Blackwellized inclusion draws, and therefore the ESS of the
+#' inclusion probability the fit reports (see
+#' [extract_posterior_inclusion_probabilities()], which is Rao-Blackwellized
+#' by default). It quantifies precision *conditional on exploration*.
+#'
+#' `estimator = "mixt"` is the `n_eff_mixt` column: the transition-based ESS of
+#' the binary indicator chain, which measures the exploration itself. Few
+#' transitions are expected when an edge's inclusion probability sits near 0 or
+#' 1, so a small (or `NA`) transition ESS beside a confident Rao-Blackwellized
+#' ESS is the signature of a decisive edge rather than of a failure; read the
+#' two together. Edges whose indicator never flipped have no exploration
+#' information, and both columns are `NA` there.
+#'
+#' Fits made with bgms < 0.2.0.0 carry no Rao-Blackwellized draws; a default
+#' call falls back to the transition ESS, while an explicit `estimator = "rb"`
+#' errors.
+#'
+#' @seealso [bgm()], [bgmCompare()], [extract_rhat()] for the
+#'   Rao-Blackwellized indicator R-hat,
+#'   [extract_posterior_inclusion_probabilities()]
 #' @family extractors
 #' @export
-extract_ess = function(bgms_object) {
+extract_ess = function(bgms_object, estimator = c("rb", "mixt")) {
   UseMethod("extract_ess")
 }
 
 #' @inheritParams extract_ess
 #' @exportS3Method
 #' @noRd
-extract_ess.bgms = function(bgms_object) {
+extract_ess.bgms = function(bgms_object, estimator = c("rb", "mixt")) {
+  estimator_missing = missing(estimator)
   ensure_summaries(bgms_object)
   result = list()
 
@@ -1439,10 +1520,9 @@ extract_ess.bgms = function(bgms_object) {
 
   # Indicator ESS (if edge selection was used)
   if(!is.null(bgms_object$posterior_summary_indicator)) {
-    # Binary indicator summaries report the mixture ESS; the Rao-Blackwellized
-    # summary reports the standard continuous ESS instead.
-    result$indicator = bgms_object$posterior_summary_indicator$n_eff_mixt %||%
-      bgms_object$posterior_summary_indicator$n_eff
+    result$indicator = indicator_ess_column(
+      bgms_object$posterior_summary_indicator, estimator, estimator_missing
+    )
     names(result$indicator) = rownames(bgms_object$posterior_summary_indicator)
   }
 
@@ -1456,7 +1536,8 @@ extract_ess.bgms = function(bgms_object) {
 #' @inheritParams extract_ess
 #' @exportS3Method
 #' @noRd
-extract_ess.bgmCompare = function(bgms_object) {
+extract_ess.bgmCompare = function(bgms_object, estimator = c("rb", "mixt")) {
+  estimator_missing = missing(estimator)
   ensure_summaries(bgms_object)
   result = list()
 
@@ -1486,10 +1567,9 @@ extract_ess.bgmCompare = function(bgms_object) {
 
   # Indicator ESS (if difference selection was used)
   if(!is.null(bgms_object$posterior_summary_indicator)) {
-    # Binary indicator summaries report the mixture ESS; the Rao-Blackwellized
-    # summary reports the standard continuous ESS instead.
-    result$indicator = bgms_object$posterior_summary_indicator$n_eff_mixt %||%
-      bgms_object$posterior_summary_indicator$n_eff
+    result$indicator = indicator_ess_column(
+      bgms_object$posterior_summary_indicator, estimator, estimator_missing
+    )
     names(result$indicator) = rownames(bgms_object$posterior_summary_indicator)
   }
 

--- a/man/bgm.Rd
+++ b/man/bgm.Rd
@@ -43,7 +43,8 @@ bgm(
   burnin,
   save,
   threshold_alpha,
-  threshold_beta
+  threshold_beta,
+  standardize
 )
 }
 \arguments{
@@ -315,6 +316,15 @@ Default: \code{1}.}
 \item{interaction_scale, burnin, save, threshold_alpha, threshold_beta}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 Deprecated arguments as of \strong{bgms 0.1.6.0}.
 Use \code{interaction_prior}, \code{warmup}, and \code{threshold_prior} instead.}
+
+\item{standardize}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical. Deprecated
+as of \strong{bgms 0.2.0.0}. Through 0.1.6.3, \code{TRUE} adjusted each
+pair's interaction prior scale by the product of the two variables'
+maximum scores. Pairwise interactions are now on the association scale
+and share one prior scale, so the per-pair adjustment is gone:
+\code{standardize = FALSE} (the old default) warns and proceeds, while
+\code{standardize = TRUE} errors and points to setting the scale directly
+through \code{interaction_prior}.}
 }
 \value{
 An S7 object of class \code{bgms} with posterior summaries, posterior mean

--- a/man/bgmCompare.Rd
+++ b/man/bgmCompare.Rd
@@ -52,7 +52,8 @@ bgmCompare(
   threshold_alpha,
   threshold_beta,
   burnin,
-  save
+  save,
+  standardize
 )
 }
 \arguments{
@@ -186,6 +187,15 @@ Deprecated arguments as of \strong{bgms 0.1.6.0}.
 Use \code{difference_scale}, \code{difference_prior}, \code{difference_probability},
 \code{beta_bernoulli_alpha}, \code{beta_bernoulli_beta}, \code{baseline_category},
 \code{interaction_prior}, \code{threshold_prior}, and \code{warmup} instead.}
+
+\item{standardize}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical. Deprecated
+as of \strong{bgms 0.2.0.0}. Through 0.1.6.3, \code{TRUE} adjusted each
+pair's baseline and difference prior scale by the product of the two
+variables' maximum scores. Pairwise interactions are now on the
+association scale and share one prior scale, so the per-pair adjustment is
+gone: \code{standardize = FALSE} (the old default) warns and proceeds,
+while \code{standardize = TRUE} errors and points to setting the scales
+directly through \code{interaction_prior} and \code{difference_scale}.}
 }
 \value{
 An S7 object of class \code{bgmCompare} supporting list-style \code{$} /

--- a/man/bgms-package.Rd
+++ b/man/bgms-package.Rd
@@ -76,7 +76,7 @@ spike-and-slab summaries.
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://Bayesian-Graphical-Modelling-Lab.github.io/bgms/}
+  \item \url{https://bayesian-graphical-modelling-lab.github.io/bgms/}
   \item \url{https://github.com/Bayesian-Graphical-Modelling-Lab/bgms}
   \item Report bugs at \url{https://github.com/Bayesian-Graphical-Modelling-Lab/bgms/issues}
 }

--- a/man/extract_ess.Rd
+++ b/man/extract_ess.Rd
@@ -4,11 +4,16 @@
 \alias{extract_ess}
 \title{Extract Effective Sample Size}
 \usage{
-extract_ess(bgms_object)
+extract_ess(bgms_object, estimator = c("rb", "mixt"))
 }
 \arguments{
 \item{bgms_object}{A fitted model object of class \code{bgms} (from \code{\link[=bgm]{bgm()}})
 or \code{bgmCompare} (from \code{\link[=bgmCompare]{bgmCompare()}}).}
+
+\item{estimator}{Character; which effective sample size to return for the
+edge (or difference) indicators. \code{"rb"} (default) returns the ESS of the
+Rao-Blackwellized inclusion draws; \code{"mixt"} returns the indicator chain's
+transition-based ESS. Ignored for all other parameter types.}
 }
 \value{
 A named list with ESS values for each parameter type present in
@@ -18,8 +23,33 @@ the model (e.g., \code{main}, \code{pairwise}, \code{indicator}).
 Retrieves effective sample size estimates for all parameters from a
 model fitted with \code{\link[=bgm]{bgm()}} or \code{\link[=bgmCompare]{bgmCompare()}}.
 }
+\details{
+The \code{indicator} element reports the two effective sample sizes of the
+inclusion inference as a pair, and both also appear in the fit summary's
+inclusion table (\code{summary(fit)$indicator}).
+
+The default, \code{estimator = "rb"}, is the \code{n_eff} column: the continuous ESS
+of the Rao-Blackwellized inclusion draws, and therefore the ESS of the
+inclusion probability the fit reports (see
+\code{\link[=extract_posterior_inclusion_probabilities]{extract_posterior_inclusion_probabilities()}}, which is Rao-Blackwellized
+by default). It quantifies precision \emph{conditional on exploration}.
+
+\code{estimator = "mixt"} is the \code{n_eff_mixt} column: the transition-based ESS of
+the binary indicator chain, which measures the exploration itself. Few
+transitions are expected when an edge's inclusion probability sits near 0 or
+1, so a small (or \code{NA}) transition ESS beside a confident Rao-Blackwellized
+ESS is the signature of a decisive edge rather than of a failure; read the
+two together. Edges whose indicator never flipped have no exploration
+information, and both columns are \code{NA} there.
+
+Fits made with bgms < 0.2.0.0 carry no Rao-Blackwellized draws; a default
+call falls back to the transition ESS, while an explicit \code{estimator = "rb"}
+errors.
+}
 \seealso{
-\code{\link[=bgm]{bgm()}}, \code{\link[=bgmCompare]{bgmCompare()}}, \code{\link[=extract_rhat]{extract_rhat()}}
+\code{\link[=bgm]{bgm()}}, \code{\link[=bgmCompare]{bgmCompare()}}, \code{\link[=extract_rhat]{extract_rhat()}} for the
+Rao-Blackwellized indicator R-hat,
+\code{\link[=extract_posterior_inclusion_probabilities]{extract_posterior_inclusion_probabilities()}}
 
 Other extractors:
 \code{\link[=extract_arguments]{extract_arguments()}},

--- a/man/extract_rhat.Rd
+++ b/man/extract_rhat.Rd
@@ -18,6 +18,12 @@ the model (e.g., \code{main}, \code{pairwise}, \code{indicator}).
 Retrieves R-hat convergence diagnostics for all parameters from a
 model fitted with \code{\link[=bgm]{bgm()}} or \code{\link[=bgmCompare]{bgmCompare()}}.
 }
+\details{
+The \code{indicator} element is the split-R-hat of the Rao-Blackwellized
+inclusion draws, matching the default of \code{\link[=extract_ess]{extract_ess()}}; the indicator
+chain's transition-based effective sample size is available as
+\code{extract_ess(fit, estimator = "mixt")}.
+}
 \seealso{
 \code{\link[=bgm]{bgm()}}, \code{\link[=bgmCompare]{bgmCompare()}}, \code{\link[=extract_ess]{extract_ess()}}
 

--- a/tests/testthat/test-extractor-functions.R
+++ b/tests/testthat/test-extractor-functions.R
@@ -266,6 +266,66 @@ test_that("extract_ess returns valid diagnostics for all fit types", {
   }
 })
 
+test_that("extract_ess indicators default to the RB n_eff and honour estimator", {
+  fixtures = get_extractor_fixtures()
+  checked = 0L
+
+  for(spec in fixtures) {
+    ctx = sprintf("[%s]", spec$label)
+    fit = spec$get_fit()
+    ind = summary(fit)$indicator
+
+    if(is.null(ind) || !all(c("n_eff", "n_eff_mixt") %in% names(ind))) next
+    checked = checked + 1L
+
+    rb = extract_ess(fit)$indicator
+    mixt = extract_ess(fit, estimator = "mixt")$indicator
+
+    # The default is the RB n_eff column, matching summary() and the R-hat that
+    # extract_rhat() reports; "mixt" is the transition ESS column.
+    expect_equal(unname(rb), ind$n_eff, info = paste(ctx, "default is RB n_eff"))
+    expect_equal(unname(mixt), ind$n_eff_mixt, info = paste(ctx, "mixt is n_eff_mixt"))
+    expect_equal(unname(extract_ess(fit, estimator = "rb")$indicator), ind$n_eff,
+      info = paste(ctx, "explicit rb is RB n_eff")
+    )
+
+    # NA masking is inherited from the summary table, per column.
+    expect_identical(is.na(unname(rb)), is.na(ind$n_eff),
+      info = paste(ctx, "RB NA positions")
+    )
+    expect_identical(is.na(unname(mixt)), is.na(ind$n_eff_mixt),
+      info = paste(ctx, "transition NA positions")
+    )
+
+    expect_error(extract_ess(fit, estimator = "nonsense"))
+  }
+
+  expect_gt(checked, 0L)
+})
+
+test_that("extract_ess indicators fall back to the transition ESS without RB draws", {
+  # Summary tables from fits predating the RB regime (bgms < 0.2.0.0) carry no
+  # n_eff column: a default call falls back, an explicit "rb" errors.
+  rb_table = data.frame(n_eff = c(100, NA), n_eff_mixt = c(80, NA))
+  legacy_table = data.frame(n_eff_mixt = c(80, NA))
+  default_arg = c("rb", "mixt")
+
+  expect_equal(indicator_ess_column(rb_table, default_arg, TRUE), c(100, NA))
+  expect_equal(indicator_ess_column(rb_table, "mixt", FALSE), c(80, NA))
+  expect_equal(indicator_ess_column(legacy_table, default_arg, TRUE), c(80, NA))
+  expect_error(indicator_ess_column(legacy_table, "rb", FALSE), "Rao-Blackwellized")
+})
+
+test_that("extract_ess indicator names and other elements ignore estimator", {
+  fit = get_bgms_fit()
+  rb = extract_ess(fit)
+  mixt = extract_ess(fit, estimator = "mixt")
+
+  expect_identical(names(rb), names(mixt))
+  expect_identical(names(rb$indicator), names(mixt$indicator))
+  expect_equal(rb$pairwise, mixt$pairwise)
+})
+
 test_that("extract_rhat and extract_ess error on non-bgms objects", {
   expect_error(extract_rhat(list()), class = "error")
   expect_error(extract_rhat(data.frame()), class = "error")

--- a/tests/testthat/test-prior-interface.R
+++ b/tests/testthat/test-prior-interface.R
@@ -455,6 +455,66 @@ test_that("deprecated main_alpha/main_beta still works", {
   expect_s3_class(fit, "bgms")
 })
 
+test_that("deprecated standardize = FALSE warns and proceeds", {
+  data("Wenchuan", package = "bgms")
+  expect_warning(
+    fit <- bgm(Wenchuan[1:50, 1:4],
+      standardize = FALSE,
+      iter = 25, warmup = 50, chains = 1,
+      display_progress = "none"
+    ),
+    "standardize"
+  )
+  expect_s3_class(fit, "bgms")
+})
+
+test_that("deprecated standardize = TRUE errors with the manual alternative", {
+  data("Wenchuan", package = "bgms")
+  # The removed per-pair adjustment has no replacement, so this must fail
+  # through lifecycle rather than as an unused-argument error.
+  expect_error(
+    bgm(Wenchuan[1:50, 1:4],
+      standardize = TRUE,
+      iter = 25, warmup = 50, chains = 1,
+      display_progress = "none"
+    ),
+    "interaction_prior"
+  )
+  expect_error(
+    bgm(Wenchuan[1:50, 1:4],
+      standardize = TRUE,
+      iter = 25, warmup = 50, chains = 1,
+      display_progress = "none"
+    ),
+    class = "defunctError"
+  )
+})
+
+test_that("bgmCompare handles the deprecated standardize on both paths", {
+  data("Wenchuan", package = "bgms")
+  x = Wenchuan[1:40, 1:4]
+  y = Wenchuan[41:80, 1:4]
+
+  expect_warning(
+    fit <- bgmCompare(x, y,
+      standardize = FALSE,
+      iter = 25, warmup = 50, chains = 1,
+      display_progress = "none"
+    ),
+    "standardize"
+  )
+  expect_s3_class(fit, "bgmCompare")
+
+  expect_error(
+    bgmCompare(x, y,
+      standardize = TRUE,
+      iter = 25, warmup = 50, chains = 1,
+      display_progress = "none"
+    ),
+    "difference_scale"
+  )
+})
+
 
 # ==============================================================================
 # 8. Backward Compatibility <U+2014> Deprecated String Edge Priors


### PR DESCRIPTION
Part of the 0.2.0.0 semantic break, to land before the `develop` -> `main`
merge.

Branches off `develop` at 45a4fae7, rebased onto it after #187 merged (the
brief's fallback base, `chore/release-meta-0200`, was deleted with that merge).
Verified on the rebased tree, so the numbers below include #186.

## extract_ess() indicators report the Rao-Blackwellized n_eff

`extract_ess()$indicator` resolved `$n_eff_mixt %||% $n_eff`, and every fit
since #182 has an `n_eff_mixt` column, so it always returned the indicator
chain's transition ESS. Meanwhile `extract_rhat()$indicator` returns the
Rao-Blackwellized split-R-hat and `extract_posterior_inclusion_probabilities()`
defaults to the Rao-Blackwellized inclusion probability, so the extractor named
after the summary's `n_eff` column was the one that did not return it. Verified
on live fits of both classes before changing anything (`bgms`: default
550/89/173 against RB `n_eff` 269/74/141).

- Default is now the RB `n_eff`; `estimator = "mixt"` returns the transition
  ESS. Both columns stay in `summary(fit)$indicator` as before.
- New internal `indicator_ess_column()` serves both S3 methods, so the two
  cannot drift apart. `estimator = c("rb", "mixt")` with `match.arg()` mirrors
  `extract_posterior_inclusion_probabilities(estimator = c("rb", "raw"))`.
- `bgmCompare` verified rather than assumed: its inclusion table carries the
  same `n_eff` and `n_eff_mixt` columns, so it gets the same semantics.
- NA masking is inherited unchanged: both estimators read their column straight
  off the summary table.
- Fits without RB draws (bgms < 0.2.0.0) carry no `n_eff` column. A default
  call falls back to the transition ESS; an explicit `estimator = "rb"` errors
  and points to `"mixt"`. Same graceful-default/explicit-error split as
  `extract_posterior_inclusion_probabilities()`.
- Column detection uses `names()`, not `$`: `$` partial-matches `n_eff` to
  `n_eff_mixt` on a data.frame, which would have made the legacy path
  undetectable.

Rd: `extract_ess()` gains `@param estimator` and a `@details` block stating the
pair (default is the ESS of the reported inclusion probability; `"mixt"` is the
transition ESS, and few transitions are expected when an edge sits near 0 or 1),
cross-referencing `extract_rhat()` and
`extract_posterior_inclusion_probabilities()`. `extract_rhat()` gains the
symmetric sentence pointing back.

## standardize= goes through lifecycle

`standardize` was a formal on the CRAN lineage (`main` R/bgm.R:361, default
`FALSE`), where `TRUE` scaled each pair's prior by the product of the two
variables' maximum scores. `develop` removed it outright, so
`bgm(standardize = TRUE)` failed with a bare `unused argument` error while every
other removed argument in the package goes through lifecycle.

Confirmed first that `develop` has no `standardize` machinery at all: no formal,
no plumbing into `bgm_spec`, nothing in `src/`. So `FALSE` matches current
behavior and `TRUE` asks for something that no longer exists.

- The formal is reinstated at the end of the deprecated block in both
  functions, with no plumbing behind it, so positional matching of live
  arguments is untouched.
- `isFALSE(standardize)` warns through `lifecycle::deprecate_warn` and
  proceeds, with the detail that the fit is unaffected. Anything else stops
  through `lifecycle::deprecate_stop`, naming `interaction_prior` (and
  `difference_scale` for `bgmCompare()`) as the manual alternative. `isFALSE`
  rather than `!isTRUE` means non-logical input also gets the informative error
  instead of being silently read as `FALSE`.
- Rd badge on both functions; the existing NEWS breaking-change line is
  rewritten, since "Passing it now errors" is no longer accurate.

## Verification

- `test-extractor-functions.R`: 3 new blocks. Across every extractor fixture
  with an inclusion table, the default equals `summary(fit)$indicator$n_eff`,
  `"mixt"` equals `n_eff_mixt`, and NA positions agree per column; the legacy
  fallback and the invalid-argument error are covered. The fixture loop is
  guarded so it cannot pass vacuously.
- `test-prior-interface.R`: 4 new tests covering both `standardize` paths on
  both functions, asserting the error class and the message content.
- `styler::style_pkg` (project style): no files changed. `lintr::lint_package()`:
  0 lints.
- `rcmdcheck(args = "--as-cran")`, macOS aarch64, R 4.6.0: 0 errors, 0 warnings,
  2 notes, unchanged from the base. Both notes are pre-existing and
  environmental (`DESCRIPTION` `Date:` over a month old; local HTML Tidy too old
  for HTML validation).

## Downstream, not in this PR

- bgms-docs `reference/extractors.qmd` documents the old `extract_ess()`
  semantics and needs re-verifying against this build.
- easybgm: the return structure of `extract_ess()` is unchanged, but the
  `indicator` values now differ. Worth a grep there before the release.
- `man/bgms-package.Rd` is regenerated here for the lower-case site URL from
  #187, which the squash-merge of that PR predates; it is roxygen fallout from
  that change rather than part of this one.
