### PR TITLE
fix REFERENCES.bib: Martarelli et al. (2023) author given names

### DIFF
--- a/inst/REFERENCES.bib
+++ b/inst/REFERENCES.bib
@@ -57,7 +57,7 @@
 
 @article{Martarelli_2023_Boredom,
   title={A Trait-Based Network Perspective on the Validation of the French Short Boredom Proneness Scale},
-  author={Martarelli, Chiara S. and Baillifard, Alexandre and Audrin, Catherine},
+  author={Martarelli, Corinna S. and Baillifard, Ambroise and Audrin, Catherine},
   journal={European Journal of Psychological Assessment},
   volume={39},
   number={6},


### PR DESCRIPTION
Two given-names corrected in the Martarelli_2023_Boredom entry, per Crossref for doi:10.1027/1015-5759/a000718: Chiara S. Martarelli -> Corinna S. Martarelli, Alexandre Baillifard -> Ambroise Baillifard. Every other field (journal, volume 39, number 6, pages 390-399, year 2023, DOI) already matched Crossref.

The entry is cited from ?Boredom via Rdpack, so the wrong names show in the rendered help references; no Rd or code changes are needed beyond the bib.

Closes the plans-board flagged item 24 (found during the bgms-docs B5 rework, which fixed the docs-side copy of the same citation).