### PR TITLE
Plain-words note for the blank cells in the inclusion table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,14 @@ released from this line yet.
   explains that the energy trace is recorded only after warmup ends, so the check
   measures transient that survived warmup.
 
+* The note printed under the inclusion table of `summary()` describes the blank
+  cells in plain terms: the inclusion draws never varied, so no precision can be
+  estimated from them, and an almost equally certain edge still shows numbers.
+  It previously attributed the blanks to indicators that were constant or not
+  updated. `print.summary.bgmCompare()` names the unsampled main-effect
+  difference rows separately, which is a different cause with a different
+  reading.
+
 # bgms 0.2.0.0
 
 This release rebuilds most of the package on top of 0.1.6.3. `bgm()` now fits

--- a/R/methods_bgmcompare.R
+++ b/R/methods_bgmcompare.R
@@ -335,9 +335,16 @@ print.summary.bgmCompare = function(x, digits = 3, ...) {
       cat("... (use `summary(fit)$indicator` to see full output)\n")
     }
     if(ind_has_na) {
-      cat("Note: NA values are suppressed in the print table; they occur for indicators\n")
-      cat("that were not updated or whose draws are constant, so ESS/Rhat are undefined.\n")
-      cat("`summary(fit)$indicator` still contains all computed values.\n")
+      cat("Note: blank mcse/n_eff/Rhat cells mark indicators whose inclusion draws never\n")
+      cat("varied: the per-iteration evidence is so one-sided that the draws round to\n")
+      cat("exactly 0 or 1, and no variation is left to estimate precision from. An\n")
+      cat("indicator that is almost as certain still shows numbers; the difference is\n")
+      cat("rounding, not evidence.\n")
+      if(isFALSE(x$arguments$main_difference_selection)) {
+        cat("Main-effect difference rows are blank when main_difference_selection = FALSE\n")
+        cat("left their indicators unsampled.\n")
+      }
+      cat("All computed values remain in `summary(fit)$indicator`.\n")
     }
     cat("\n")
   }

--- a/R/methods_bgms.R
+++ b/R/methods_bgms.R
@@ -188,9 +188,11 @@ print.summary.bgms = function(x, digits = 3, ...) {
     print(ind)
     if(nrow(x$indicator) > .summary_preview_rows) cat("... (use `summary(fit)$indicator` to see full output)\n")
     if(ind_has_na) {
-      cat("Note: NA values are suppressed in the print table; they occur for indicators\n")
-      cat("that were not updated or whose draws are constant, so ESS/Rhat are undefined.\n")
-      cat("`summary(fit)$indicator` still contains all computed values.\n")
+      cat("Note: blank mcse/n_eff/Rhat cells mark indicators whose inclusion draws never\n")
+      cat("varied: the per-iteration evidence is so one-sided that the draws round to\n")
+      cat("exactly 0 or 1, and no variation is left to estimate precision from. An edge\n")
+      cat("that is almost as certain still shows numbers; the difference is rounding, not\n")
+      cat("evidence. All computed values remain in `summary(fit)$indicator`.\n")
     }
     cat("\n")
   }

--- a/tests/testthat/_snaps/summary-marking.md
+++ b/tests/testthat/_snaps/summary-marking.md
@@ -31,9 +31,14 @@
       B (main)
       B-C (pairwise)
       C (main)
-      Note: NA values are suppressed in the print table; they occur for indicators
-      that were not updated or whose draws are constant, so ESS/Rhat are undefined.
-      `summary(fit)$indicator` still contains all computed values.
+      Note: blank mcse/n_eff/Rhat cells mark indicators whose inclusion draws never
+      varied: the per-iteration evidence is so one-sided that the draws round to
+      exactly 0 or 1, and no variation is left to estimate precision from. An
+      indicator that is almost as certain still shows numbers; the difference is
+      rounding, not evidence.
+      Main-effect difference rows are blank when main_difference_selection = FALSE
+      left their indicators unsampled.
+      All computed values remain in `summary(fit)$indicator`.
       
       Group differences (main effects):
       parameter mean mcse sd n_eff share_incl Rhat


### PR DESCRIPTION
The note printed under the inclusion table of `summary()` described the blank
cells as indicators that were not updated or whose draws were constant. That
stopped being true when the mask moved onto the Rao-Blackwellized inclusion
draws, and it also asked the reader to know what those draws are.

## What the note says now

For `bgm()`:

```
Note: blank mcse/n_eff/Rhat cells mark indicators whose inclusion draws never
varied: the per-iteration evidence is so one-sided that the draws round to
exactly 0 or 1, and no variation is left to estimate precision from. An edge
that is almost as certain still shows numbers; the difference is rounding, not
evidence. All computed values remain in `summary(fit)$indicator`.
```

The sentence about an almost equally certain edge is there because being
decided is not what empties the cells. An edge at 0.9999 still prints numbers;
only an edge that has run all the way to the numerical bound cannot.

The note states what the blank is and leaves the judgment to the diagnostics
vignette. A blank row is benign when the flip counts show the chain moved, and
those counts stay in the table beside it.

## bgmCompare

The compare table has a second cause: rows whose indicators were never sampled
because `main_difference_selection = FALSE`. Those rows are blank throughout,
not only in the precision columns, so they get their own sentence, printed only
when that argument is FALSE.

## Not in this PR

The three notes under the pairwise and difference tables say the blanks are for
effects that were never selected. That is also inaccurate, since the blanks
appear from about ten or fewer included draws, but it is a separate table and a
separate fix.

## Checks

`tests/testthat/_snaps/summary-marking.md` regenerated, and the tests in that
file pass. The wording was also read back off a real `bgm()` fit with a
saturated edge.
