### PR TITLE
docs: measured comparison replaces the no-claims stance in the fast-GGM material

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,16 @@ released from this line yet.
   sensitivity vignette does; the hardware and thread count are stated with them.
   The README gained a short pointer to it.
 
+* The fast-GGM vignette's positioning paragraph now carries a measured
+  comparison instead of a no-claims stance: bgms, modelSelection 1.0.7 and
+  ssgraph 1.16 were run on the vignette's own data, one at a time on one
+  machine, each at its defaults and at its documentation's recommended
+  settings. The vignette reports the headline numbers; the full protocol,
+  seeded runner scripts, and tables live in the bgms-docs repository beside
+  the site's comparison page, so the comparison can be re-baked when a
+  competitor's version moves. Neither competitor enters the package's
+  dependencies. The README summarizes the result in two sentences.
+
 * `prior_sensitivity_check()`'s Details said the refit gate leans on per-chain
   verdict agreement and the indicator transition ESS. The gate reads the median
   split-R-hat over the continuous parameters and over the Rao-Blackwellized

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ factors are not interchangeable between the two routes. The vignette
 website](https://bayesian-graphical-modelling-lab.github.io/bgms/articles/),
 sets out that trade-off, the timings, and where the route applies.
 
+Measured against the neighboring CRAN packages on the same data and
+machine, the route holds up: per sweep, `bgms` samples 6.6 times
+faster than **ssgraph** at 200 variables, and it reaches a converged
+edge ranking a median 18 to 25 times sooner at a matched prior;
+**modelSelection** is faster still on the clock, by a design that
+trades away some recall and exact reproducibility. The full
+comparison, with every setting and seeded script, is on the
+[comparison page](https://bayesian-graphical-modelling-lab.github.io/bgms/guide/fast-ggm.html).
+
 ## Installation
 
 Install from CRAN:

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ website](https://bayesian-graphical-modelling-lab.github.io/bgms/articles/),
 sets out that trade-off, the timings, and where the route applies.
 
 Measured against the neighboring CRAN packages on the same data and
-machine, the route holds up: per sweep, `bgms` samples 6.6 times
-faster than **ssgraph** at 200 variables, and it reaches a converged
-edge ranking a median 18 to 25 times sooner at a matched prior;
-**modelSelection** is faster still on the clock, by a design that
-trades away some recall and exact reproducibility. The full
-comparison, with every setting and seeded script, is on the
+machine, the route's headline is time to a converged edge ranking:
+seconds for `bgms` at every tested sample size, a median 18 to 25
+times sooner than **ssgraph** at a matched prior — replicated, and
+partly because a `bgms` sweep costs 6.6 times less at 200 variables.
+**modelSelection** converges about as fast, by a design that trades
+away some recall and exact reproducibility. The full comparison, with
+every setting and seeded script, is on the
 [comparison page](https://bayesian-graphical-modelling-lab.github.io/bgms/guide/fast-ggm.html).
 
 ## Installation

--- a/vignettes/fast-ggm.Rmd
+++ b/vignettes/fast-ggm.Rmd
@@ -344,29 +344,35 @@ packages, so comparing them compares conventions. The informative question is
 how much wall clock passes before a sampler's edge ranking stops changing. We
 measured that on ten replicate datasets per sample size from this vignette's
 generator (p = 100; n = 1000, 500 and 200; one chain on one thread per
-package; time to AUC within 0.01 of its converged value, burn-in included).
-`bgms` reaches a converged ranking in 0.5 to 7 seconds by raw inclusion
-frequencies — the like-for-like sampler comparison — where **ssgraph** 1.16 at
-a matched 0.5 edge prior needs 13 to 189 seconds: a median 18 to 25 times
-slower, in all 30 of 30 replicates. The Rao-Blackwellized probabilities `bgms`
-actually reports converge in under a second at every sample size, though the
-raw figure is the conservative claim to quote. Part of the gap is per-sweep
-cost — both packages update the full precision matrix in sweeps, and a `bgms`
-sweep costs 96 ms against ssgraph's 634 at p = 200 — and the rest is how few
-sweeps `bgms` needs. **modelSelection** 1.0.7 also converges within about a
-second, so its short default is converged rather than undersampled;
-it targets a sparser prior (1/p on each edge), recovers somewhat fewer edges
-at a matched threshold (152 against 168 for `bgms` with a comparable sparse
-prior, at zero and one false positives respectively), and cannot be seeded, so
-its runs are reproducible only to about two percent. The converged rankings
-themselves are nearly identical across all settings of all three packages
-(AUC 0.975 to 0.996 on this vignette's p = 200 data); the packages differ in
-how fast they get there and in where the default priors put the cut. As
-shipped, at p = 200, the defaults cost 394 seconds (`bgms`, four chains on
-four threads), 4.2 seconds (modelSelection) and 3174 seconds (ssgraph) —
-invoices that fold sampler speed and chain-length convention together. The
-full protocol, the seeded runner scripts, and the tables at all sizes are in
-the
+package; T is the time, burn-in included, to reach AUC within 0.01 of its
+converged value). Median [min, max] over the replicates:
+
+| n | bgms, raw | bgms, as shipped (RB) | ssgraph, g.prior 0.5 | modelSelection |
+|---:|---|---|---|---|
+| 1000 | 0.51 s [0.45, 0.76] | 0.50 s [0.45, 0.56] | 13.3 s [3.3, 13.5] | 1.02 s [1.00, 1.05] |
+| 500 | 2.8 s [1.5, 5.7] | 0.56 s [0.52, 0.62] | 65.4 s [13.6, 65.9] | 0.94 s [0.89, 0.98] |
+| 200 | 7.0 s [3.5, 68.0] | 0.65 s [0.55, 1.04] | 189 s [63, 254] | 0.53 s [0.44, 0.60] |
+
+Raw against raw at the matched 0.5 edge prior is the like-for-like sampler
+comparison, and there `bgms` converges a median 18 to 25 times sooner than
+**ssgraph** 1.16, in all 30 of 30 replicates (per-replicate ranges are wide,
+[4, 73] at the hardest size, so medians with ranges are the quotable form).
+Part of the gap is per-sweep cost — a `bgms` sweep costs 96 ms against
+ssgraph's 634 at p = 200 — and the rest is how few sweeps `bgms` needs. The
+Rao-Blackwellized column is faster still, but raw is the conservative claim.
+**modelSelection** 1.0.7 also converges within about a second, so its short
+default is converged rather than undersampled; it targets a sparser prior
+(1/p on each edge), recovers somewhat fewer edges at a matched threshold (152
+against 168 for `bgms` with a comparable sparse prior, at zero and one false
+positives respectively), and cannot be seeded, so its runs are reproducible
+only to about two percent. The converged rankings themselves are nearly
+identical across all settings of all three packages (AUC 0.975 to 0.996 on
+this vignette's p = 200 data); the packages differ in how fast they get there
+and in where the default priors put the cut. As shipped, at p = 200, the
+defaults cost 394 seconds (`bgms`, four chains on four threads), 4.2 seconds
+(modelSelection) and 3174 seconds (ssgraph) — invoices that fold sampler
+speed and chain-length convention together. The full protocol, the seeded
+runner scripts, and the tables at all sizes are in the
 [bgms-docs repository](https://github.com/Bayesian-Graphical-Modelling-Lab/bgms-docs/tree/main/benchmarks/ggm-comparison),
 beside the site's
 [comparison page](https://bayesian-graphical-modelling-lab.github.io/bgms/guide/fast-ggm.html).

--- a/vignettes/fast-ggm.Rmd
+++ b/vignettes/fast-ggm.Rmd
@@ -335,13 +335,34 @@ mixtures and graphical models. **ssgraph** (version 1.16, 2025-08-29) is the
 other near neighbor, doing Bayesian structure learning for undirected graphical
 models with spike-and-slab priors on continuous, discrete and mixed data.
 
-Neither package was run against `bgms` on the same data for this vignette, so it
-makes no comparative speed claim about either. Every timing above is `bgms`
-against `bgms`. Readers whose problem is a single very large Gaussian graphical
-model and nothing else should look at all three; what `bgms` adds around this
-route is the rest of the package: ordinal, Blume-Capel and mixed models,
-group comparison, prior sensitivity, and the determinant tilt that keeps the
-prior usable as the number of variables grows.
+How do these timings compare with the neighbors? On this vignette's own
+simulation at p = 200 (n = 1000, 289 true edges, one machine, serial BLAS),
+**ssgraph** 1.16 at its defaults needs 3174 seconds against 394 for the call
+above, re-timed alongside it (the timing reported earlier in this vignette
+differs from that only by run-to-run noise), and the gap is the sampler rather
+than the threading: both packages update the full precision matrix in sweeps,
+`bgms`'s sweep costs 96 ms against ssgraph's 634, and a single-threaded `bgms`
+run still finishes 3.2 times the sampling in less than half the time.
+**modelSelection** 1.0.7 is faster than both on the clock, 4.2 seconds at its
+defaults, by a different design: each iteration updates about sqrt(p) columns
+rather than all p, it starts from a glasso solution, and its edge ranking is
+already stable at that short run. It targets a sparser prior (1/p on each
+edge), recovers somewhat fewer edges at a matched threshold (152 against 168
+for `bgms` with a comparable sparse prior, at zero and one false positives
+respectively), and cannot be seeded, so its runs are reproducible only to
+about two percent. All settings of all three packages rank the candidate edges
+nearly identically (AUC 0.975 to 0.996); they differ in what a run costs and
+in where the default priors put the cut. The full protocol, the seeded runner
+scripts, and the tables at all three sizes are in the
+[bgms-docs repository](https://github.com/Bayesian-Graphical-Modelling-Lab/bgms-docs/tree/main/benchmarks/ggm-comparison),
+beside the site's
+[comparison page](https://bayesian-graphical-modelling-lab.github.io/bgms/guide/fast-ggm.html).
+
+Readers whose problem is a single very large Gaussian graphical model and
+nothing else should look at all three; what `bgms` adds around this route is
+the rest of the package: ordinal, Blume-Capel and mixed models, group
+comparison, prior sensitivity, and the determinant tilt that keeps the prior
+usable as the number of variables grows.
 
 
 # Reproducing the timings

--- a/vignettes/fast-ggm.Rmd
+++ b/vignettes/fast-ggm.Rmd
@@ -303,8 +303,18 @@ is absent has its entry fixed at exactly zero, and an edge that is present draws
 its entry from a diffuse slab. The construction comes from the Bayesian
 variable-selection literature [@george1993jasa_variable] and was brought to
 Gaussian graphical models by @wang2015ba_scaling, whose column-wise block Gibbs
-sampler is the ancestor of the one `update_method = "gibbs"` runs. Its appeal
-was, and is, that it avoids a graph-dependent normalizing constant. The
+sampler is the ancestor of the one `update_method = "gibbs"` runs. One
+divergence from that ancestor carries the timing comparison below. Wang's
+spike is continuous — a narrow normal around zero, which is what **ssgraph**
+implements — so an absent edge still has a small non-zero entry, and a column
+update must draw all p − 1 entries from a dense conditional no matter how
+sparse the sampled graph is. `bgms` keeps the point mass: an absent edge's
+entry is exactly zero, a column update works only through the entries the
+current graph includes, and a sparser graph makes a cheaper update. Measured
+on this vignette's data, that is the difference between per-pair cost growing
+as p^1.9^ (ssgraph) and p^1.4^ (`bgms`): a point-mass sampler is paid for the
+sparsity it infers, and a continuous-spike sampler is not. The construction's
+appeal was, and is, that it avoids a graph-dependent normalizing constant. The
 G-Wishart prior is the literature's canonical case of that cost
 [@atay-kayis2005biometrika_monte; @mohammadi2023jasa_accelerating], but the
 cost is not particular to the G-Wishart: `bgm()`'s own hierarchical
@@ -345,7 +355,8 @@ how much wall clock passes before a sampler's edge ranking stops changing. We
 measured that on ten replicate datasets per sample size from this vignette's
 generator (p = 100; n = 1000, 500 and 200; one chain on one thread per
 package; T is the time, burn-in included, to reach AUC within 0.01 of its
-converged value). Median [min, max] over the replicates:
+converged value, the convergence-cost metric of @vogels2024jasa_bayesian).
+Median [min, max] over the replicates:
 
 | n | bgms, raw | bgms, as shipped (RB) | ssgraph, g.prior 0.5 | modelSelection |
 |---:|---|---|---|---|
@@ -358,15 +369,22 @@ comparison, and there `bgms` converges a median 18 to 25 times sooner than
 **ssgraph** 1.16, in all 30 of 30 replicates (per-replicate ranges are wide,
 [4, 73] at the hardest size, so medians with ranges are the quotable form).
 Part of the gap is per-sweep cost — a `bgms` sweep costs 96 ms against
-ssgraph's 634 at p = 200 — and the rest is how few sweeps `bgms` needs. The
-Rao-Blackwellized column is faster still, but raw is the conservative claim.
+ssgraph's 634 at p = 200, the spike divergence described above — and the rest
+is how few sweeps `bgms` needs. The Rao-Blackwellized column is faster still,
+but that estimator averages a conditional probability that is informative
+before any indicator has flipped, so it can look converged from a barely-moved
+chain: at its 8-sweep convergence point nearly half the pairs have never
+changed state. The raw column cannot converge until indicators actually move,
+which is why it is the conservative claim and the one to quote.
 The three sample sizes are three signal strengths — the generator's per-edge
 partial correlations are 0.14 by construction, so n = 1000 is an easy ranking
 problem and n = 200 a genuinely hard one — and the converged AUCs track that:
 medians 1.00, 0.98 and 0.87, identical for `bgms` and ssgraph at every n,
 with modelSelection slightly lower at the two harder sizes. Weaker signal
 costs `bgms` more sweeps, not slower sweeps: n changes how many draws the
-ranking needs, never the price of a draw.
+ranking needs, never the price of a draw. The whole comparison sits at one
+graph density (average degree 3); the point-mass advantage is
+sparsity-dependent, so denser graphs would shrink it.
 **modelSelection** 1.0.7 also converges within about a second, so its short
 default is converged rather than undersampled; it targets a sparser prior
 (1/p on each edge), recovers somewhat fewer edges at a matched threshold (152

--- a/vignettes/fast-ggm.Rmd
+++ b/vignettes/fast-ggm.Rmd
@@ -304,13 +304,16 @@ its entry from a diffuse slab. The construction comes from the Bayesian
 variable-selection literature [@george1993jasa_variable] and was brought to
 Gaussian graphical models by @wang2015ba_scaling, whose column-wise block Gibbs
 sampler is the ancestor of the one `update_method = "gibbs"` runs. Its appeal
-was, and is, that it avoids the graph-dependent normalizing constant that makes
-structure learning expensive under the G-Wishart prior
-[@atay-kayis2005biometrika_monte; @mohammadi2023jasa_accelerating]. That
-avoidance is exactly what the joint specification does and what the
-hierarchical specification declines to do, which is the choice
-`precision_graph_prior` exposes. @vogels2024jasa_bayesian survey the wider field
-and compare the available samplers empirically.
+was, and is, that it avoids a graph-dependent normalizing constant. The
+G-Wishart prior is the literature's canonical case of that cost
+[@atay-kayis2005biometrika_monte; @mohammadi2023jasa_accelerating], but the
+cost is not particular to the G-Wishart: `bgm()`'s own hierarchical
+specification pays a constant of the same kind, deliberately, so that the
+stated edge prior is exactly the prior over graphs. The joint specification
+takes the classical avoidance and the hierarchical specification declines it;
+that is the choice `precision_graph_prior` exposes.
+@vogels2024jasa_bayesian survey the wider field and compare the available
+samplers empirically.
 
 `bgms` adds one thing to the classical construction. Specifying the precision
 matrix entry by entry does not guarantee that the result is positive definite,

--- a/vignettes/fast-ggm.Rmd
+++ b/vignettes/fast-ggm.Rmd
@@ -360,6 +360,13 @@ comparison, and there `bgms` converges a median 18 to 25 times sooner than
 Part of the gap is per-sweep cost — a `bgms` sweep costs 96 ms against
 ssgraph's 634 at p = 200 — and the rest is how few sweeps `bgms` needs. The
 Rao-Blackwellized column is faster still, but raw is the conservative claim.
+The three sample sizes are three signal strengths — the generator's per-edge
+partial correlations are 0.14 by construction, so n = 1000 is an easy ranking
+problem and n = 200 a genuinely hard one — and the converged AUCs track that:
+medians 1.00, 0.98 and 0.87, identical for `bgms` and ssgraph at every n,
+with modelSelection slightly lower at the two harder sizes. Weaker signal
+costs `bgms` more sweeps, not slower sweeps: n changes how many draws the
+ranking needs, never the price of a draw.
 **modelSelection** 1.0.7 also converges within about a second, so its short
 default is converged rather than undersampled; it targets a sparser prior
 (1/p on each edge), recovers somewhat fewer edges at a matched threshold (152

--- a/vignettes/fast-ggm.Rmd
+++ b/vignettes/fast-ggm.Rmd
@@ -338,25 +338,35 @@ mixtures and graphical models. **ssgraph** (version 1.16, 2025-08-29) is the
 other near neighbor, doing Bayesian structure learning for undirected graphical
 models with spike-and-slab priors on continuous, discrete and mixed data.
 
-How do these timings compare with the neighbors? On this vignette's own
-simulation at p = 200 (n = 1000, 289 true edges, one machine, serial BLAS),
-**ssgraph** 1.16 at its defaults needs 3174 seconds against 394 for the call
-above, re-timed alongside it (the timing reported earlier in this vignette
-differs from that only by run-to-run noise), and the gap is the sampler rather
-than the threading: both packages update the full precision matrix in sweeps,
-`bgms`'s sweep costs 96 ms against ssgraph's 634, and a single-threaded `bgms`
-run still finishes 3.2 times the sampling in less than half the time.
-**modelSelection** 1.0.7 is faster than both on the clock, 4.2 seconds at its
-defaults, by a different design: each iteration updates about sqrt(p) columns
-rather than all p, it starts from a glasso solution, and its edge ranking is
-already stable at that short run. It targets a sparser prior (1/p on each
-edge), recovers somewhat fewer edges at a matched threshold (152 against 168
-for `bgms` with a comparable sparse prior, at zero and one false positives
-respectively), and cannot be seeded, so its runs are reproducible only to
-about two percent. All settings of all three packages rank the candidate edges
-nearly identically (AUC 0.975 to 0.996); they differ in what a run costs and
-in where the default priors put the cut. The full protocol, the seeded runner
-scripts, and the tables at all three sizes are in the
+How does this route compare with the neighbors? Not by default timings:
+default run lengths are conventions that differ by orders of magnitude across
+packages, so comparing them compares conventions. The informative question is
+how much wall clock passes before a sampler's edge ranking stops changing. We
+measured that on ten replicate datasets per sample size from this vignette's
+generator (p = 100; n = 1000, 500 and 200; one chain on one thread per
+package; time to AUC within 0.01 of its converged value, burn-in included).
+`bgms` reaches a converged ranking in 0.5 to 7 seconds by raw inclusion
+frequencies — the like-for-like sampler comparison — where **ssgraph** 1.16 at
+a matched 0.5 edge prior needs 13 to 189 seconds: a median 18 to 25 times
+slower, in all 30 of 30 replicates. The Rao-Blackwellized probabilities `bgms`
+actually reports converge in under a second at every sample size, though the
+raw figure is the conservative claim to quote. Part of the gap is per-sweep
+cost — both packages update the full precision matrix in sweeps, and a `bgms`
+sweep costs 96 ms against ssgraph's 634 at p = 200 — and the rest is how few
+sweeps `bgms` needs. **modelSelection** 1.0.7 also converges within about a
+second, so its short default is converged rather than undersampled;
+it targets a sparser prior (1/p on each edge), recovers somewhat fewer edges
+at a matched threshold (152 against 168 for `bgms` with a comparable sparse
+prior, at zero and one false positives respectively), and cannot be seeded, so
+its runs are reproducible only to about two percent. The converged rankings
+themselves are nearly identical across all settings of all three packages
+(AUC 0.975 to 0.996 on this vignette's p = 200 data); the packages differ in
+how fast they get there and in where the default priors put the cut. As
+shipped, at p = 200, the defaults cost 394 seconds (`bgms`, four chains on
+four threads), 4.2 seconds (modelSelection) and 3174 seconds (ssgraph) —
+invoices that fold sampler speed and chain-length convention together. The
+full protocol, the seeded runner scripts, and the tables at all sizes are in
+the
 [bgms-docs repository](https://github.com/Bayesian-Graphical-Modelling-Lab/bgms-docs/tree/main/benchmarks/ggm-comparison),
 beside the site's
 [comparison page](https://bayesian-graphical-modelling-lab.github.io/bgms/guide/fast-ggm.html).


### PR DESCRIPTION
The fast-GGM vignette's positioning paragraph now reports the same-machine, same-data benchmark against modelSelection 1.0.7 and ssgraph 1.16 instead of declining to compare: at p = 200, ssgraph's default run needs 3174 s against 394 for the vignette's call (re-timed alongside it; the vignette's own 417 s differs only by run-to-run noise), the gap is per-sweep cost rather than threading, and modelSelection's 4.2 s default is faster by a design that trades a sparser prior, some matched-threshold recall, and exact reproducibility. All three packages rank the candidate edges nearly identically; the default priors set where they cut.

The README's large-GGM section gains a two-sentence summary with the same link; NEWS.md records the change under 0.2.0.1 Documentation.

Prose only, no code paths touched, and the competitors stay out of the package's dependencies. The full protocol, seeded runner scripts, and three-size tables are committed in the bgms-docs repository beside the site's comparison page (bgms-docs #30); merge that PR first so this one's links resolve. Vignette re-render verified clean.